### PR TITLE
chore: add legacy/ with hand-written containerfiles from FlagGems

### DIFF
--- a/legacy/README.md
+++ b/legacy/README.md
@@ -1,0 +1,9 @@
+# Legacy Containerfiles
+
+Hand-written containerfiles migrated from FlagGems `container/` directory.
+
+These are kept as reference until:
+1. All backends are verified with the new `runtime/` build system
+2. Wheel-based FlagGems installation is working
+
+Once both conditions are met, this directory can be deleted.

--- a/legacy/flaggems-ascend-8.5.0
+++ b/legacy/flaggems-ascend-8.5.0
@@ -1,0 +1,82 @@
+# ============================================================
+# FlagGems development image for Ascend CANN 8.5.0
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=ascend-cann:8.5.0
+ARG PYTHON_VERSION=3.11.15
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-ascend/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir --index ${EXTRA_PYPI} \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=METAX"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[ascend]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+ENTRYPOINT ["bash"]

--- a/legacy/flaggems-ascend-9.0.0
+++ b/legacy/flaggems-ascend-9.0.0
@@ -1,0 +1,86 @@
+# ============================================================
+# FlagGems development image for Ascend CANN 8.5.0
+# ============================================================
+# History:
+# - 2026/06/18: Initial version
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=ascend-cann:9.0.0
+ARG PYTHON_VERSION=3.11.15
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-ascend/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir --index ${EXTRA_PYPI} \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=METAX"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[ascend-cann9]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com \
+  && uv pip install --no-cache-dir --index ${FLAGOS_PYPI} \
+      "triton_ascend==3.2.1"
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+ENTRYPOINT ["bash"]

--- a/legacy/flaggems-cambricon-4.4.3
+++ b/legacy/flaggems-cambricon-4.4.3
@@ -1,0 +1,82 @@
+# ============================================================
+# FlagGems development image for Cambricon Neuware 4.4.3
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=cambricon-neuware:4.4.3
+ARG PYTHON_VERSION=3.10
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-cambricon/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir --index ${EXTRA_PYPI} \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=METAX"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[cambricon]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+ENTRYPOINT ["bash"]

--- a/legacy/flaggems-enflame-1.9.10
+++ b/legacy/flaggems-enflame-1.9.10
@@ -1,0 +1,93 @@
+# ============================================================
+# FlagGems development image for Enflame TOPS 1.9.10
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=enflame-tops:1.9.10
+ARG PYTHON_VERSION=3.12
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-enflame/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=false
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv venv /venv --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/venv \
+    PATH="/venv/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir --index ${EXTRA_PYPI} \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=METAX"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[enflame]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG INCLUDE_TESTS
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libelf1 \
+        libpython3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /venv /venv
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/venv \
+   PATH="/venv/bin:${PATH}"
+
+ENTRYPOINT ["bash"]

--- a/legacy/flaggems-hygon-26.04
+++ b/legacy/flaggems-hygon-26.04
@@ -1,0 +1,96 @@
+# ============================================================
+# FlagGems development image for Hygon DTK-26.04
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=hygon-dtk:26.04
+ARG PYTHON_VERSION=3.10
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-hygon/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=METAX"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[hygon]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG INCLUDE_TESTS
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libelf1 \
+        libnuma-dev \
+        libgfortran5 \
+        libpython3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+ENTRYPOINT ["bash"]

--- a/legacy/flaggems-iluvatar-4.4.0
+++ b/legacy/flaggems-iluvatar-4.4.0
@@ -1,0 +1,89 @@
+# ============================================================
+# FlagGems development image for Iluvatar Corex 4.4.0
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=iluvatar-corex:4.4.0
+ARG PYTHON_VERSION=3.12
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-iluvatar/simple
+ARG EXTRA_PYPI=http://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Python build dependencies ──────────────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=IX"
+# ENV CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CUDA_COMPILER_FORCED=TRUE"
+# ENV CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CUDA_COMPILER=/usr/local/corex/bin/nvcc -DCUDAToolkit_ROOT=/usr/local/corex"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[iluvatar]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG PYTHON_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION}-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Copy venv from builder ─────────────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+ENTRYPOINT ["bash"]

