### PR TITLE
refactor(configs): reconcile env.base/runtime with base images

### DIFF
--- a/base/ascend-cann8.5.0
+++ b/base/ascend-cann8.5.0
@@ -46,4 +46,4 @@ RUN curl -o /ops.run ${FILE_STORE}/ascend/${OPS_PACKAGE} \
 
 ENV ASCEND_HOME=/usr/local/Ascend/ascend-toolkit/latest
 ENV PATH="${ASCEND_HOME}/bin:${ASCEND_HOME}/compiler/ccec_compiler/bin:${PATH}"
-ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEND_HOME}/lib64/plugin/opskernel:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEND_HOME}/lib64/plugin/opskernel"

--- a/base/ascend-cann9.0.0
+++ b/base/ascend-cann9.0.0
@@ -53,4 +53,4 @@ RUN bash -c "source /usr/local/Ascend/cann/set_env.sh && \
 
 ENV ASCEND_HOME=/usr/local/Ascend/ascend-toolkit/latest
 ENV PATH="${ASCEND_HOME}/bin:${ASCEND_HOME}/compiler/ccec_compiler/bin:${PATH}"
-ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEND_HOME}/lib64/plugin/opskernel:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEND_HOME}/lib64/plugin/opskernel"

--- a/base/mthreads-musa4.3.6
+++ b/base/mthreads-musa4.3.6
@@ -33,7 +33,7 @@ RUN curl -o /toolkits.tar.gz ${FILE_STORE}/${TOOKIT_PKG} \
 
 ENV MUSA_HOME=/usr/local/musa
 ENV PATH="${MUSA_HOME}/bin:${PATH}"
-ENV LD_LIBRARY_PATH="${MUSA_HOME}/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="${MUSA_HOME}/lib"
 
 # Install MCCL
 RUN curl -o /mccl.tar.gz ${FILE_STORE}/${MCCL_PKG} \

--- a/base/mthreads-musa5.2.0
+++ b/base/mthreads-musa5.2.0
@@ -33,7 +33,7 @@ RUN curl -o /toolkits.tar.gz ${FILE_STORE}/${TOOKIT_PKG} \
 
 ENV MUSA_HOME=/usr/local/musa
 ENV PATH="${MUSA_HOME}/bin:${PATH}"
-ENV LD_LIBRARY_PATH="${MUSA_HOME}/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="${MUSA_HOME}/lib"
 
 # Install MCCL
 RUN curl -o /mccl.tar.gz ${FILE_STORE}/${MCCL_PKG} \

--- a/configs.yaml
+++ b/configs.yaml
@@ -29,8 +29,12 @@
 #   "triton_post_install:" — extra packages installed after Triton (COMPILER=triton).
 #   "env:"             — environment split by which image consumes it:
 #                          base:        vars baked into flagos-base-{vendor}-{backend}
-#                          base_source: scripts sourced when building the base image
+#                          base_source: vendor scripts sourced to set up the base env
 #                          runtime:     vars baked into flagos-runtime-{vendor}-{backend}
+#                        base/runtime must mirror EXACTLY what the image sets — the
+#                        source of truth for per-image env documentation. base_source
+#                        scripts should eventually be expanded into the base image as
+#                        ENV (so users need not source them), but are kept until then.
 #   "deps:"            — Python dependencies (torch stack, etc.).
 
 base_image_prefix: "flagos-base"
@@ -84,6 +88,7 @@ vendors:
       triton: triton-ascend==3.2.0
       flagtree: flagtree==0.6.0+ascend3.2
       env:
+        # TODO: expand set_env.sh into the base image as ENV (avoid sourcing).
         base_source:
           - /usr/local/Ascend/cann/set_env.sh
       deps:
@@ -99,6 +104,7 @@ vendors:
       triton_post_install:
         - triton_ascend==3.2.1
       env:
+        # TODO: expand set_env.sh into the base image as ENV (avoid sourcing).
         base_source:
           - /usr/local/Ascend/cann/set_env.sh
       deps:
@@ -113,7 +119,7 @@ vendors:
       env:
         base:
           PATH: /usr/local/neuware/bin:$PATH
-          LD_LIBRARY_PATH: /usr/local/neuware/lib64:$LD_LIBRARY_PATH
+          LD_LIBRARY_PATH: /usr/local/neuware/lib64
       deps:
         - cambricon_dali==0.13.0
         - torch==2.7.1+cpu
