### PR TITLE
feat: merge backends.yaml into configs.yaml as dependency source of truth

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -1,7 +1,7 @@
 # FlagOS build configuration.
 #
-# Defines the supported vendors and their backends.
-# Used by both base/build.py and runtime/build.py.
+# Single source of truth for all vendor/backend dependencies and build
+# settings. Used by base/build.py and runtime/build.py.
 #
 # Base image naming convention:
 #   {base_image_prefix}-{vendor}-{backend}:{version}-{revision}
@@ -12,72 +12,294 @@
 #   flagos-runtime-{vendor}-{backend}:latest
 #   e.g. flagos-runtime-nvidia-cuda12.8:latest
 #
-# For multi-backend vendors (nvidia, ascend), the FlagGems pyproject
-# extras key is "{vendor}-{backend_no_dots}" (e.g. "nvidia-cuda128").
-# For single-backend vendors, it is just the vendor name (e.g. "cambricon").
+# The PyPI index URL is auto-generated: pypi_base.format(vendor=<vendor>).
+# Override per-backend with an explicit "index:" field if needed.
 #
-# "env" defines environment variables to set in runtime containers.
-# These are container-specific and not used for bare-metal/VM
-# installations (see FlagGems backends.yaml env/env_source for that).
+# Vendor entry:
+#   "env:"      — environment variables set in the *runtime container*.
+#                 Container-specific; not used for bare-metal/VM installs.
+#   "backends:" — mapping of backend name → backend spec (see below).
+#                 The backend name (e.g. "cuda12.8") matches base/{vendor}-{backend}.
+#
+# Backend spec fields:
+#   "extras:"          — FlagGems pyproject extra name, passed verbatim as the
+#                        EXTRAS_GROUP build-arg (`pip install ".[<extras>]"`).
+#                        Opaque to build-infra; the naming is owned by FlagGems.
+#   "python:"          — Python version for the venv.
+#   "cmake_backend:"   — FLAGGEMS_BACKEND for C++ extensions (only where supported).
+#   "triton:"          — vendor Triton package(s).
+#   "flagtree:"        — FlagTree package (preferred compiler).
+#   "triton_post_install:" — extra packages installed after Triton (COMPILER=triton).
+#   "env:"             — environment for *bare-metal/VM* installs. Same field name
+#                        as the vendor-level container env but a different concept;
+#                        distinguished by nesting level.
+#   "env_source:"      — vendor scripts to source on bare-metal installs.
+#   "deps:"            — Python dependencies (torch stack, etc.).
 
 base_image_prefix: "flagos-base"
 
+pypi_base: "https://resource.flagos.net/repository/flagos-pypi-{vendor}/simple"
+mirror: "https://mirrors.aliyun.com/pypi/simple"
+
 vendors:
   nvidia:
-    backends:
-      - cuda12.8
-      - cuda13.3
     env:
       NVIDIA_VISIBLE_DEVICES: "all"
       NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
+    backends:
+      cuda12.8:
+        extras: nvidia-cuda128
+        python: "3.12"
+        cmake_backend: CUDA
+        triton: triton==3.6.0
+        flagtree: flagtree==0.6.0
+        env:
+          PATH: /usr/local/cuda/bin:$PATH
+          LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
+        deps:
+          - torch==2.10.0+cu128
+          - torchaudio==2.10.0+cu128
+          - torchvision==0.25.0+cu128
+
+      cuda13.3:
+        extras: nvidia-cuda133
+        python: "3.12"
+        cmake_backend: CUDA
+        triton: triton==3.6.0
+        flagtree: flagtree==0.6.0
+        env:
+          PATH: /usr/local/cuda/bin:$PATH
+          LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
+        deps:
+          - torch==2.11.0+cu130
+          - torchaudio==2.11.0+cu130
+          - torchvision==0.26.0+cu130
 
   ascend:
     backends:
-      - cann8.5.0
-      - cann9.0.0
+      cann8.5.0:
+        extras: ascend-cann850
+        python: "3.11"
+        cmake_backend: NPU
+        triton: triton-ascend==3.2.0
+        flagtree: flagtree==0.6.0+ascend3.2
+        env_source:
+          - /usr/local/Ascend/cann/set_env.sh
+        deps:
+          - torch==2.9.0+cpu
+          - torch-npu==2.9.0
+
+      cann9.0.0:
+        extras: ascend-cann900
+        python: "3.11"
+        cmake_backend: NPU
+        triton: triton==3.5.0
+        flagtree: flagtree==0.6.0+ascend3.5
+        env_source:
+          - /usr/local/Ascend/cann/set_env.sh
+        triton_post_install:
+          - triton_ascend==3.2.1
+        deps:
+          - torch==2.10.0+cpu
+          - torch-npu==2.10.0
 
   cambricon:
     backends:
