### PR TITLE
refactor: split backend env into base/runtime flavors, flatten vendor map

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -15,11 +15,8 @@
 # The PyPI index URL is auto-generated: pypi_base.format(vendor=<vendor>).
 # Override per-backend with an explicit "index:" field if needed.
 #
-# Vendor entry:
-#   "env:"      — environment variables set in the *runtime container*.
-#                 Container-specific; not used for bare-metal/VM installs.
-#   "backends:" — mapping of backend name → backend spec (see below).
-#                 The backend name (e.g. "cuda12.8") matches base/{vendor}-{backend}.
+# Each vendor maps directly to its backends (backend name → backend spec).
+# The backend name (e.g. "cuda12.8") matches base/{vendor}-{backend}.
 #
 # Backend spec fields:
 #   "extras:"          — FlagGems pyproject extra name, passed verbatim as the
@@ -30,10 +27,10 @@
 #   "triton:"          — vendor Triton package(s).
 #   "flagtree:"        — FlagTree package (preferred compiler).
 #   "triton_post_install:" — extra packages installed after Triton (COMPILER=triton).
-#   "env:"             — environment for *bare-metal/VM* installs. Same field name
-#                        as the vendor-level container env but a different concept;
-#                        distinguished by nesting level.
-#   "env_source:"      — vendor scripts to source on bare-metal installs.
+#   "env:"             — environment split by which image consumes it:
+#                          base:        vars baked into flagos-base-{vendor}-{backend}
+#                          base_source: scripts sourced when building the base image
+#                          runtime:     vars baked into flagos-runtime-{vendor}-{backend}
 #   "deps:"            — Python dependencies (torch stack, etc.).
 
 base_image_prefix: "flagos-base"
@@ -43,253 +40,258 @@ mirror: "https://mirrors.aliyun.com/pypi/simple"
 
 vendors:
   nvidia:
-    env:
-      NVIDIA_VISIBLE_DEVICES: "all"
-      NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
-    backends:
-      cuda12.8:
-        extras: nvidia-cuda128
-        python: "3.12"
-        cmake_backend: CUDA
-        triton: triton==3.6.0
-        flagtree: flagtree==0.6.0
-        env:
+    cuda12.8:
+      extras: nvidia-cuda128
+      python: "3.12"
+      cmake_backend: CUDA
+      triton: triton==3.6.0
+      flagtree: flagtree==0.6.0
+      env:
+        base:
           PATH: /usr/local/cuda/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
-        deps:
-          - torch==2.10.0+cu128
-          - torchaudio==2.10.0+cu128
-          - torchvision==0.25.0+cu128
+        runtime:
+          NVIDIA_VISIBLE_DEVICES: "all"
+          NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
+      deps:
+        - torch==2.10.0+cu128
+        - torchaudio==2.10.0+cu128
+        - torchvision==0.25.0+cu128
 
-      cuda13.3:
-        extras: nvidia-cuda133
-        python: "3.12"
-        cmake_backend: CUDA
-        triton: triton==3.6.0
-        flagtree: flagtree==0.6.0
-        env:
+    cuda13.3:
+      extras: nvidia-cuda133
+      python: "3.12"
+      cmake_backend: CUDA
+      triton: triton==3.6.0
+      flagtree: flagtree==0.6.0
+      env:
+        base:
           PATH: /usr/local/cuda/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
-        deps:
-          - torch==2.11.0+cu130
-          - torchaudio==2.11.0+cu130
-          - torchvision==0.26.0+cu130
+        runtime:
+          NVIDIA_VISIBLE_DEVICES: "all"
+          NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
+      deps:
+        - torch==2.11.0+cu130
+        - torchaudio==2.11.0+cu130
+        - torchvision==0.26.0+cu130
 
   ascend:
-    backends:
-      cann8.5.0:
-        extras: ascend-cann850
-        python: "3.11"
-        cmake_backend: NPU
-        triton: triton-ascend==3.2.0
-        flagtree: flagtree==0.6.0+ascend3.2
-        env_source:
+    cann8.5.0:
+      extras: ascend-cann850
+      python: "3.11"
+      cmake_backend: NPU
+      triton: triton-ascend==3.2.0
+      flagtree: flagtree==0.6.0+ascend3.2
+      env:
+        base_source:
           - /usr/local/Ascend/cann/set_env.sh
-        deps:
-          - torch==2.9.0+cpu
-          - torch-npu==2.9.0
+      deps:
+        - torch==2.9.0+cpu
+        - torch-npu==2.9.0
 
