### PR TITLE
fix(runtime): rename image to flagos-runtime and use variant naming

### DIFF
--- a/runtime/build.py
+++ b/runtime/build.py
@@ -183,7 +183,9 @@ def main():
         include_tests_override=args.include_tests,
     )
 
-    image_name = f"flaggems-{backend_key}"
+    vendor = backend_key.split("-")[0]
+    image_suffix = f"{vendor}-{variant}"
+    image_name = f"flagos-runtime-{image_suffix}"
 
     if args.tag:
         tag = args.tag


### PR DESCRIPTION
- Image prefix: `flaggems-{backend_key}` → `flagos-runtime-{vendor}-{variant}`
- Use human-readable variant names with dots (`cuda12.8`, not `cuda128`)

Examples:
```
flagos-runtime-nvidia-cuda12.8:latest
flagos-runtime-metax-maca3.7.2.1:latest
harbor.baai.ac.cn/flagos21/flagos-runtime-nvidia-cuda12.8:latest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)