--- a/legacy/flaggems-kunlunxin-5.29.0
+++ b/legacy/flaggems-kunlunxin-5.29.0
@@ -1,0 +1,96 @@
+# ============================================================
+# FlagGems — Kununxin (KLX) XPU container image
+# Two-stage build: devel (build extensions) → runtime
+# ============================================================
+# Status:
+# - 20260602 - Initial version
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=kunlunxin-xre:5.29.0
+ARG PYTHON_VERSION=3.10
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-kunlunxin/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv python install ${PYTHON_VERSION} && \
+  uv venv /flagos --python ${PYTHON_VERSION} --relocatable --python-preference only-managed
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir \
+        "setuptools>=64.0,<80.0" \
+        "scikit-build-core==0.12.2" \
+        "pybind11==3.0.3" \
+        "cmake>=3.20,<4.0" \
+        "ninja==1.13.0" \
+        "pip"
+
+# ── PyTorch + torch_xpu + Triton ─────────────────────────────
+# The first command installs the default Triton, the seconds replaces it
+RUN uv pip install ".[kunlunxin]" \
+      --index ${FLAGOS_PYPI} \
+      --trusted-host resource.flagos.net \
+  && uv pip install triton==3.0.0+a48aedef --index ${FLAGOS_PYPI}
+RUN uv pip install ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG INCLUDE_TESTS
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libelf1 \
+        libz3-4 \
+        libpython3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+ENTRYPOINT ["bash"]

--- a/legacy/flaggems-metax-3.7.2.1
+++ b/legacy/flaggems-metax-3.7.2.1
@@ -1,0 +1,95 @@
+# ============================================================
+# FlagGems development image for MetaX MACA 3.7.2.0
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=metax-maca:3.7.2.1
+ARG PYTHON_VERSION=3.12
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-metax/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl build-essential ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && mv ~/.local/bin/uv /usr/local/bin/uv
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=METAX"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[metax]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      mkdir /app && \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG INCLUDE_TESTS
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential libpython3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flaogs \
+   PATH="/flagos/bin:${PATH}" \
+   LD_LIBRARY_PATH="/flagos/lib/python3.12/site-packages/triton/backends/metax/lib:${LD_LIBRARY_PATH}"
+
+ENTRYPOINT ["bash"]

--- a/legacy/flaggems-mthreads-4.3.6
+++ b/legacy/flaggems-mthreads-4.3.6
@@ -1,0 +1,108 @@
+# ============================================================
+# FlagGems — Mthreads (Moore Threads) GPU container image
+# Two-stage build: devel (build extensions) → runtime
+# ============================================================
+# Status:
+# - 20260602 - Initial version, to be verified
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=mthreads-musa:4.3.6
+ARG PYTHON_VERSION=3.10
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-mthreads/simple
+ARG EXTRA_PYPI=http://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Python build dependencies ──────────────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv python install ${PYTHON_VERSION} && \
+    uv venv /flagos --python ${PYTHON_VERSION} --relocatable --python-preference only-managed
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install \
+        "setuptools>=64.0,<80.0" \
+        "scikit-build-core==0.12.2" \
+        "pybind11==3.0.3" \
+        "cmake>=3.20,<4.0" \
+        "ninja==1.13.0" \
+        "pip"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+RUN uv pip install .
+RUN uv pip install ".[mthreads]" \
+    --index ${FLAGOS_PYPI} \
+    --trusted-host resource.flagos.net
+
+RUN uv pip install ".[test]"
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG PYTHON_VERSION
+ARG INCLUDE_TESTS
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libelf1 \
+        libnuma-dev \
+        libgfortran5 \
+        libpython3-dev \
+        libopenmpi-dev openmpi-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+  PATH="/flagos/bin:${PATH}"
+
+# ── Mthreads runtime environment ──────────────────────────────
+ENV MUSA_HOME="/usr/local/musa" \
+    MTHREADS_VISIBLE_DEVICES=all
+ENV LD_LIBRARY_PATH="${VIRTUAL_ENV}/lib:${MUSA_HOME}/lib:${LD_LIBRARY_PATH}" \
+    PATH="${MUSA_HOME}/bin:${PATH}" \
+    GEMS_VENDOR=mthreads
+
+# ── Runtime defaults ───────────────────────────────────────────
+WORKDIR /app
+
+ENTRYPOINT ["bash"]

