### PR TITLE
Add OCI version label to all containerfiles

### DIFF
--- a/container/containerfile.amd
+++ b/container/containerfile.amd
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.0"
 
 ARG PYTHON_VERSION=3
 ARG TORCH_VERSION=latest

--- a/container/containerfile.ascend-cann8.5.0
+++ b/container/containerfile.ascend-cann8.5.0
@@ -6,6 +6,7 @@
 
 FROM ubuntu:22.04 AS Builder
 
+LABEL org.opencontainers.image.version="2.1.0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.ascend-cann9.0.0
+++ b/container/containerfile.ascend-cann9.0.0
@@ -6,6 +6,7 @@
 
 FROM ubuntu:22.04 AS Builder
 
+LABEL org.opencontainers.image.version="2.1.0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.cambricon
+++ b/container/containerfile.cambricon
@@ -6,6 +6,7 @@
 
 FROM ubuntu:22.04
 
+LABEL org.opencontainers.image.version="2.1.0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.enflame
+++ b/container/containerfile.enflame
@@ -6,6 +6,7 @@
 
 FROM ubuntu:24.04
 
+LABEL org.opencontainers.image.version="2.1.0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.hygon
+++ b/container/containerfile.hygon
@@ -6,6 +6,7 @@
 
 FROM ubuntu:22.04
 
+LABEL org.opencontainers.image.version="2.1.0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.iluvatar
+++ b/container/containerfile.iluvatar
@@ -6,6 +6,7 @@
 FROM ubuntu:24.04 AS builder
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.0"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore

--- a/container/containerfile.kunlunxin
+++ b/container/containerfile.kunlunxin
@@ -6,6 +6,7 @@
 
 FROM ubuntu:22.04
 
+LABEL org.opencontainers.image.version="2.1.0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.metax
+++ b/container/containerfile.metax
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.0"
 
 ARG PYTHON_VERSION=3
 ARG TORCH_VERSION=latest

--- a/container/containerfile.mthreads
+++ b/container/containerfile.mthreads
@@ -4,6 +4,7 @@
 FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.0"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/mthreads

--- a/container/containerfile.nvidia
+++ b/container/containerfile.nvidia
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.0"
 
 ARG PYTHON_VERSION=3
 ARG TORCH_VERSION=latest

--- a/container/containerfile.tsingmicro
+++ b/container/containerfile.tsingmicro
@@ -6,6 +6,7 @@
 
 FROM ubuntu:22.04
 
+LABEL org.opencontainers.image.version="2.1.0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 ARG PYTHON_VERSION=3.10


### PR DESCRIPTION
Add `org.opencontainers.image.version="2.1.0"` to all 12 containerfiles, matching the current FlagOS release tag. Also ensure `org.opencontainers.image.authors` is consistently present across all files.

Affected files:
- `containerfile.amd`
- `containerfile.ascend-cann8.5.0`
- `containerfile.ascend-cann9.0.0`
- `containerfile.cambricon`
- `containerfile.enflame`
- `containerfile.hygon`
- `containerfile.iluvatar`
- `containerfile.kunlunxin`
- `containerfile.metax`
- `containerfile.mthreads`
- `containerfile.nvidia`
- `containerfile.tsingmicro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)