### PR TITLE
Rename POST_INSTALL to TRITON_POST_INSTALL

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -14,7 +14,7 @@ ARG INCLUDE_TESTS=true
 ARG PYTHON_VERSION=3.12
 ARG FLAGOS_PYPI=""
 ARG EXTRAS_GROUP=""
-ARG POST_INSTALL=""
+ARG TRITON_POST_INSTALL=""
 # TODO: Remove FLAGGEMS_VERSION once we switch to wheel-based install.
 # Buildkit excludes .git from the build context, so setuptools-scm
 # cannot detect the version. build.py reads it from git describe and
@@ -31,7 +31,7 @@ ARG PYTHON_VERSION
 ARG FLAGOS_PYPI
 ARG EXTRA_PYPI
 ARG EXTRAS_GROUP
-ARG POST_INSTALL
+ARG TRITON_POST_INSTALL
 ARG INCLUDE_TESTS
 ARG FLAGGEMS_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
@@ -70,9 +70,9 @@ RUN uv pip install --no-cache-dir ".[$EXTRAS_GROUP]" \
       --trusted-host resource.flagos.net \
       --trusted-host mirrors.aliyun.com
 
-# ── Post-install (e.g. triton_ascend) ──────────────────────────
-RUN if [ -n "${POST_INSTALL}" ]; then \
-      sh -c "${POST_INSTALL}"; \
+# ── Triton post-install (e.g. triton_ascend) ─────────────────
+RUN if [ -n "${TRITON_POST_INSTALL}" ]; then \
+      sh -c "${TRITON_POST_INSTALL}"; \
     fi
 
 # ── Test dependencies ──────────────────────────────────────────

--- a/runtime/build.py
+++ b/runtime/build.py
@@ -170,12 +170,20 @@ def resolve_build_args(
         "INCLUDE_TESTS": include_tests_override or "true",
     }
 
-    # Optional post-install hook from backends.yaml
-    post_install = backend_info.get("post_install", "")
-    if isinstance(post_install, str):
-        post_install = post_install.strip()
-    if post_install:
-        args["POST_INSTALL"] = post_install
+    # Optional triton-specific post-install packages from backends.yaml
+    # These are only needed when using triton (not flagtree).
+    triton_post = backend_info.get("triton_post_install", [])
+    if isinstance(triton_post, list) and triton_post:
+        pkgs = " ".join(triton_post)
+        flagos_pypi = args["FLAGOS_PYPI"]
+        extra_pypi = args["EXTRA_PYPI"]
+        cmd = (
+            f"uv pip install --no-cache-dir"
+            f" --default-index {flagos_pypi}"
+            f" --index {extra_pypi}"
+            f" {pkgs}"
+        )
+        args["TRITON_POST_INSTALL"] = cmd
 
     return args
 


### PR DESCRIPTION
## Context

FlagGems renamed `post_install` → `triton_post_install` in `backends.yaml` (flagos-ai/FlagGems#4680). `triton_ascend` is only needed when using triton as the compiler, not FlagTree.

## Changes

### runtime/build.py
- Read `triton_post_install` list from backends.yaml
- Construct full `uv pip install` command with both vendor and public mirror indexes
- Pass as `TRITON_POST_INSTALL` build-arg

### runtime/Containerfile
- Rename `POST_INSTALL` ARG → `TRITON_POST_INSTALL`
- Update RUN step and comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)