### PR TITLE
Add revision label to containerfiles and CI check

### DIFF
--- a/.github/workflows/check-revision.yaml
+++ b/.github/workflows/check-revision.yaml
@@ -1,0 +1,55 @@
+name: Check containerfile revision
+
+on:
+  pull_request:
+    paths:
+      - 'container/containerfile.*'
+
+jobs:
+  check-revision-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check revision label was bumped
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+
+          changed_files=$(git diff --name-only "$BASE" "$HEAD" -- 'container/containerfile.*')
+          if [ -z "$changed_files" ]; then
+            echo "No containerfiles changed."
+            exit 0
+          fi
+
+          failed=0
+          for f in $changed_files; do
+            # Skip deleted files
+            if [ ! -f "$f" ]; then
+              continue
+            fi
+
+            old_rev=$(git show "${BASE}:${f}" 2>/dev/null \
+              | grep -oP 'org\.opencontainers\.image\.revision="\K[^"]+' || echo "")
+            new_rev=$(grep -oP 'org\.opencontainers\.image\.revision="\K[^"]+' "$f" || echo "")
+
+            if [ -z "$new_rev" ]; then
+              echo "❌ $f: missing org.opencontainers.image.revision label"
+              failed=1
+            elif [ -z "$old_rev" ]; then
+              echo "✅ $f: new file (revision=$new_rev)"
+            elif [ "$old_rev" = "$new_rev" ]; then
+              echo "❌ $f: revision unchanged ($new_rev) — please bump it"
+              failed=1
+            else
+              echo "✅ $f: revision $old_rev -> $new_rev"
+            fi
+          done
+
+          if [ "$failed" -eq 1 ]; then
+            echo ""
+            echo "::error::One or more containerfiles were modified without bumping org.opencontainers.image.revision"
+            exit 1
+          fi

--- a/container/containerfile.amd
+++ b/container/containerfile.amd
@@ -2,6 +2,7 @@ FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 
 ARG PYTHON_VERSION=3
 ARG TORCH_VERSION=latest

--- a/container/containerfile.ascend-cann8.5.0
+++ b/container/containerfile.ascend-cann8.5.0
@@ -7,6 +7,7 @@
 FROM ubuntu:22.04 AS Builder
 
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.ascend-cann9.0.0
+++ b/container/containerfile.ascend-cann9.0.0
@@ -7,6 +7,7 @@
 FROM ubuntu:22.04 AS Builder
 
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.cambricon
+++ b/container/containerfile.cambricon
@@ -7,6 +7,7 @@
 FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.enflame
+++ b/container/containerfile.enflame
@@ -7,6 +7,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.hygon
+++ b/container/containerfile.hygon
@@ -7,6 +7,7 @@
 FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.iluvatar
+++ b/container/containerfile.iluvatar
@@ -7,6 +7,7 @@ FROM ubuntu:24.04 AS builder
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore

--- a/container/containerfile.kunlunxin
+++ b/container/containerfile.kunlunxin
@@ -7,6 +7,7 @@
 FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────

--- a/container/containerfile.metax
+++ b/container/containerfile.metax
@@ -2,6 +2,7 @@ FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 
 ARG PYTHON_VERSION=3
 ARG TORCH_VERSION=latest

--- a/container/containerfile.mthreads
+++ b/container/containerfile.mthreads
@@ -5,6 +5,7 @@ FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/mthreads

--- a/container/containerfile.nvidia
+++ b/container/containerfile.nvidia
@@ -2,6 +2,7 @@ FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 
 ARG PYTHON_VERSION=3
 ARG TORCH_VERSION=latest

--- a/container/containerfile.tsingmicro
+++ b/container/containerfile.tsingmicro
@@ -7,6 +7,7 @@
 FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 ARG PYTHON_VERSION=3.10


### PR DESCRIPTION
## Changes

### Revision label

Add `org.opencontainers.image.revision="0"` to all 12 containerfiles as the initial revision counter. Each time a containerfile is modified, the revision must be incremented.

### CI check

Add `check-revision.yaml` workflow that runs on PRs touching `container/containerfile.*`. It compares the `org.opencontainers.image.revision` value against the base branch and fails if:
- The label is missing
- The label was not bumped

Example output:
```
✅ container/containerfile.nvidia: revision 0 -> 1
❌ container/containerfile.ascend-cann9.0.0: revision unchanged (0) — please bump it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)