-      - neuware4.4.3
+      neuware4.4.3:
+        extras: cambricon
+        python: "3.10"
+        triton: triton==3.2.0+mlu1.7.2
+        env:
+          PATH: /usr/local/neuware/bin:$PATH
+          LD_LIBRARY_PATH: /usr/local/neuware/lib64:$LD_LIBRARY_PATH
+        deps:
+          - cambricon_dali==0.13.0
+          - torch==2.7.1+cpu
+          - torch-mlu==1.29.2+torch2.7.1
+          - torch-mlu-ops==1.8.0+torch2.7.1
 
   enflame:
     backends:
-      - tops1.9.10
+      tops1.9.10:
+        extras: enflame
+        python: "3.12"
+        cmake_backend: GCU
+        triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
+        flagtree: flagtree==0.6.0+enflame3.6
+        env:
+          LD_LIBRARY_PATH: /opt/OpenCloudOS/gcc-toolset-14/root/usr/lib64:$LD_LIBRARY_PATH
+        deps:
+          - pyefml==1.9.10
+          - torch==2.10.0+cpu
+          - torchaudio==2.10.0+cpu
+          - torchvision==0.25.0+cpu
+          - torch-gcu==2.10.0+3.7.20260408
+          - flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323
 
   hygon:
     backends:
-      - dtk26.04
+      dtk26.04:
+        extras: hygon
+        python: "3.10"
+        triton: triton==3.3.0+das.opt1.dtk2604.torch290
+        flagtree: flagtree==0.5.1+hcu3.1
+        env_source:
+          - /opt/dtk-26.04/env.sh
+        deps:
+          - torch==2.9.0+das.opt1.dtk2604
 
   iluvatar:
     backends:
-      - corex4.4.0
+      corex4.4.0:
+        extras: iluvatar
+        python: "3.10"
+        cmake_backend: IX
+        triton: triton==3.1.0+corex.4.4.0
+        # flagtree==0.5.1+iluvatar3.1 — plugin loading bug in venv, disabled for now
+        env:
+          COREX_ROOT: /usr/local/corex
+          PATH: $COREX_ROOT/bin:$PATH
+          LD_LIBRARY_PATH: $COREX_ROOT/lib:$LD_LIBRARY_PATH
+        deps:
+          - torch==2.7.1+corex.4.4.0
+          - torchaudio==2.7.1+corex.4.4.0
+          - torchvision==0.22.1+corex.4.4.0
 
   kunlunxin:
     backends:
-      - xre5.29.0
+      xre5.29.0:
+        extras: kunlunxin
+        python: "3.10"
+        triton: triton==3.0.0+a48aedef
+        flagtree: flagtree==0.5.1+xpu3.0
+        env:
+          LD_LIBRARY_PATH: /xcudart/lib:/usr/local/cuda/lib64
+        deps:
+          - apex==0.1
+          - benchflow==1.0.0
+          - colorama==0.4.6
+          - flash_attn==2.4.2+7e2dd4d
+          - hydrax==0.1.0
+          - hyperparameter==0.5.6
+          - psutil==6.1.0
+          - regex==2026.4.4
+          - torch==2.9.0+cu129
+          - torchaudio==2.9.0+cu129
+          - torchvision==0.24.0+cu129
+          - torch_plugin==0.1.0
+          - torch_xray==2.0.4
+          - xformers==0.0.29+1e7a8ec.d20260114
+          - xmlir==1.0.0.1
 
   metax:
     backends:
-      - maca3.7.2.1
+      maca3.7.2.1:
+        extras: metax
+        python: "3.12"
+        triton: triton==3.0.0+metax3.7.2.0
+        flagtree: flagtree==3.1.0+metax3.7.2.0
+        env:
+          MACA_PATH: /opt/maca
+          LD_LIBRARY_PATH: $MACA_PATH/lib:$MACA_PATH/mxgpu_llvm/lib:$LD_LIBRARY_PATH
+        deps:
+          - torch==2.8.0+metax3.7.2.0
+          - torchaudio==2.4.1+metax3.7.2.0
+          - torchvision==0.15.1+metax3.7.2.0
+          - flash_attn==2.6.3+metax3.7.2.0torch2.8
 
   mthreads:
