### PR TITLE
ci: add reusable Nexus upload workflow for component repos

### DIFF
--- a/.github/workflows/upload-nexus.yml
+++ b/.github/workflows/upload-nexus.yml
@@ -1,0 +1,168 @@
+# Reusable Nexus upload workflow for FlagOS component repos.
+#
+# Component repos reference it with a thin caller workflow:
+#
+#   jobs:
+#     upload:
+#       uses: flagos-ai/build-infra/.github/workflows/upload-nexus.yml@main
+#       with:
+#         run_id: ${{ github.event.inputs.run_id }}
+#       secrets: inherit
+#
+# One workflow, one secret. Org-level secrets (configured once on the
+# flagos-ai org, reaching this workflow via the caller's
+# `secrets: inherit`):
+#   NEXUS_TOKEN      "user:token" pair for curl -u. The single
+#                    credential identifying this shared workflow.
+#   NEXUS_CA_CERT    optional - PEM CA certificate; when set it is
+#                    installed into the runner trust store before
+#                    upload. Not needed while the endpoint serves a
+#                    publicly-signed certificate.
+#
+# Upload methods follow the Sonatype-documented per-format commands:
+#   apt hosted: POST the package bytes to the repository ROOT
+#               (Content-Type: multipart/form-data, --data-binary);
+#               Nexus derives the pool/ path from the deb metadata.
+#   yum hosted: PUT the package to <repo-url>/<filename>.
+#
+# The artifact download targets the CALLER's repository (reusable
+# workflows run in the caller's context), so this single file serves
+# every component repo without per-repo configuration.
+
+name: Upload to Nexus Repository (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      run_id:
+        description: 'Build workflow run ID (optional, uses latest successful run if blank)'
+        required: false
+        type: string
+
+env:
+  NEXUS_APT_URL: https://resource.flagos.net/repository/flagos-apt-hosted
+  NEXUS_YUM_URL: https://resource.flagos.net/repository/flagos-yum-hosted
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure SSL trust (optional internal CA)
+        env:
+          NEXUS_CA_CERT: ${{ secrets.NEXUS_CA_CERT }}
+        run: |
+          if [ -n "${NEXUS_CA_CERT}" ]; then
+            echo "${NEXUS_CA_CERT}" | sudo tee /usr/local/share/ca-certificates/flagos-nexus-ca.crt > /dev/null
+            sudo update-ca-certificates
+            echo "Installed internal CA into the runner trust store."
+          else
+            echo "NEXUS_CA_CERT not set - using the system trust store."
+          fi
+
+      - name: Download deb build artifacts
+        uses: dawidd6/action-download-artifact@v12
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build-deb.yml
+          run_id: ${{ inputs.run_id }}
+          workflow_conclusion: success
+          path: packages/
+
+      - name: Download rpm build artifacts
+        uses: dawidd6/action-download-artifact@v12
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build-rpm.yml
+          run_id: ${{ inputs.run_id }}
+          workflow_conclusion: success
+          path: packages/
+        continue-on-error: true
+
+      - name: List downloaded packages
+        run: |
+          echo "Downloaded packages:"
+          find packages/ -name "*.deb" -o -name "*.rpm" | sort
+
+      - name: Upload deb packages to Nexus APT repository
+        env:
+          NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
+        run: |
+          set -e
+          if [ -z "${NEXUS_TOKEN}" ]; then
+            echo "ERROR: NEXUS_TOKEN secret is empty or unset"
+            exit 1
+          fi
+          # apt hosted: POST the bytes to the repository root; Nexus
+          # derives the pool/ path from the package's control fields.
+          found=0
+          uploaded=0
+          while IFS= read -r deb; do
+            [ -z "$deb" ] && continue
+            found=$((found + 1))
+            filename=$(basename "$deb")
+            echo "Uploading: $filename"
+            if curl -f -u "${NEXUS_TOKEN}" \
+                 -H 'Content-Type: multipart/form-data' \
+                 --data-binary "@${deb}" \
+                 "${NEXUS_APT_URL}/"; then
+              echo "  -> OK"
+              uploaded=$((uploaded + 1))
+            else
+              echo "  -> FAILED"
+            fi
+          done < <(find packages/ -name "*.deb")
+          echo "Uploaded $uploaded of $found deb package(s)"
+          echo "DEB_FOUND=$found" >> "$GITHUB_ENV"
+          echo "DEB_UPLOADED=$uploaded" >> "$GITHUB_ENV"
+
+      - name: Upload rpm packages to Nexus YUM repository
+        env:
+          NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
+        run: |
+          set -e
+          if [ -z "${NEXUS_TOKEN}" ]; then
+            echo "ERROR: NEXUS_TOKEN secret is empty or unset"
+            exit 1
+          fi
+          # yum hosted: PUT to <repo-url>/<filename>.
+          found=0
+          uploaded=0
+          while IFS= read -r rpm; do
+            [ -z "$rpm" ] && continue
+            found=$((found + 1))
+            filename=$(basename "$rpm")
+            echo "Uploading: $filename"
+            if curl -f -u "${NEXUS_TOKEN}" \
+                 --upload-file "$rpm" \
+                 "${NEXUS_YUM_URL}/${filename}"; then
+              echo "  -> OK"
+              uploaded=$((uploaded + 1))
+            else
+              echo "  -> FAILED"
+            fi
+          done < <(find packages/ -name "*.rpm" ! -name "*.src.rpm")
+          echo "Uploaded $uploaded of $found rpm package(s)"
+          echo "RPM_FOUND=$found" >> "$GITHUB_ENV"
+          echo "RPM_UPLOADED=$uploaded" >> "$GITHUB_ENV"
+
+      - name: Summary and fail-loud check
+        if: always()
+        run: |
+          echo ""
+          echo "Upload step finished."
+          echo "Packages discovered on disk:"
+          find packages/ -name "*.deb" -o -name "*.rpm" | xargs -I{} basename {} | sort
+          echo ""
+          echo "Tally:"
+          echo "  deb: ${DEB_UPLOADED:-?} / ${DEB_FOUND:-?}"
+          echo "  rpm: ${RPM_UPLOADED:-?} / ${RPM_FOUND:-?}"
+          fail=0
+          if [ "${DEB_FOUND:-0}" -gt 0 ] && [ "${DEB_UPLOADED:-0}" -eq 0 ]; then
+            echo "ERROR: ${DEB_FOUND} deb file(s) discovered but none uploaded - token or Nexus permission misconfigured"
+            fail=1
+          fi
+          if [ "${RPM_FOUND:-0}" -gt 0 ] && [ "${RPM_UPLOADED:-0}" -eq 0 ]; then
+            echo "ERROR: ${RPM_FOUND} rpm file(s) discovered but none uploaded - token or Nexus permission misconfigured"
+            fail=1
+          fi
+          exit $fail

--- a/.github/workflows/upload-nexus.yml
+++ b/.github/workflows/upload-nexus.yml
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Download deb build artifacts
-        uses: dawidd6/action-download-artifact@v12
+        uses: dawidd6/action-download-artifact@v16
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-deb.yml
@@ -50,7 +50,7 @@ jobs:
           path: packages/
 
       - name: Download rpm build artifacts
-        uses: dawidd6/action-download-artifact@v12
+        uses: dawidd6/action-download-artifact@v16
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-rpm.yml

--- a/.github/workflows/upload-nexus.yml
+++ b/.github/workflows/upload-nexus.yml
@@ -1,6 +1,4 @@
-# Reusable Nexus upload workflow for FlagOS component repos.
-#
-# Component repos reference it with a thin caller workflow:
+# Reusable Nexus upload workflow. Component repos call it with:
 #
 #   jobs:
 #     upload:
@@ -9,25 +7,8 @@
 #         run_id: ${{ github.event.inputs.run_id }}
 #       secrets: inherit
 #
-# One workflow, one secret. Org-level secrets (configured once on the
-# flagos-ai org, reaching this workflow via the caller's
-# `secrets: inherit`):
-#   NEXUS_TOKEN      "user:token" pair for curl -u. The single
-#                    credential identifying this shared workflow.
-#   NEXUS_CA_CERT    optional - PEM CA certificate; when set it is
-#                    installed into the runner trust store before
-#                    upload. Not needed while the endpoint serves a
-#                    publicly-signed certificate.
-#
-# Upload methods follow the Sonatype-documented per-format commands:
-#   apt hosted: POST the package bytes to the repository ROOT
-#               (Content-Type: multipart/form-data, --data-binary);
-#               Nexus derives the pool/ path from the deb metadata.
-#   yum hosted: PUT the package to <repo-url>/<filename>.
-#
-# The artifact download targets the CALLER's repository (reusable
-# workflows run in the caller's context), so this single file serves
-# every component repo without per-repo configuration.
+# Secrets (org-level): NEXUS_TOKEN  - "user:token" for curl -u (required)
+#                      NEXUS_CA_CERT - PEM, only for non-public CA endpoints
 
 name: Upload to Nexus Repository (reusable)
 
@@ -92,8 +73,6 @@ jobs:
             echo "ERROR: NEXUS_TOKEN secret is empty or unset"
             exit 1
           fi
-          # apt hosted: POST the bytes to the repository root; Nexus
-          # derives the pool/ path from the package's control fields.
           found=0
           uploaded=0
           while IFS= read -r deb; do
@@ -124,7 +103,6 @@ jobs:
             echo "ERROR: NEXUS_TOKEN secret is empty or unset"
             exit 1
           fi
-          # yum hosted: PUT to <repo-url>/<filename>.
           found=0
           uploaded=0
           while IFS= read -r rpm; do


### PR DESCRIPTION
## Summary

Adds a reusable `upload-nexus.yml`. Component repos call it with a ~25-line caller:

```yaml
jobs:
  upload:
    uses: flagos-ai/build-infra/.github/workflows/upload-nexus.yml@main
    with:
      run_id: ${{ github.event.inputs.run_id }}
    secrets: inherit
```

One org-level secret: `NEXUS_TOKEN` (`user:token` for `curl -u`). Repo URLs are hardcoded in the workflow env.

- deb: POST `--data-binary` to the apt repo root
- rpm: PUT `--upload-file` to `<yum-url>/<filename>`
- fails the job when artifacts were found but none uploaded (the old standalone workflows exited 0 while uploading nothing — see libtriton_jit run 26499200640)
- optional `NEXUS_CA_CERT` for a non-public CA endpoint

## Pending

- org `NEXUS_TOKEN` secret (scoped to component repos + build-infra)
- pilot: flagos-ai/libtriton_jit#28 (draft until this merges)