### PR TITLE
chore: remove pre_install from runtime Containerfile and build.py

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -15,7 +15,6 @@ ARG PYTHON_VERSION=3.12
 ARG FLAGOS_PYPI=""
 ARG EXTRAS_GROUP=""
 ARG POST_INSTALL=""
-ARG PRE_INSTALL=""
 # TODO: Remove FLAGGEMS_VERSION once we switch to wheel-based install.
 # Buildkit excludes .git from the build context, so setuptools-scm
 # cannot detect the version. build.py reads it from git describe and
@@ -95,13 +94,7 @@ RUN mkdir -p /app && \
 # ════════════════════════════════════════════════════════════════
 FROM ${BASE_IMAGE} AS runtime
 
-ARG PRE_INSTALL
 ARG DEBIAN_FRONTEND=noninteractive
-
-# ── Pre-install (e.g. SDK tarballs) ────────────────────────────
-RUN if [ -n "${PRE_INSTALL}" ]; then \
-      sh -c "${PRE_INSTALL}"; \
-    fi
 
 # ── Copy uv and venv from builder ─────────────────────────────
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv

--- a/runtime/build.py
+++ b/runtime/build.py
@@ -170,13 +170,12 @@ def resolve_build_args(
         "INCLUDE_TESTS": include_tests_override or "true",
     }
 
-    # Optional hooks from backends.yaml
-    for key in ("pre_install", "post_install"):
-        val = backend_info.get(key, "")
-        if isinstance(val, str):
-            val = val.strip()
-        if val:
-            args[key.upper()] = val
+    # Optional post-install hook from backends.yaml
+    post_install = backend_info.get("post_install", "")
+    if isinstance(post_install, str):
+        post_install = post_install.strip()
+    if post_install:
+        args["POST_INSTALL"] = post_install
 
     return args
 


### PR DESCRIPTION
No backends have `pre_install` steps. Remove the ARG, conditional RUN, and build.py handling.

`post_install` is retained (used by ascend-cann900 for triton_ascend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)