-    backends:
-      - musa4.3.6
     env:
       MTHREADS_VISIBLE_DEVICES: "all"
       LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
+    backends:
+      musa4.3.6:
+        extras: mthreads-musa436
+        python: "3.10"
+        cmake_backend: MUSA
+        triton: triton==3.6.0+git89458660
+        flagtree: flagtree==0.6.0+mthreads3.6
+        env:
+          MUSA_HOME: /usr/local/musa
+          PATH: $MUSA_HOME/bin:$PATH
+          LD_LIBRARY_PATH: $VIRTUAL_ENV/lib:$MUSA_HOME/lib:$LD_LIBRARY_PATH
+        deps:
+          - torch==2.9.0+musa.4.3.6
+          - torch_musa==2.9.0
+          - mkl==2024.0.0
+
+      # No base image yet — dependency spec kept as source of truth.
+      musa5.2.0:
+        extras: mthreads-musa520
+        python: "3.10"
+        cmake_backend: MUSA
+        triton: triton==3.6.0
+        flagtree: flagtree==0.6.0+mthreads3.6
+        env:
+          MUSA_HOME: /usr/local/musa
+          PATH: $MUSA_HOME/bin:$PATH
+          LD_LIBRARY_PATH: $VIRTUAL_ENV/lib:$MUSA_HOME/lib:$LD_LIBRARY_PATH
+        deps:
+          - torch==2.9.0+musa5.2.0
+          - torch_musa==2.9.1
+          - mkl==2024.0.0
+
+  # No base image yet — dependency spec kept as source of truth.
+  spacemit:
+    backends:
+      spacemit:
+        extras: spacemit
+        python: "3.12"
+        triton: triton==3.6.0+spacemit.a5
+        deps:
+          - torch==2.8.0+spacemit.0
 
   sunrise:
     backends:
-      - tangrt1.2.0
+      tangrt1.2.0:
+        extras: sunrise
+        python: "3.10"
+        triton: triton==3.4.0.6+gite4f6d6e4
+        # flagtree==0.4.0+sunrise3.4 — requires GLIBC_2.39, unavailable on current system
+        env:
+          LD_LIBRARY_PATH: /usr/local/tangrt/targets/linux-x86_64/lib:$LD_LIBRARY_PATH
+        deps:
+          - torch==2.11.0+cpu
+          - torchaudio==2.11.0+cpu
+          - torchvision==0.26.0+cpu
+          - torch-ptpu==0.2.3+torch2.11
 
   thead:
     backends:
-      - ppu2.0.0
+      ppu2.0.0:
+        extras: thead
+        python: "3.12"
+        triton: triton==3.5.0+ppu2.0.0.oe
+        env_source:
+          - /usr/local/PPU_SDK/envsetup.sh
+        deps:
+          - torch==2.9.0+ppu2.0.0.oe
 
   tsingmicro:
-    backends:
-      - tsm260604
     env:
       USE_TORCH_XLA: "0"
       TORCH_COMPILE_DISABLE: "1"
+    backends:
+      tsm260604:
+        extras: tsingmicro
+        python: "3.10"
+        triton: triton==3.3.0+gitfe2a28fa
+        flagtree: flagtree==0.5.0.post20260612+git705a4064
+        env:
+          TX8_DEPS_ROOT: /opt/tx8_deps
+          LLVM_SYSPATH: /opt/llvm
+          LLVM_BINARY_DIR: ${LLVM_SYSPATH}/bin
+          PYTHONPATH: ${LLVM_SYSPATH}/python_packages/mlir_core
+          LD_LIBRARY_PATH: /usr/local/kuiper/lib:/usr/local/kuiper/tsm8-profiler/lib:${TX8_DEPS_ROOT}/lib:${LD_LIBRARY_PATH}
+          USE_TORCH_XLA: "0"
+          TORCH_COMPILE_DISABLE: "1"
+        deps:
+          - torch==2.7.0+cpu
+          - torchvision==0.22.0+cpu
+          - torchaudio==2.7.0+cpu
+          - torch_txda==0.1.0+20260615.37ba6bbd
+          - txops==0.1.0+20260508.60287151