-      cann9.0.0:
-        extras: ascend-cann900
-        python: "3.11"
-        cmake_backend: NPU
-        triton: triton==3.5.0
-        flagtree: flagtree==0.6.0+ascend3.5
-        env_source:
+    cann9.0.0:
+      extras: ascend-cann900
+      python: "3.11"
+      cmake_backend: NPU
+      triton: triton==3.5.0
+      flagtree: flagtree==0.6.0+ascend3.5
+      triton_post_install:
+        - triton_ascend==3.2.1
+      env:
+        base_source:
           - /usr/local/Ascend/cann/set_env.sh
-        triton_post_install:
-          - triton_ascend==3.2.1
-        deps:
-          - torch==2.10.0+cpu
-          - torch-npu==2.10.0
+      deps:
+        - torch==2.10.0+cpu
+        - torch-npu==2.10.0
 
   cambricon:
-    backends:
-      neuware4.4.3:
-        extras: cambricon
-        python: "3.10"
-        triton: triton==3.2.0+mlu1.7.2
-        env:
+    neuware4.4.3:
+      extras: cambricon
+      python: "3.10"
+      triton: triton==3.2.0+mlu1.7.2
+      env:
+        base:
           PATH: /usr/local/neuware/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/neuware/lib64:$LD_LIBRARY_PATH
-        deps:
-          - cambricon_dali==0.13.0
-          - torch==2.7.1+cpu
-          - torch-mlu==1.29.2+torch2.7.1
-          - torch-mlu-ops==1.8.0+torch2.7.1
+      deps:
+        - cambricon_dali==0.13.0
+        - torch==2.7.1+cpu
+        - torch-mlu==1.29.2+torch2.7.1
+        - torch-mlu-ops==1.8.0+torch2.7.1
 
   enflame:
-    backends:
-      tops1.9.10:
-        extras: enflame
-        python: "3.12"
-        cmake_backend: GCU
-        triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
-        flagtree: flagtree==0.6.0+enflame3.6
-        env:
+    tops1.9.10:
+      extras: enflame
+      python: "3.12"
+      cmake_backend: GCU
+      triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
+      flagtree: flagtree==0.6.0+enflame3.6
+      env:
+        base:
           LD_LIBRARY_PATH: /opt/OpenCloudOS/gcc-toolset-14/root/usr/lib64:$LD_LIBRARY_PATH
-        deps:
-          - pyefml==1.9.10
-          - torch==2.10.0+cpu
-          - torchaudio==2.10.0+cpu
-          - torchvision==0.25.0+cpu
-          - torch-gcu==2.10.0+3.7.20260408
-          - flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323
+      deps:
+        - pyefml==1.9.10
+        - torch==2.10.0+cpu
+        - torchaudio==2.10.0+cpu
+        - torchvision==0.25.0+cpu
+        - torch-gcu==2.10.0+3.7.20260408
+        - flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323
 
   hygon:
-    backends:
-      dtk26.04:
-        extras: hygon
-        python: "3.10"
-        triton: triton==3.3.0+das.opt1.dtk2604.torch290
-        flagtree: flagtree==0.5.1+hcu3.1
-        env_source:
+    dtk26.04:
+      extras: hygon
+      python: "3.10"
+      triton: triton==3.3.0+das.opt1.dtk2604.torch290
+      flagtree: flagtree==0.5.1+hcu3.1
+      env:
+        base_source:
           - /opt/dtk-26.04/env.sh
-        deps:
-          - torch==2.9.0+das.opt1.dtk2604
+      deps:
+        - torch==2.9.0+das.opt1.dtk2604
 
   iluvatar:
-    backends:
-      corex4.4.0:
-        extras: iluvatar
-        python: "3.10"
-        cmake_backend: IX
-        triton: triton==3.1.0+corex.4.4.0
-        # flagtree==0.5.1+iluvatar3.1 — plugin loading bug in venv, disabled for now
-        env:
+    corex4.4.0:
+      extras: iluvatar
+      python: "3.10"
+      cmake_backend: IX
+      triton: triton==3.1.0+corex.4.4.0
+      # flagtree==0.5.1+iluvatar3.1 — plugin loading bug in venv, disabled for now
+      env:
+        base:
           COREX_ROOT: /usr/local/corex
           PATH: $COREX_ROOT/bin:$PATH
           LD_LIBRARY_PATH: $COREX_ROOT/lib:$LD_LIBRARY_PATH
