### PR TITLE
fix(runtime): suppress InvalidDefaultArgInFrom warnings

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -6,7 +6,7 @@
 # which reads configs.yaml and FlagGems's backends.yaml.
 # ============================================================
 
-ARG BASE_IMAGE
+ARG BASE_IMAGE=scratch
 ARG EXTRA_PYPI="https://mirrors.aliyun.com/pypi/simple"
 ARG INCLUDE_TESTS=true
 


### PR DESCRIPTION
Give `BASE_IMAGE` a dummy default (`scratch`) to suppress buildkit warnings:

```
InvalidDefaultArgInFrom: Default value for ARG ${BASE_IMAGE} results in empty or invalid base image name
```

The actual value is always provided via `--build-arg` by `build.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)