--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -3,7 +3,7 @@
 #
 # A single Containerfile for all backends. Backend-specific
 # settings are passed as --build-arg by runtime/build.py,
-# which reads configs.yaml and FlagGems's backends.yaml.
+# which reads configs.yaml.
 # ============================================================
 
 ARG BASE_IMAGE

--- a/runtime/build.py
+++ b/runtime/build.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Build FlagGems runtime container images.
 
-Reads configs.yaml and FlagGems's src/flag_gems/backends.yaml to resolve
-build arguments, then invokes `docker build` with the appropriate
---build-arg values.
+Reads configs.yaml (the single source of truth for vendor/backend
+dependencies) to resolve build arguments, then invokes `docker build`
+with the appropriate --build-arg values.
 
 Usage:
     python runtime/build.py <backend-key> --flaggems-dir <path> [options]
@@ -63,33 +63,32 @@ def get_flaggems_version(flaggems_dir: Path) -> str:
 
 
 def resolve_backend(backend_arg: str, configs: dict):
-    """Resolve user input to (flaggems_key, vendor, backend).
+    """Resolve user input to (backend_info, vendor, backend).
 
-    configs.yaml maps vendor → {backends: [...], env: {...}}.
+    configs.yaml maps vendor → {env: {...}, backends: {backend: {spec}}}.
 
     Accepts:
       - "nvidia-cuda12.8" (vendor-backend)
       - "metax" (vendor shorthand, if single backend)
 
-    Returns (flaggems_key, vendor, backend) where:
-      - flaggems_key is the key in FlagGems backends.yaml (dots stripped)
+    Returns (backend_info, vendor, backend) where:
+      - backend_info is the backend spec dict from configs.yaml
       - vendor is the vendor name