@@ -127,9 +133,6 @@ vendors:
       cmake_backend: GCU
       triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
       flagtree: flagtree==0.6.0+enflame3.6
-      env:
-        base:
-          LD_LIBRARY_PATH: /opt/OpenCloudOS/gcc-toolset-14/root/usr/lib64:$LD_LIBRARY_PATH
       deps:
         - pyefml==1.9.10
         - torch==2.10.0+cpu
@@ -145,6 +148,7 @@ vendors:
       triton: triton==3.3.0+das.opt1.dtk2604.torch290
       flagtree: flagtree==0.5.1+hcu3.1
       env:
+        # TODO: expand env.sh into the base image as ENV (avoid sourcing).
         base_source:
           - /opt/dtk-26.04/env.sh
       deps:
@@ -160,8 +164,8 @@ vendors:
       env:
         base:
           COREX_ROOT: /usr/local/corex
-          PATH: $COREX_ROOT/bin:$PATH
-          LD_LIBRARY_PATH: $COREX_ROOT/lib:$LD_LIBRARY_PATH
+          PATH: /usr/local/corex/bin:$PATH
+          LD_LIBRARY_PATH: /usr/local/corex/lib
       deps:
         - torch==2.7.1+corex.4.4.0
         - torchaudio==2.7.1+corex.4.4.0
@@ -175,7 +179,8 @@ vendors:
       flagtree: flagtree==0.5.1+xpu3.0
       env:
         base:
-          LD_LIBRARY_PATH: /xcudart/lib:/usr/local/cuda/lib64
+          PATH: /usr/local/xpu/bin:$PATH
+          LD_LIBRARY_PATH: /usr/local/xpu/lib:/usr/local/xcudart/lib
       deps:
         - apex==0.1
         - benchflow==1.0.0
@@ -201,8 +206,9 @@ vendors:
       flagtree: flagtree==3.1.0+metax3.7.2.0
       env:
         base:
+          PATH: /opt/maca/mxgpu_llvm/bin:/opt/maca/bin:${PATH}
           MACA_PATH: /opt/maca
-          LD_LIBRARY_PATH: $MACA_PATH/lib:$MACA_PATH/mxgpu_llvm/lib:$LD_LIBRARY_PATH
+          LD_LIBRARY_PATH: /opt/maca/lib:/opt/maca/mxgpu_llvm/lib
       deps:
         - torch==2.8.0+metax3.7.2.0
         - torchaudio==2.4.1+metax3.7.2.0
@@ -219,8 +225,8 @@ vendors:
       env:
         base:
           MUSA_HOME: /usr/local/musa
-          PATH: $MUSA_HOME/bin:$PATH
-          LD_LIBRARY_PATH: $VIRTUAL_ENV/lib:$MUSA_HOME/lib:$LD_LIBRARY_PATH
+          PATH: /usr/local/musa/bin:${PATH}
+          LD_LIBRARY_PATH: /usr/local/musa/lib
         runtime:
           MTHREADS_VISIBLE_DEVICES: "all"
           LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
@@ -239,8 +245,8 @@ vendors:
       env:
         base:
           MUSA_HOME: /usr/local/musa
-          PATH: $MUSA_HOME/bin:$PATH
-          LD_LIBRARY_PATH: $VIRTUAL_ENV/lib:$MUSA_HOME/lib:$LD_LIBRARY_PATH
+          PATH: /usr/local/musa/bin:${PATH}
+          LD_LIBRARY_PATH: /usr/local/musa/lib
         runtime:
           MTHREADS_VISIBLE_DEVICES: "all"
           LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
@@ -266,7 +272,9 @@ vendors:
       # flagtree==0.4.0+sunrise3.4 — requires GLIBC_2.39, unavailable on current system
       env:
         base:
-          LD_LIBRARY_PATH: /usr/local/tangrt/targets/linux-x86_64/lib:$LD_LIBRARY_PATH
+          TANGRT_ROOT: /usr/local/tangrt
+          LIBRARY_PATH: /usr/local/tangrt/targets/linux-x86_64/lib:/usr/local/tangrt/lib/linux-x86_64
+          LD_LIBRARY_PATH: /usr/local/tangrt/targets/linux-x86_64/lib:/usr/local/tangrt/lib/linux-x86_64
       deps:
         - torch==2.11.0+cpu
         - torchaudio==2.11.0+cpu
@@ -279,6 +287,7 @@ vendors:
       python: "3.12"
       triton: triton==3.5.0+ppu2.0.0.oe
       env:
