### PR TITLE
chore: add flagtree-builder/ with low-glibc FlagTree wheel builder

### DIFF
--- a/flagtree-builder/README.md
+++ b/flagtree-builder/README.md
@@ -1,0 +1,46 @@
+# flagtree-builder
+
+Containerfiles that build **FlagTree wheels** on an old-glibc base so the
+resulting `libtriton.so` loads on nodes with older glibc (e.g. the h100 CI
+runner running Ubuntu 22.04 / glibc 2.35).
+
+Files are named `{vendor}-{backend}`, one per target:
+
+| File         | Target             | Base                        |
+|--------------|--------------------|-----------------------------|
+| `nvidia-cuda`| FlagTree for NVIDIA| Ubuntu 22.04 (glibc 2.35)   |
+
+## Build
+
+Run from inside this folder:
+
+```sh
+podman build -t flagtree-build:0.6.0 -f nvidia-cuda .
+
+# behind a proxy:
+podman build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy \
+             -t flagtree-build:0.6.0 -f nvidia-cuda .
+```
+
+Useful build args (see the Containerfile for the full list):
+
+- `FLAGTREE_REF` — git branch/tag to build (default `0.6.0`).
+- `FLAGTREE_WHEEL_VERSION` — wheel version string (default `0.6.0`). A clean
+  version (no `+git<sha>`) also needs `FLAGTREE_PYPI_KEY`; otherwise the wheel
+  is versioned `<ver>.git<sha>`.
+- `FLAGTREE_PYPI_KEY` — unlocks the clean version (md5-gated in FlagTree's
+  `setup.py`).
+
+The build runs in `Release` mode, which strips `libtriton.so` (~840 MB → ~150 MB)
+and drops asserts. A smoke test installs the freshly built wheel and imports
+`triton`, failing the build if the wheel is broken.
+
+## Extract the wheel
+
+The wheel is written to `/wheels` in the image:
+
+```sh
+id=$(podman create flagtree-build:0.6.0)
+podman cp $id:/wheels ./wheels
+podman rm $id
+```

--- a/flagtree-builder/nvidia-cuda
+++ b/flagtree-builder/nvidia-cuda
@@ -1,0 +1,73 @@
+# Build a FlagTree 0.6.0 wheel on Ubuntu 22.04 (glibc 2.35) so the resulting
+# libtriton.so links against an older glibc and loads on older-glibc nodes
+# (e.g. the h100 CI runner, ubuntu 22.04 / glibc 2.35). Output wheel -> /wheels.
+#
+# Build:
+#   podman build -t flagtree-build:0.6.0 -f nvidia-cuda .
+#   # behind a proxy:
+#   podman build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy \
+#                -t flagtree-build:0.6.0 -f nvidia-cuda .
+#
+# Extract the wheel:
+#   id=$(podman create flagtree-build:0.6.0); podman cp $id:/wheels ./wheels; podman rm $id
+FROM ubuntu:22.04
+
+# Proxy is only consumed during build (predefined ARG, not persisted in the image).
+ARG http_proxy=
+ARG https_proxy=
+ARG FLAGTREE_REF=0.6.0
+# Clean version + lean build, matching FlagTree's official nv-delivery CI:
+#  - FLAGTREE_WHEEL_VERSION sets the wheel version; a clean (no +git<sha>) version
+#    also requires the secret FLAGTREE_PYPI_KEY (md5-gated in setup.py). Without the
+#    key you get "<ver>.git<sha>"; with nothing set you get "0.6.0+git<sha>".
+#  - Release build type strips the .so and drops asserts (fixes the ~840 MB
+#    unstripped libtriton.so -> ~150 MB).
+ARG FLAGTREE_WHEEL_VERSION=0.6.0
+ARG FLAGTREE_PYPI_KEY=
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System build deps for the LLVM/Triton native build + Python 3.12 (deadsnakes).
+# gnupg/dirmngr are needed by add-apt-repository to import the PPA key.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common ca-certificates gnupg dirmngr \
+        git wget curl \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        build-essential cmake ninja-build \
+        zlib1g zlib1g-dev libxml2 libxml2-dev nlohmann-json3-dev \
+        libncurses5-dev libncursesw5-dev libgdbm-dev libnss3-dev \
+        libssl-dev libreadline-dev libffi-dev libsqlite3-dev \
+        libdb5.3-dev libbz2-dev libexpat1-dev liblzma-dev \
+        python3.12 python3.12-venv python3.12-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# pip for python3.12 (deadsnakes ships ensurepip via the python3.12-venv package).
+RUN python3.12 -m ensurepip --upgrade \
+    && python3.12 -m pip install --no-cache-dir --upgrade pip wheel setuptools
+
+# Build the FlagTree wheel from source.
+# Unconditionally use the proxy (passed as build-args, applied to every RUN,
+# not persisted in the image). Force HTTP/1.1 for git, and retry the flaky
+# network-heavy steps.
+RUN git config --global http.version HTTP/1.1 \
+    && for i in 1 2 3 4 5 6 7 8; do \
+         git clone --branch "${FLAGTREE_REF}" --depth 1 \
+           https://github.com/flagos-ai/flagtree /opt/flagtree && break; \
+         echo ">>> flagtree clone attempt $i failed, retrying in 5s..."; \
+         rm -rf /opt/flagtree; sleep 5; \
+       done \
+    && test -d /opt/flagtree/.git \
+    && cd /opt/flagtree \
+    && python3.12 -m pip install --no-cache-dir -r python/requirements.txt \
+    && export TRITON_APPEND_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release" \
+    && export FLAGTREE_WHEEL_VERSION="${FLAGTREE_WHEEL_VERSION}" \
+    && export FLAGTREE_PYPI_KEY="${FLAGTREE_PYPI_KEY}" \
+    && for i in 1 2 3 4 5; do \
+         python3.12 -m pip wheel . --no-build-isolation -w /wheels -v && break; \
+         echo ">>> wheel build attempt $i failed, retrying in 10s..."; sleep 10; \
+       done \
+    && ls -la /wheels/*.whl
+
+# Smoke test: install the freshly built wheel and import it (fails the build if broken).
+RUN python3.12 -m pip install --no-cache-dir /wheels/*.whl \
+    && python3.12 -c "import triton; print('OK triton', triton.__version__)"


### PR DESCRIPTION
## What

Add `flagtree-builder/` — a home for **FlagTree wheel builders** that run on an
old-glibc base so the resulting `libtriton.so` loads on nodes with older glibc
(e.g. the h100 CI runner on Ubuntu 22.04 / glibc 2.35).

This file previously sat untracked at the repo root. This PR moves it into the
folder, renames it to `nvidia-cuda` (matching the `base/` `{vendor}-{backend}`
naming), and documents it.

## Contents

- `flagtree-builder/nvidia-cuda` — builds FlagTree 0.6.0 on Ubuntu 22.04. Runs a
  `Release` build (strips `libtriton.so`, ~840 MB → ~150 MB) and smoke-tests the
  wheel by importing `triton`.
- `flagtree-builder/README.md` — build/extract steps, build args
  (`FLAGTREE_REF` / `FLAGTREE_WHEEL_VERSION` / `FLAGTREE_PYPI_KEY`), naming.

## Notes

Standalone: the builder clones FlagTree from git and has no build-context
dependency, so `podman build -f nvidia-cuda .` works from inside the folder.
Not wired into any CI here — run manually to produce a wheel.
