### PR TITLE
docs: add Simplified Chinese (zh-cn) translation

### DIFF
--- a/docs/content/zh-cn/_index.md
+++ b/docs/content/zh-cn/_index.md
@@ -5,6 +5,13 @@ type: docs
 
 # build-infra
 
-中文文档建设中。请先参阅 [English documentation]({{< relref "/" >}})。
+FlagOS 容器镜像构建基础设施。本仓库定义并构建 **base 镜像**——在操作系统之上叠加
+厂商 SDK 与工具链——FlagOS 的运行时镜像正是构建在这些 base 镜像之上。
 
-(Chinese documentation is under construction — see the English docs for now.)
+- **[概览]({{< relref "overview" >}})** —— 镜像如何分层与命名。
+- **[镜像]({{< relref "images" >}})** —— 支持的厂商/后端目录，以及每个镜像的参考
+  （装了什么、设了哪些环境变量、带哪些依赖）。
+- **[使用]({{< relref "usage" >}})** —— 如何拉取与运行镜像。
+- **[贡献]({{< relref "contribution/onboarding" >}})** —— 如何接入一个新的厂商/后端。
+
+本文档中的所有事实信息都由 `configs.yaml` + `base/` 自动生成，因此不会与源头脱节。

--- a/docs/content/zh-cn/contribution/_index.md
+++ b/docs/content/zh-cn/contribution/_index.md
@@ -1,0 +1,9 @@
+---
+title: 贡献
+weight: 40
+bookCollapseSection: true
+---
+
+# 贡献
+
+- **[厂商接入]({{< relref "onboarding" >}})** —— 添加一个新的厂商/后端 base 镜像。

--- a/docs/content/zh-cn/contribution/onboarding.md
+++ b/docs/content/zh-cn/contribution/onboarding.md
@@ -1,0 +1,88 @@
+---
+title: 厂商接入
+weight: 10
+---
+
+# 厂商接入
+
+如何把一个新的厂商/后端接入 FlagOS base 镜像流水线。你需要提供：
+
+1. 一个 **base containerfile** —— `base/<vendor>-<backend>`
+2. `configs.yaml` 里的一个 **后端条目**（依赖 / 构建设置）
+3. *（可选）* `.github/build-config.yml` 里的一个 **runner 覆盖项**
+
+合并后，由维护者按需构建镜像。不需要每个厂商单独的 JSON 或矩阵脚本——构建矩阵由
+`configs.yaml` + `base/` 推导得到。
+
+## 流水线如何工作
+
+- `base/generate_matrix.py` 读取 `configs.yaml`，为每个存在 `base/<vendor>-<backend>`
+  文件的后端生成一个构建矩阵条目（没有该文件的后端会被跳过）。`runson` 和镜像仓库
+  地址来自 `.github/build-config.yml`。
+- `.github/workflows/trigger.yml` 是**手动**（`workflow_dispatch`）构建：选择一个
+  后端（或 `all`）以及是否推送。
+- 每个条目运行 `python base/build.py <vendor>-<backend> [--push]`，它会从
+  `.github/build-config.yml` 读取镜像仓库地址、从 containerfile 的 OCI label 读取
+  version/revision，并把镜像打标签为
+  `flagos-base-<vendor>-<backend>:<version>-<revision>`。
+
+## 命名
+
+| 项目               | 约定                                                     |
+|--------------------|----------------------------------------------------------|
+| Base containerfile | `base/<vendor>-<backend>`（如 `base/nvidia-cuda12.8`）   |
+| 镜像 tag           | `flagos-base-<vendor>-<backend>:<version>-<revision>`    |
+| configs.yaml 键    | `vendors.<vendor>.<backend>`                             |
+
+`<backend>` 段是 SDK/工具链版本（如 `cuda12.8`、`cann9.0.0`、`neuware4.4.3`），
+且必须在 `base/` 文件名和 `configs.yaml` 键之间保持一致。
+
+## 第 1 步 —— 添加 base containerfile
+
+参照已有的（如 `base/nvidia-cuda12.8`）创建 `base/<vendor>-<backend>`。它**必须**
+包含以下 OCI label：
+
+```dockerfile
+LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="<version>"
+LABEL org.opencontainers.image.revision="<revision>"
+```
+
+- `version` / `revision` 生成镜像 tag `…:<version>-<revision>`。
+- 每次修改已有 containerfile 都要**递增 `revision`**——改了 `base/` 文件却不递增的
+  PR 会被 `check-revision` 检查拦下。新文件从 `revision="0"` 开始。
+- 尽量用 `ENV` 直接烘焙厂商 SDK 环境（不要求用户 source 脚本）。只有当 `FROM` 镜像
+  本身已设置 `LD_LIBRARY_PATH` 时（如 `nvcr.io/nvidia/cuda`）才追加
+  `:${LD_LIBRARY_PATH}`；纯 `ubuntu:*` 基础镜像没有该变量，无需追加。
+
+## 第 2 步 —— 添加 configs.yaml 条目
+
+在 `configs.yaml` 里对应的厂商下添加后端。完整字段说明见该文件的头部注释。最小形态：
+
+```yaml
+vendors:
+  <vendor>:
+    <backend>:
+      extras: <flaggems-pyproject-extra>   # 如 nvidia-cuda128
+      python: "3.12"
+      triton: triton==...
+      # flagtree / cmake_backend / deps / env 按需填写
+```
+
+## 第 3 步 —— runner（仅在需要时）
+
+base 镜像默认在 `ubuntu-latest` 上构建。如果某个后端需要特定架构或硬件（如
+`ascend` 的包是 `aarch64`），在 `.github/build-config.yml` 的 `runners.overrides`
+下添加覆盖项：
+
+```yaml
+runners:
+  overrides:
+    <vendor>-<backend>: [self-hosted, <label>...]
+```
+
+## 第 4 步 —— 开 PR，然后构建
+
+带上新的 `base/` 文件和 `configs.yaml` 条目开一个 PR。合并后，由维护者通过
+**Base Image Build (manual)** 工作流（`workflow_dispatch`）按需构建镜像——选择你的
+后端以及是否推送。base 镜像不会在每次变更时自动构建。

