### PR TITLE
Add containerfile for CANN 9.0.0

### DIFF
--- a/container/containerfile.ascend-cann9.0.0
+++ b/container/containerfile.ascend-cann9.0.0
@@ -1,0 +1,53 @@
+# ============================================================
+# Base image for Ascend CANN 9.0.0 on Ubuntu 22.04
+# =========================================================
+# History:
+# -0260615: Initial version
+
+FROM ubuntu:22.04 AS Builder
+
+LABEL org.opencontainers.image.authors="FlagOS contributors"
+
+# ── Build arguments ────────────────────────────────────────────
+ARG PYTHON_VERSION=3.11
+ARG ARCH=aarch64
+ARG PRODUCT=910b
+
+ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore
+ENV CANN_PACKAGE=Ascend-cann-toolkit_9.0.0_linux-aarch64.run
+ENV OPS_PACKAGE=Ascend-cann-${PRODUCT}-ops_9.0.0_linux-aarch64.run
+ENV NNAL_PACKAGE=Ascend-cann-nnal_9.0.0_linux-aarch64.run
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+# python are required by the CANN toolkit/ops installer
+# libelf1 and libpython3-dev are required by the runtime.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl unzip net-tools pciutils\
+        gcc g++ build-essential make \
+        python${PYTHON_VERSION} python3-pip python${PYTHON_VERSION}-dev \
+        libelf1 \
+        libpython3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Install CANN toolkit ──────────────────────────────────────
+RUN curl -o /cann.run ${FILE_STORE}/ascend/${CANN_PACKAGE} \
+    && chmod +x /cann.run \
+    && /cann.run --full --quiet --nox11 --install-for-all \
+    && rm /cann.run
+
+RUN curl -o /ops.run ${FILE_STORE}/ascend/${OPS_PACKAGE} \
+    && chmod +x /ops.run \
+    && /ops.run --install --quiet --nox11 --install-for-all \
+    && rm /ops.run
+
+RUN curl -o /nnal.run ${FILE_STORE}/ascend/${NNAL_PACKAGE} \
+    && chmod +x /nnal.run \
+    && /nnal.run --install --quiet --nox11 --install-for-all \
+    && rm /nnal.run
+
+ENV ASCEND_HOME=/usr/local/Ascend/ascend-toolkit/latest
+ENV PATH="${ASCEND_HOME}/bin:${ASCEND_HOME}/compiler/ccec_compiler/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEND_HOME}/lib64/plugin/opskernel:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
This PR adds a new containerfile for CANN 9.0.0 on Ascend backends.

The product series (910b, A3, 950) can be specified as build args.