-        deps:
-          - torch==2.7.1+corex.4.4.0
-          - torchaudio==2.7.1+corex.4.4.0
-          - torchvision==0.22.1+corex.4.4.0
+      deps:
+        - torch==2.7.1+corex.4.4.0
+        - torchaudio==2.7.1+corex.4.4.0
+        - torchvision==0.22.1+corex.4.4.0
 
   kunlunxin:
-    backends:
-      xre5.29.0:
-        extras: kunlunxin
-        python: "3.10"
-        triton: triton==3.0.0+a48aedef
-        flagtree: flagtree==0.5.1+xpu3.0
-        env:
+    xre5.29.0:
+      extras: kunlunxin
+      python: "3.10"
+      triton: triton==3.0.0+a48aedef
+      flagtree: flagtree==0.5.1+xpu3.0
+      env:
+        base:
           LD_LIBRARY_PATH: /xcudart/lib:/usr/local/cuda/lib64
-        deps:
-          - apex==0.1
-          - benchflow==1.0.0
-          - colorama==0.4.6
-          - flash_attn==2.4.2+7e2dd4d
-          - hydrax==0.1.0
-          - hyperparameter==0.5.6
-          - psutil==6.1.0
-          - regex==2026.4.4
-          - torch==2.9.0+cu129
-          - torchaudio==2.9.0+cu129
-          - torchvision==0.24.0+cu129
-          - torch_plugin==0.1.0
-          - torch_xray==2.0.4
-          - xformers==0.0.29+1e7a8ec.d20260114
-          - xmlir==1.0.0.1
+      deps:
+        - apex==0.1
+        - benchflow==1.0.0
+        - colorama==0.4.6
+        - flash_attn==2.4.2+7e2dd4d
+        - hydrax==0.1.0
+        - hyperparameter==0.5.6
+        - psutil==6.1.0
+        - regex==2026.4.4
+        - torch==2.9.0+cu129
+        - torchaudio==2.9.0+cu129
+        - torchvision==0.24.0+cu129
+        - torch_plugin==0.1.0
+        - torch_xray==2.0.4
+        - xformers==0.0.29+1e7a8ec.d20260114
+        - xmlir==1.0.0.1
 
   metax:
-    backends:
-      maca3.7.2.1:
-        extras: metax
-        python: "3.12"
-        triton: triton==3.0.0+metax3.7.2.0
-        flagtree: flagtree==3.1.0+metax3.7.2.0
-        env:
+    maca3.7.2.1:
+      extras: metax
+      python: "3.12"
+      triton: triton==3.0.0+metax3.7.2.0
+      flagtree: flagtree==3.1.0+metax3.7.2.0
+      env:
+        base:
           MACA_PATH: /opt/maca
           LD_LIBRARY_PATH: $MACA_PATH/lib:$MACA_PATH/mxgpu_llvm/lib:$LD_LIBRARY_PATH
-        deps:
-          - torch==2.8.0+metax3.7.2.0
-          - torchaudio==2.4.1+metax3.7.2.0
-          - torchvision==0.15.1+metax3.7.2.0
-          - flash_attn==2.6.3+metax3.7.2.0torch2.8
+      deps:
+        - torch==2.8.0+metax3.7.2.0
+        - torchaudio==2.4.1+metax3.7.2.0
+        - torchvision==0.15.1+metax3.7.2.0
+        - flash_attn==2.6.3+metax3.7.2.0torch2.8
 
   mthreads:
-    env:
-      MTHREADS_VISIBLE_DEVICES: "all"
-      LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
-    backends:
-      musa4.3.6:
-        extras: mthreads-musa436
-        python: "3.10"
-        cmake_backend: MUSA
-        triton: triton==3.6.0+git89458660
-        flagtree: flagtree==0.6.0+mthreads3.6
-        env:
+    musa4.3.6:
+      extras: mthreads-musa436
+      python: "3.10"
+      cmake_backend: MUSA
+      triton: triton==3.6.0+git89458660
+      flagtree: flagtree==0.6.0+mthreads3.6
+      env:
+        base:
           MUSA_HOME: /usr/local/musa
           PATH: $MUSA_HOME/bin:$PATH
           LD_LIBRARY_PATH: $VIRTUAL_ENV/lib:$MUSA_HOME/lib:$LD_LIBRARY_PATH