--- a/docs/content/zh-cn/images/_index.md
+++ b/docs/content/zh-cn/images/_index.md
@@ -1,0 +1,14 @@
+---
+title: 镜像
+weight: 20
+bookCollapseSection: true
+---
+
+# 镜像目录
+
+支持的厂商/后端 base 镜像。由 `configs.yaml` + `base/` 生成。
+
+{{< backend-catalog >}}
+
+每个镜像内设置的环境变量与完整依赖列表见
+**[每镜像参考]({{< relref "reference" >}})**。

--- a/docs/content/zh-cn/images/reference.md
+++ b/docs/content/zh-cn/images/reference.md
@@ -1,0 +1,11 @@
+---
+title: 每镜像参考
+weight: 10
+---
+
+# 每镜像参考
+
+每个镜像里有什么：镜像 tag、镜像内设置的环境变量，以及完整依赖列表。由
+`configs.yaml` + `base/` 生成。
+
+{{< image-reference >}}

--- a/docs/content/zh-cn/overview/_index.md
+++ b/docs/content/zh-cn/overview/_index.md
@@ -1,0 +1,26 @@
+---
+title: 概览
+weight: 10
+---
+
+# 概览
+
+## 镜像分层
+
+- **base** —— 在操作系统之上叠加厂商 SDK/工具链 + Python 工具链。由
+  `base/build.py` 从 `base/<vendor>-<backend>` 构建，打标签为
+  `flagos-base-<vendor>-<backend>:<version>-<revision>`（version/revision 取自
+  containerfile 的 OCI label）。
+- **runtime** —— 在 base 镜像之上安装 FlagGems（单独的流程）。
+- **app** —— 应用层（未来）。
+
+## 命名与镜像仓库
+
+所有镜像推送到 `.github/build-config.yml` 里配置的**同一个镜像仓库**，各层之间只在
+服务器上的**路径前缀**不同（base 镜像用 `flagbase`）。
+
+## 事实源
+
+`configs.yaml` 保存每个后端的依赖和镜像环境；每个 `base/<name>` containerfile 承载
+操作系统 + SDK 安装以及 OCI version/revision label。本文档里的目录和每镜像参考都由
+这些文件生成，因此始终与实际构建一致。