-      - backend is the configs.yaml backend name (for base image name)
+      - backend is the configs.yaml backend name (for base/runtime image names)
     """
     vendors = configs.get("vendors", {})
 
     for vendor, info in vendors.items():
-        backends = info.get("backends", [])
-        for backend in backends:
+        backends = info.get("backends", {})
+        for backend, backend_info in backends.items():
             if backend_arg == f"{vendor}-{backend}":
-                flaggems_key = f"{vendor}-{backend.replace('.', '')}"
-                return flaggems_key, vendor, backend
+                return backend_info, vendor, backend
             if backend_arg == vendor and len(backends) == 1:
-                return vendor, vendor, backend
+                return backend_info, vendor, backend
 
     # Vendor name with multiple backends
     if backend_arg in vendors:
-        backends = vendors[backend_arg].get("backends", [])
+        backends = vendors[backend_arg].get("backends", {})
         if len(backends) > 1:
             names = [f"{backend_arg}-{b}" for b in backends]
             sys.exit(
@@ -135,11 +134,10 @@ def resolve_base_image(
 
 
 def resolve_build_args(
-    flaggems_key: str,
+    backend_info: dict,
     vendor: str,
     backend: str,
     configs: dict,
-    backends_yaml: dict,
     repo_root: Path,
     *,
     base_image_override: str | None = None,
@@ -148,12 +146,8 @@ def resolve_build_args(
 ) -> dict[str, str]:
     """Resolve all docker build-arg values for a given backend."""
 
-    backend_info = backends_yaml.get("backends", {}).get(flaggems_key)
-    if backend_info is None:
-        sys.exit(f"Error: '{flaggems_key}' not found in backends.yaml")
-
-    pypi_base = backends_yaml.get("pypi_base", "")
-    mirror = backends_yaml.get("mirror", "https://mirrors.aliyun.com/pypi/simple")
+    pypi_base = configs.get("pypi_base", "")
+    mirror = configs.get("mirror", "https://mirrors.aliyun.com/pypi/simple")
 
     args = {
         "BASE_IMAGE": base_image_override
@@ -161,11 +155,11 @@ def resolve_build_args(
         "PYTHON_VERSION": backend_info.get("python", "3.12"),
         "FLAGOS_PYPI": pypi_base.format(vendor=vendor) if pypi_base else "",
         "EXTRA_PYPI": extra_pypi_override or mirror,
-        "EXTRAS_GROUP": flaggems_key,
+        "EXTRAS_GROUP": backend_info.get("extras", ""),
         "INCLUDE_TESTS": include_tests_override or "true",
     }
 
-    # Optional triton-specific post-install packages from backends.yaml
+    # Optional triton-specific post-install packages from configs.yaml.
     # These are only needed when using triton (not flagtree).
     triton_post = backend_info.get("triton_post_install", [])
     if isinstance(triton_post, list) and triton_post:
@@ -196,7 +190,7 @@ def main():
     parser.add_argument(
         "--flaggems-dir",
         required=True,
-        help="Path to FlagGems source tree (used as build context and for backends.yaml)",
+        help="Path to FlagGems source tree (used as the docker build context)",
     )
     parser.add_argument("--base-image", help="Override base image")
     parser.add_argument("--extra-pypi", help="Override extra PyPI mirror URL")
@@ -222,30 +216,25 @@ def main():
     flaggems_dir = Path(args.flaggems_dir).resolve()
 
     configs_path = repo_root / "configs.yaml"
-    backends_path = flaggems_dir / "src" / "flag_gems" / "backends.yaml"
     containerfile = script_dir / "Containerfile"
 
     if not configs_path.exists():
         sys.exit(f"Error: {configs_path} not found")
-    if not backends_path.exists():
-        sys.exit(f"Error: {backends_path} not found")
     if not containerfile.exists():
         sys.exit(f"Error: {containerfile} not found")
 
     configs = load_yaml(configs_path)
-    backends_yaml = load_yaml(backends_path)
 
     # TODO: Remove FLAGGEMS_VERSION once we switch to wheel-based install.
     flaggems_version = get_flaggems_version(flaggems_dir)
 
-    flaggems_key, vendor, backend = resolve_backend(args.backend, configs)
+    backend_info, vendor, backend = resolve_backend(args.backend, configs)
 
     build_args = resolve_build_args(
-        flaggems_key,
+        backend_info,
         vendor,
         backend,
         configs,
-        backends_yaml,
         repo_root,
         base_image_override=args.base_image,
         extra_pypi_override=args.extra_pypi,


### PR DESCRIPTION
## What

Migrate the full per-backend dependency spec from FlagGems's `src/flag_gems/backends.yaml` into build-infra's `configs.yaml`, making build-infra the single source of truth. build-infra no longer reads FlagGems's `backends.yaml` at all.

This continues the consolidation trend of #74/#76/#77/#79.

## Changes

- **`configs.yaml`**: `vendors.<v>.backends` changes from a list of names to a mapping `backend -> spec`. Each entry carries `python`, `cmake_backend`, `triton`, `flagtree`, `triton_post_install`, `deps`, bare-metal `env`/`env_source`, and an explicit `extras` field (the FlagGems pyproject extra name). Top-level `pypi_base`/`mirror` added. Vendor-level container `env` preserved (distinguished from backend-level bare-metal `env` by nesting).
- **`runtime/build.py`**: reads all backend spec from `configs.yaml`; drops the `backends.yaml` read and its `--flaggems-dir` dependency for config (still used as the docker build context + `git describe` version). `EXTRAS_GROUP` now comes from the explicit `extras` field. `resolve_backend` keeps #78's contract: dotted `vendor-backend` + single-vendor shorthand only.
- **`runtime/Containerfile`**: comment no longer references `backends.yaml`. Install flow unchanged (`uv pip install ".[$EXTRAS_GROUP]"`).

All **16** backends migrated (including `mthreads-musa520` and `spacemit`, which have no base image yet — kept as source of truth, marked in comments).

## Out of scope

FlagGems-side consumers (`_setup.py`, `setup.sh`, `pyproject.toml`, `tools/`) still own their `backends.yaml`; reconciling them is a follow-up. The `extras` naming stays owned by FlagGems and is passed through opaquely.

## Verification

- Field-level diff of merged `configs.yaml` vs original `backends.yaml`: 16/16 entries, all fields identical, no info lost.
- `build.py --dry-run` regression across dotted inputs (`nvidia-cuda12.8`, `ascend-cann9.0.0` incl. `TRITON_POST_INSTALL`, `metax`, `mthreads-musa4.3.6`) — build-args correct.
- Confirmed `build.py` no longer opens FlagGems's `backends.yaml` (works with an empty `--flaggems-dir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
