### PR TITLE
Fix tsingmicro containerfile

### DIFF
--- a/container/containerfile.tsingmicro
+++ b/container/containerfile.tsingmicro
@@ -24,10 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ── TsingMicro Runtime packages ───────────────────────────────────
-ENV PACKAGE_NAME="Tsm_validation_suite Tsm_runtime Tsm_ccl"
-
-RUN mkdir -p /lib/firmware
-WORKDIR /lib/firmware
+ENV PACKAGE_NAME="Tsm_validation_suite Tsm_runtime Tsm_ccl Tsm_profiler"
 
 RUN set -eux ; \
   for pkg in ${PACKAGE_NAME}; do \
@@ -39,4 +36,5 @@ RUN set -eux ; \
   done
 
 ENV PATH="/usr/local/kuiper/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/kuiper/lib"
+ENV LD_LIBRARY_PATH="/usr/local/kuiper/lib:/usr/local/kuiper/tsm8-profiler/lib"
+

--- a/container/containerfile.tsingmicro
+++ b/container/containerfile.tsingmicro
@@ -16,10 +16,15 @@ ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/tsingmicr
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# libfmt, libunwind8, libopenmpi3 are depdencies for torch_txda;
+# clang is dendency from triton;
+# sudo is hardcoded dependency from TSM installers.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl ca-certificates \
-      gcc g++ build-essential cmake \
+      gcc g++ build-essential cmake clang \
       libopenmpi3 sudo \
+      libfmt-dev libunwind8 \
+      libpython3-dev \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR fixes the container file for the TsingMicro base image.

- The compiler tool chain (gcc, g++, cmake, clang are now pushed down from FlagOS images
  to the base image layer. They are hard requirements not only during installation
  (for example, C++ operators), but also dynamic compilation of FlagOS operators (i.e. gems).
- The `Tsm_profiler` package is a hard requirement from torch_txda, and it demands for
  a dedicated environment variable customization.
- The `torch_txda` new version (`0.1.0+20260610.3968e515`) introduced dependencies over some
  native libraries such as `libfmt-dev`, `libunwind8`, `libopenmpi3`, without which the
  `torch_txda` cannot be imported.