--- a/docs/content/zh-cn/usage/_index.md
+++ b/docs/content/zh-cn/usage/_index.md
@@ -1,0 +1,29 @@
+---
+title: 使用
+weight: 30
+---
+
+# 使用镜像
+
+## 拉取
+
+镜像名和 tag 见[目录]({{< relref "images" >}})。例如：
+
+```bash
+docker pull harbor.baai.ac.cn/flagbase/flagos-base-nvidia-cuda12.8:2.1.0-0
+```
+
+## 镜像内预置了什么
+
+每个 base 镜像都用 `ENV` 直接烘焙了厂商 SDK 环境（`PATH`、`LD_LIBRARY_PATH` 以及
+厂商特有的变量）——你无需 source 任何脚本。每个镜像的具体变量见
+[每镜像参考]({{< relref "images/reference" >}})。
+
+## 按需构建
+
+base 镜像是手动构建的，不会每次变更都触发（厂商 SDK 变更不频繁）：
+
+- **CI：** 运行 **Base Image Build (manual)** GitHub Actions 工作流
+  （`workflow_dispatch`）——选择一个后端（或 `all`）以及是否推送。
+- **本地：** `python base/build.py <vendor>-<backend> [--push]`（会从
+  `.github/build-config.yml` 读取镜像仓库地址）。

--- a/docs/i18n/zh-cn.toml
+++ b/docs/i18n/zh-cn.toml
@@ -1,24 +1,22 @@
-# Chinese translations for the docs shortcode headers.
-# Placeholder (English values) until translated — keeps the reserved zh-cn
-# language building cleanly.
+# Chinese translations for the docs shortcode table headers.
 
 [vendor]
-other = "Vendor"
+other = "厂商"
 
 [backend]
-other = "Backend"
+other = "后端"
 
 [image]
-other = "Image"
+other = "镜像"
 
 [base_os]
-other = "Base OS"
+other = "基础系统"
 
 [python]
 other = "Python"
 
 [compiler]
-other = "Compiler"
+other = "编译器"
 
 [torch]
 other = "Torch"
@@ -27,10 +25,10 @@ other = "Torch"
 other = "Extras"
 
 [env_var]
-other = "Variable"
+other = "变量"
 
 [env_value]
-other = "Value"
+other = "值"
 
 [dependency]
-other = "Dependency"
+other = "依赖"


### PR DESCRIPTION
Translate the docs site into Simplified Chinese, using the zh-cn structure reserved in #86.

## Changes
- **`docs/i18n/zh-cn.toml`** — Chinese table headers (厂商/后端/镜像/基础系统/编译器/变量/值/依赖).
- **`docs/content/zh-cn/**`** — translated landing, overview, images catalog + per-image reference, usage, and contribution/onboarding pages (mirrors content/en).

The data-driven shortcodes (`backend-catalog`, `image-reference`) are shared across languages, so the catalog / env / deps tables render with Chinese headers and the same generated data.

## Verification
- `hugo build`: EN 19 pages, ZH-CN 18 pages, no errors.
- zh-cn catalog renders the full Chinese header row + all 14 image tags; reference page renders Chinese env headers with real data (NVIDIA_VISIBLE_DEVICES, MUSA_HOME, …).
- hugo-book language switcher (English / 简体中文) active.

Publishes to https://flagos-ai.github.io/release-info/ (zh-cn at /zh-cn/) on merge.