-        deps:
-          - torch==2.9.0+musa.4.3.6
-          - torch_musa==2.9.0
-          - mkl==2024.0.0
+        runtime:
+          MTHREADS_VISIBLE_DEVICES: "all"
+          LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
+      deps:
+        - torch==2.9.0+musa.4.3.6
+        - torch_musa==2.9.0
+        - mkl==2024.0.0
 
-      # No base image yet — dependency spec kept as source of truth.
-      musa5.2.0:
-        extras: mthreads-musa520
-        python: "3.10"
-        cmake_backend: MUSA
-        triton: triton==3.6.0
-        flagtree: flagtree==0.6.0+mthreads3.6
-        env:
+    # No base image yet — dependency spec kept as source of truth.
+    musa5.2.0:
+      extras: mthreads-musa520
+      python: "3.10"
+      cmake_backend: MUSA
+      triton: triton==3.6.0
+      flagtree: flagtree==0.6.0+mthreads3.6
+      env:
+        base:
           MUSA_HOME: /usr/local/musa
           PATH: $MUSA_HOME/bin:$PATH
           LD_LIBRARY_PATH: $VIRTUAL_ENV/lib:$MUSA_HOME/lib:$LD_LIBRARY_PATH
-        deps:
-          - torch==2.9.0+musa5.2.0
-          - torch_musa==2.9.1
-          - mkl==2024.0.0
+        runtime:
+          MTHREADS_VISIBLE_DEVICES: "all"
+          LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
+      deps:
+        - torch==2.9.0+musa5.2.0
+        - torch_musa==2.9.1
+        - mkl==2024.0.0
 
   # No base image yet — dependency spec kept as source of truth.
   spacemit:
-    backends:
-      spacemit:
-        extras: spacemit
-        python: "3.12"
-        triton: triton==3.6.0+spacemit.a5
-        deps:
-          - torch==2.8.0+spacemit.0
+    spacemit:
+      extras: spacemit
+      python: "3.12"
+      triton: triton==3.6.0+spacemit.a5
+      deps:
+        - torch==2.8.0+spacemit.0
 
   sunrise:
-    backends:
-      tangrt1.2.0:
-        extras: sunrise
-        python: "3.10"
-        triton: triton==3.4.0.6+gite4f6d6e4
-        # flagtree==0.4.0+sunrise3.4 — requires GLIBC_2.39, unavailable on current system
-        env:
+    tangrt1.2.0:
+      extras: sunrise
+      python: "3.10"
+      triton: triton==3.4.0.6+gite4f6d6e4
+      # flagtree==0.4.0+sunrise3.4 — requires GLIBC_2.39, unavailable on current system
+      env:
+        base:
           LD_LIBRARY_PATH: /usr/local/tangrt/targets/linux-x86_64/lib:$LD_LIBRARY_PATH
-        deps:
-          - torch==2.11.0+cpu
-          - torchaudio==2.11.0+cpu
-          - torchvision==0.26.0+cpu
-          - torch-ptpu==0.2.3+torch2.11
+      deps:
+        - torch==2.11.0+cpu
+        - torchaudio==2.11.0+cpu
+        - torchvision==0.26.0+cpu
+        - torch-ptpu==0.2.3+torch2.11
 
   thead:
-    backends:
-      ppu2.0.0:
-        extras: thead
-        python: "3.12"
-        triton: triton==3.5.0+ppu2.0.0.oe
-        env_source:
+    ppu2.0.0:
+      extras: thead
+      python: "3.12"
+      triton: triton==3.5.0+ppu2.0.0.oe
+      env:
+        base_source:
           - /usr/local/PPU_SDK/envsetup.sh
-        deps:
-          - torch==2.9.0+ppu2.0.0.oe
+      deps:
+        - torch==2.9.0+ppu2.0.0.oe
 
   tsingmicro:
-    env:
-      USE_TORCH_XLA: "0"
-      TORCH_COMPILE_DISABLE: "1"
-    backends:
-      tsm260604:
-        extras: tsingmicro
-        python: "3.10"
-        triton: triton==3.3.0+gitfe2a28fa
-        flagtree: flagtree==0.5.0.post20260612+git705a4064
-        env:
+    tsm260604:
+      extras: tsingmicro
+      python: "3.10"
+      triton: triton==3.3.0+gitfe2a28fa
+      flagtree: flagtree==0.5.0.post20260612+git705a4064
+      env:
+        base:
           TX8_DEPS_ROOT: /opt/tx8_deps
           LLVM_SYSPATH: /opt/llvm
           LLVM_BINARY_DIR: ${LLVM_SYSPATH}/bin
