### PR TITLE
feat(base): add MooreThreads MUSA 5.2.0 base image

### DIFF
--- a/base/mthreads-musa5.2.0
+++ b/base/mthreads-musa5.2.0
@@ -1,0 +1,52 @@
+# ============================================================
+# Base image for MooreThreads MUSA 5.2.0 on Ubuntu 22.04
+# ============================================================
+FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.0"
+LABEL org.opencontainers.image.revision="0"
+
+# ── Build arguments ────────────────────────────────────────────
+ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/mthreads
+ENV TOOKIT_PKG=musa_toolkits_5.2.0.tar.gz
+ENV MCCL_PKG=mccl.2.4.0.PH1.tar.gz
+ENV MUDNN_PKG=mudnn.3.4.0.PH1.tar.gz
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates \
+        gcc g++ build-essential cmake \
+        libelf1 libnuma-dev libgfortran5 libpython3-dev \
+        libopenmpi-dev openmpi-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Toolkit
+RUN curl -o /toolkits.tar.gz ${FILE_STORE}/${TOOKIT_PKG} \
+    && tar xzvf /toolkits.tar.gz -C /tmp \
+    && cd /tmp/musa_toolkits_install \
+    && ./install.sh \
+    && rm -fr /tmp/* \
+    && rm /toolkits.tar.gz
+
+ENV MUSA_HOME=/usr/local/musa
+ENV PATH="${MUSA_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${MUSA_HOME}/lib:${LD_LIBRARY_PATH}"
+
+# Install MCCL
+RUN curl -o /mccl.tar.gz ${FILE_STORE}/${MCCL_PKG} \
+  && tar xzf /mccl.tar.gz -C /tmp \
+  && cd /tmp/mccl \
+  && ./install.sh \
+  && rm -fr /tmp/* \
+  && rm /mccl.tar.gz
+
+# Install MuDNN
+RUN curl -o /mudnn.tar.gz ${FILE_STORE}/${MUDNN_PKG} \
+  && tar xzvf /mudnn.tar.gz -C /tmp \
+  && cd /tmp/mudnn \
+  && ./install_mudnn.sh \
+  && rm -fr /tmp/* \
+  && rm /mudnn.tar.gz


### PR DESCRIPTION
## What

Add `base/mthreads-musa5.2.0`, the base image for the `mthreads-musa520` backend that was migrated into `configs.yaml` (#80) but had no base image yet.

## Details

- Mirrors the `base/mthreads-musa4.3.6` template on `ubuntu:22.04`.
- Installs the MUSA **5.2.0** toolkit + **mccl 2.4.0** + **mudnn 3.4.0** (same install scripts as 4.3.6).
- `revision` starts at `0` for the fresh image → `flagos-base-mthreads-musa5.2.0:2.1.0-0`.

## Verification

- All three package URLs return HTTP 200 on `flagos-filestore/mthreads/`:
  `musa_toolkits_5.2.0.tar.gz`, `mccl.2.4.0.PH1.tar.gz`, `mudnn.3.4.0.PH1.tar.gz`.
- `runtime/build.py mthreads-musa5.2.0 --dry-run` now resolves the proper base image tag (previously fell back to `:latest`).

Follow-up: `spacemit` remains the last configs.yaml backend without a base image.