--- a/legacy/flaggems-nvidia-12.8
+++ b/legacy/flaggems-nvidia-12.8
@@ -1,0 +1,114 @@
+# ============================================================
+# FlagGems + vLLM — NVIDIA GPU container image
+# Two-stage build: devel (build C extensions) → runtime
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG CUDA_VERSION=12.8.0
+ARG UBUNTU_VERSION=22.04
+ARG PYTHON_VERSION=3.12
+ARG TORCH_INDEX=https://resource.flagos.net/repository/flagos-pypi-nvidia/simple
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS builder
+
+ARG PYTHON_VERSION=3.12
+ARG TORCH_INDEX=https://resource.flagos.net/repository/flagos-pypi-nvidia/simple
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        git \
+        curl \
+        ca-certificates \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-venv \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
+    && update-alternatives --install /usr/bin/python  python  /usr/bin/python${PYTHON_VERSION} 1 \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Python build dependencies ──────────────────────────────────
+RUN pip install uv --no-cache-dir
+ENV VIRTUAL_ENV="/venv"
+RUN uv venv ${VIRTUAL_ENV}
+ENV PATH="${VIRTUAL_ENV}/"bin":/usr/local/cuda/bin:$PATH"
+RUN uv pip install --no-cache-dir \
+        "setuptools>=64.0,<80.0" \
+        "scikit-build-core==0.12.2" \
+        "pybind11==3.0.3" \
+        "cmake>=3.20,<4.0" \
+        "ninja==1.13.0"
+
+# ── PyTorch + Triton (NVIDIA cu128) ────────────────────────────
+RUN uv pip install --no-cache-dir \
+        --index-url ${TORCH_INDEX} \
+        "torch==2.10.0+cu128" \
+        "torchvision==0.25.0+cu128" \
+        "torchaudio==2.10.0+cu128" \
+        "triton==3.6.0"
+
+# ── Build FlagGems (with C extensions) ─────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=CUDA"
+
+RUN uv pip install --no-cache-dir --no-build-isolation .
+RUN uv pip install --no-cache-dir --no-build-isolation ".[test]"
+
+# ── Install vLLM ───────────────────────────────────────────────
+# NOTE: The vllm installed is 0.21.0 currently (2026/05/27)
+# TODO: This drags in torch 2.11, torchaudio 2.11, torchvision 0.26 for cu128
+RUN uv pip install --no-cache-dir vllm --torch-backend=cu128
+
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION} AS runtime
+
+ARG PYTHON_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+
+# NOTE: This sets up a minimal Python runtime with gcc for operator compilation
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        build-essential \
+        ca-certificates \
+        gcc \
+        g++ \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-venv \
+        python3-pip \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
+    && update-alternatives --install /usr/bin/python  python  /usr/bin/python${PYTHON_VERSION} 1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Copy installed packages from builder ───────────────────────
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /venv /venv
+
+# ── NVIDIA runtime environment ─────────────────────────────────
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}" \
+    PATH="/venv/bin:${PATH}"
+
+# ── Runtime defaults ───────────────────────────────────────────
+WORKDIR /workspace
+EXPOSE 8000
+
+ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]

