### PR TITLE
feat(base): add --registry option to build.py

### DIFF
--- a/base/build.py
+++ b/base/build.py
@@ -56,6 +56,10 @@ def main():
         "name",
         help="Base containerfile name (e.g. nvidia-cuda12.8, ascend-cann9.0.0)",
     )
+    parser.add_argument(
+        "--registry",
+        help="Container registry prefix (e.g. harbor.baai.ac.cn/flagos21-base)",
+    )
     parser.add_argument("--tag", "-t", help="Override image tag")
     parser.add_argument("--push", action="store_true", help="Push after building")
     parser.add_argument(
@@ -87,7 +91,15 @@ def main():
             f"Error: no LABEL org.opencontainers.image.revision found in {containerfile}"
         )
 
-    tag = args.tag or f"{IMAGE_PREFIX}-{args.name}:{version}-{revision}"
+    image_name = f"{IMAGE_PREFIX}-{args.name}"
+    image_tag = f"{version}-{revision}"
+
+    if args.tag:
+        tag = args.tag
+    elif args.registry:
+        tag = f"{args.registry}/{image_name}:{image_tag}"
+    else:
+        tag = f"{image_name}:{image_tag}"
 
     cmd = ["docker", "build", "-f", str(containerfile), "-t", tag, str(repo_root)]
 

--- a/runtime/build.py
+++ b/runtime/build.py
@@ -142,7 +142,11 @@ def main():
         choices=["true", "false"],
         help="Override whether to include tests",
     )
-    parser.add_argument("--tag", "-t", help="Image tag")
+    parser.add_argument(
+        "--registry",
+        help="Container registry prefix (e.g. harbor.baai.ac.cn/flagos21)",
+    )
+    parser.add_argument("--tag", "-t", help="Override image tag")
     parser.add_argument("--push", action="store_true", help="Push after building")
     parser.add_argument(
         "--dry-run", action="store_true", help="Print command without executing"
@@ -179,7 +183,14 @@ def main():
         include_tests_override=args.include_tests,
     )
 
-    tag = args.tag or f"flaggems-{backend_key}:latest"
+    image_name = f"flaggems-{backend_key}"
+
+    if args.tag:
+        tag = args.tag
+    elif args.registry:
+        tag = f"{args.registry}/{image_name}:latest"
+    else:
+        tag = f"{image_name}:latest"
 
     cmd = ["docker", "build"]
     for key, value in build_args.items():


### PR DESCRIPTION
Add `--registry` option so base images can be pushed to a private registry.

```bash
# Local build (no registry)
python base/build.py nvidia-cuda12.8 --dry-run
# → flagos-base-nvidia-cuda12.8:2.1.0-0

# Push to private registry
python base/build.py nvidia-cuda12.8 --registry harbor.baai.ac.cn/flagos21-base --push
# → harbor.baai.ac.cn/flagos21-base/flagos-base-nvidia-cuda12.8:2.1.0-0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)