+        # TODO: expand envsetup.sh into the base image as ENV (avoid sourcing).
         base_source:
           - /usr/local/PPU_SDK/envsetup.sh
       deps:
@@ -292,11 +301,13 @@ vendors:
       flagtree: flagtree==0.5.0.post20260612+git705a4064
       env:
         base:
-          TX8_DEPS_ROOT: /opt/tx8_deps
-          LLVM_SYSPATH: /opt/llvm
-          LLVM_BINARY_DIR: ${LLVM_SYSPATH}/bin
-          PYTHONPATH: ${LLVM_SYSPATH}/python_packages/mlir_core
-          LD_LIBRARY_PATH: /usr/local/kuiper/lib:/usr/local/kuiper/tsm8-profiler/lib:${TX8_DEPS_ROOT}/lib:${LD_LIBRARY_PATH}
+          KUIPER_PATH: /usr/local/kuiper
+          TX8_DEPS_ROOT: /usr/local/tx8_deps
+          LLVM_SYSPATH: /usr/local/llvm
+          PATH: /usr/local/kuiper/bin:${PATH}
+          LLVM_BINARY_DIR: /usr/local/llvm/bin
+          PYTHONPATH: /usr/local/llvm/python_packages/mlir_core
+          LD_LIBRARY_PATH: /usr/local/tx8_deps/lib:/usr/local/kuiper/lib:/usr/local/kuiper/tsm8-profiler/lib
           USE_TORCH_XLA: "0"
           TORCH_COMPILE_DISABLE: "1"
         runtime:


### PR DESCRIPTION
## What

Treat `configs.yaml` `env.base` / `env.runtime` as the **source of truth for per-image environment documentation** (used when batch-building/uploading images to tell users what env vars each image sets). So each block must mirror **exactly** what the corresponding `base/`/runtime image bakes. This PR cross-checks every backend against its `base/{vendor}-{backend}` file and reconciles the gaps.

## Changes

**Fix diverged values** (originally lifted verbatim from FlagGems bare-metal `backends.yaml`):
- **kunlunxin** — `LD` was `/xcudart/lib:/usr/local/cuda/lib64`; real image uses `/usr/local/xpu/lib:/usr/local/xcudart/lib` (+ `PATH=/usr/local/xpu/bin`). CUDA libs are intentionally not on `LD` (xcudart shim).
- **tsingmicro** — `/opt/tx8_deps`,`/opt/llvm` → `/usr/local/...`; added `KUIPER_PATH`/`PATH`.
- **metax** — added the `PATH` the base image sets.
- **sunrise** — added `TANGRT_ROOT`/`LIBRARY_PATH`, completed `LD`.

**Drop bare-metal artifact:**
- **enflame** — removed `env.base` (`/opt/OpenCloudOS/gcc-toolset-14/...`); that was a hack for an old-OS runner (outdated gcc), irrelevant on the clean `ubuntu:24.04` base.

**Expand inter-variable references to literals** in `env.base` (docs readability) — musa, tsingmicro, sunrise, iluvatar. The defined vars (`MUSA_HOME`, `KUIPER_PATH`, `TANGRT_ROOT`, `COREX_ROOT`, …) are kept; only cross-references between them are expanded.

**Normalize `LD_LIBRARY_PATH` append:**
- Drop `:${LD_LIBRARY_PATH}` where the base is `FROM` plain ubuntu (no pre-existing `LD`) — in **both** configs and the base containerfiles: mthreads×2, ascend×2, cambricon, iluvatar.
- Keep it for **nvidia** (`FROM nvcr.io/nvidia/cuda` presets `LD`) and for **runtime** env (built on top of base, which does have `LD`).

**base_source** (ascend×2, hygon, thead) kept, each with a `# TODO` to eventually expand the vendor script into the base image as `ENV` (avoid sourcing scripts).

## Notes

- No functional change to build args — `build.py` does not consume `env`. The `LD` append removals are no-ops (base `LD` is empty).
- Fully-redundant-but-correct `env.base` (nvidia/cambricon/iluvatar) kept as documentation / future cross-check fodder.

## Verification

- YAML loads (13 vendors / 16 backends); `env` sub-keys are only `base`/`base_source`/`runtime`.
- `build.py --dry-run` unaffected across representative backends.
- Only `nvidia` base images retain the `LD` append (correct, `FROM nvcr`).
