### PR TITLE
chore: trim runtime_env — remove vars already in base images

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -59,21 +59,9 @@ runtime_env:
   nvidia-cuda13.3:
     NVIDIA_VISIBLE_DEVICES: "all"
     NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
-  metax:
-    MACA_PATH: "/opt/maca"
-    LD_LIBRARY_PATH: "$MACA_PATH/lib:$MACA_PATH/mxgpu_llvm/lib:$LD_LIBRARY_PATH"
   mthreads:
-    MUSA_HOME: "/usr/local/musa"
     MTHREADS_VISIBLE_DEVICES: "all"
-    LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${MUSA_HOME}/lib:${LD_LIBRARY_PATH}"
-    GEMS_VENDOR: "mthreads"
-  sunrise:
-    LD_LIBRARY_PATH: "/usr/local/tangrt/targets/linux-x86_64/lib"
+    LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
   tsingmicro:
-    TX8_DEPS_ROOT: "/usr/local/tx8_deps"
-    LLVM_SYSPATH: "/usr/local/llvm"
-    LLVM_BINARY_DIR: "${LLVM_SYSPATH}/bin"
-    PYTHONPATH: "${LLVM_SYSPATH}/python_packages/mlir_core"
-    LD_LIBRARY_PATH: "${TX8_DEPS_ROOT}/lib:${LD_LIBRARY_PATH}"
     USE_TORCH_XLA: "0"
     TORCH_COMPILE_DISABLE: "1"


### PR DESCRIPTION
Remove env vars from `runtime_env` that are already baked into base image containerfiles. Also remove `GEMS_VENDOR` (unnecessary).

**Removed** (already in base):
- metax: `MACA_PATH`, `LD_LIBRARY_PATH`
- mthreads: `MUSA_HOME`
- sunrise: `LD_LIBRARY_PATH`
- tsingmicro: `TX8_DEPS_ROOT`, `LLVM_*`, `LD_LIBRARY_PATH`

**Remaining** (runtime-only):
- nvidia: `NVIDIA_VISIBLE_DEVICES`, `NVIDIA_DRIVER_CAPABILITIES`
- mthreads: `MTHREADS_VISIBLE_DEVICES`, `${VIRTUAL_ENV}/lib` in `LD_LIBRARY_PATH`
- tsingmicro: `USE_TORCH_XLA`, `TORCH_COMPILE_DISABLE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)