--- a/legacy/flaggems-nvidia-13.3
+++ b/legacy/flaggems-nvidia-13.3
@@ -1,0 +1,122 @@
+# ============================================================
+# FlagGems + vLLM — NVIDIA GPU container image
+# Two-stage build: devel (build C extensions) → runtime
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG CUDA_VERSION=13.3.0
+ARG UBUNTU_VERSION=24.04
+ARG PYTHON_VERSION=3.12
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-nvidia/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl gcc g++ make build-essential cmake git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Prepare uv and virtual environment ─────────────────────────
+ARG UV_VERSION=0.11.22
+ARG UV_MIRROR=https://resource.flagos.net/repository/flagos-filestore/utils
+RUN ARCH=$(uname -m) && \
+    curl -sSf "${UV_MIRROR}/uv-${ARCH}-${UV_VERSION}-linux-gnu.tar.gz" \
+    | tar xf - -C /usr/local/bin
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir \
+        "setuptools>=64.0,<80.0" \
+        "scikit-build-core==0.12.2" \
+        "pybind11==3.0.3" \
+        "cmake>=3.20,<4.0" \
+        "ninja==1.13.0" \
+        "pip"
+
+# ── PyTorch + Triton/FlagTree  ─────────────────────────────────
+RUN uv pip install --no-cache-dir ".[nvidia-cuda133]" \
+    --default-index ${FLAGOS_PYPI} \
+    --index ${EXTRA_PYPI} \
+    --trusted-host resource.flagos.net
+
+# ── Build FlagGems (with C extensions) ─────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=CUDA"
+
+RUN uv pip install --no-cache-dir --no-build-isolation .
+RUN uv pip install --no-cache-dir --no-build-isolation ".[test]" \
+    --index ${EXTRA_PYPI}
+
+# ── Copy test suite if requested ───────────────────────────────
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ── Install vLLM ───────────────────────────────────────────────
+# NOTE: The vllm installed is 0.21.0 currently (2026/05/27)
+# RUN uv pip install --no-cache-dir vllm --torch-backend=cu130
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION} AS runtime
+
+ARG PYTHON_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+
+# NOTE: This sets up a minimal Python runtime with gcc for operator compilation
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc g++ make build-essential cmake \
+        libelf1 \
+        libpython3-dev \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── NVIDIA runtime environment ─────────────────────────────────
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+# ── Runtime defaults ───────────────────────────────────────────
+ENTRYPOINT ["bash"]
+
+# If installing vLLM, port 8000 has to be exposed
+# EXPOSE 8000
+# ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]

--- a/legacy/flaggems-tsingmicro-260614
+++ b/legacy/flaggems-tsingmicro-260614
@@ -1,0 +1,122 @@
+# ============================================================
+# FlagGems development image for TsingMicro TSM 260604
+# ============================================================
+# History:
+# - 20260610: Initial version
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=tsingmicro-tsm:260604
+ARG PYTHON_VERSION=3.10
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-tsingmicro/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+ARG USE_FLAGTREE=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+# All required packages are installed in the base image
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv python install ${PYTHON_VERSION} && \
+  uv venv /flagos --python ${PYTHON_VERSION} --relocatable --python-preference only-managed
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir \
+  --index ${EXTRA_PYPI} --trusted-host mirrors.aliyun.com \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=?"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[tsingmicro]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG USE_FLAGTREE
+ARG DEBIAN_FRONTEND=noninteractive
+ENV FILESTORE=https://resource.flagos.net/repository/flagos-filestore/tsingmicro
+# ── Install tx8_deps for FlagTree ──────────────────────────────
+RUN if [ "$USE_FLAGTREE" = "true" ]; then \
+    curl -o tx8.tar.gz ${FILESTORE}/tx8_depends_dev_20260507_104051.tar.gz \
+    && tar xvf tx8.tar.gz -C /usr/local \
+    && rm tx8.tar.gz; \
+  fi
+
+RUN if [ "$USE_FLAGTREE" = "true" ]; then \
+    curl -o llvm.tar.gz ${FILESTORE}/llvm-a66376b0-ubuntu-x64.tgz \
+    && tar xvf llvm.tar.gz -C /usr/local \
+    && rm llvm.tar.gz; \
+  fi
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+
+# The following environment variables are for flagtree.
+# Hopefully harmless to Triton
+ENV TX8_DEPS_ROOT=/usr/local/tx8_deps \
+    LLVM_SYSPATH=/usr/local/llvm
+ENV  LLVM_BINARY_DIR=${LLVM_SYSPATH}/bin \
+    PYTHONPATH=${LLVM_SYSPATH}/python_packages/mlir_core \
+    LD_LIBRARY_PATH=${TX8_DEPS_ROOT}/lib:${LD_LIBRARY_PATH}
+
+# - Torch XLA is not used in TsingMicro, and it may lead to LLVM error
+# - Torch compiler is not supported on TsingMicro, and in particular,
+#   it is not used for inference scenario
+ENV USE_TORCH_XLA=0 \
+    TORCH_COMPILE_DISABLE=1
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+# Runtime environment
+WORKDIR /app
+
+ENTRYPOINT ["bash"]


### PR DESCRIPTION
Migrate hand-written containerfiles from FlagGems `container/` to `legacy/` as reference.

To be removed once:
1. All backends are verified with the new `runtime/` build system
2. Wheel-based FlagGems installation is working

🤖 Generated with [Claude Code](https://claude.com/claude-code)