@@ -297,9 +299,12 @@ vendors:
           LD_LIBRARY_PATH: /usr/local/kuiper/lib:/usr/local/kuiper/tsm8-profiler/lib:${TX8_DEPS_ROOT}/lib:${LD_LIBRARY_PATH}
           USE_TORCH_XLA: "0"
           TORCH_COMPILE_DISABLE: "1"
-        deps:
-          - torch==2.7.0+cpu
-          - torchvision==0.22.0+cpu
-          - torchaudio==2.7.0+cpu
-          - torch_txda==0.1.0+20260615.37ba6bbd
-          - txops==0.1.0+20260508.60287151
+        runtime:
+          USE_TORCH_XLA: "0"
+          TORCH_COMPILE_DISABLE: "1"
+      deps:
+        - torch==2.7.0+cpu
+        - torchvision==0.22.0+cpu
+        - torchaudio==2.7.0+cpu
+        - torch_txda==0.1.0+20260615.37ba6bbd
+        - txops==0.1.0+20260508.60287151

--- a/runtime/build.py
+++ b/runtime/build.py
@@ -65,7 +65,7 @@ def get_flaggems_version(flaggems_dir: Path) -> str:
 def resolve_backend(backend_arg: str, configs: dict):
     """Resolve user input to (backend_info, vendor, backend).
 
-    configs.yaml maps vendor → {env: {...}, backends: {backend: {spec}}}.
+    configs.yaml maps vendor → {backend: {spec}}.
 
     Accepts:
       - "nvidia-cuda12.8" (vendor-backend)
@@ -78,8 +78,7 @@ def resolve_backend(backend_arg: str, configs: dict):
     """
     vendors = configs.get("vendors", {})
 
-    for vendor, info in vendors.items():
-        backends = info.get("backends", {})
+    for vendor, backends in vendors.items():
         for backend, backend_info in backends.items():
             if backend_arg == f"{vendor}-{backend}":
                 return backend_info, vendor, backend
@@ -88,7 +87,7 @@ def resolve_backend(backend_arg: str, configs: dict):
 
     # Vendor name with multiple backends
     if backend_arg in vendors:
-        backends = vendors[backend_arg].get("backends", {})
+        backends = vendors[backend_arg]
         if len(backends) > 1:
             names = [f"{backend_arg}-{b}" for b in backends]
             sys.exit(


### PR DESCRIPTION
## What

Make the two environment "flavors" in `configs.yaml` explicit, and flatten the vendor map now that it holds nothing but backends.

## Changes

### Explicit env flavors
Each backend's `env` is now split by which image consumes it:

```yaml
env:
  base:               # baked into flagos-base-{vendor}-{backend}
    PATH: /usr/local/cuda/bin:$PATH
    LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
  base_source:        # scripts sourced when building the base image (was env_source)
    - /usr/local/Ascend/cann/set_env.sh
  runtime:            # baked into flagos-runtime-{vendor}-{backend} (was vendor-level env)
    NVIDIA_VISIBLE_DEVICES: "all"
```

Previously the container/runtime env sat at vendor level and the bare-metal/SDK env sat at backend level under the same field name `env` — ambiguous. Now both live under each backend's `env` block, labelled by target image. Runtime env is duplicated across a vendor's backends (e.g. both nvidia backends carry `NVIDIA_*`).

### Flatten vendor map
With the vendor-level `env` gone, a vendor holds only its backends, so the `backends:` wrapper was pure indentation. Vendors now map directly to backend-name → spec:

```yaml
vendors:
  nvidia:
    cuda12.8: { ... }
    cuda13.3: { ... }
```

`runtime/build.py` `resolve_backend` updated to iterate the flattened shape.

## Notes

- No functional change to build args — `build.py` does not consume `env` (base/runtime env wiring into the Containerfiles is future work).
- `tsingmicro` intentionally carries `USE_TORCH_XLA`/`TORCH_COMPILE_DISABLE` in both `base` and `runtime` (needed at build and run).

## Verification

- YAML loads; 13 vendors / 16 backends; every backend has `extras`/`python`.
- `build.py` dry-run regression: dotted names (`nvidia-cuda12.8`, `ascend-cann9.0.0`, `mthreads-musa4.3.6`), single-vendor shorthand (`metax`), and the multi-backend error path all correct.
