### PR TITLE
docs: fix env/data monospace styling (obsolete <tt> → code.plain)

### DIFF
--- a/docs/assets/_custom.scss
+++ b/docs/assets/_custom.scss
@@ -1,0 +1,13 @@
+// Site custom styles (overrides the theme's empty _custom.scss).
+
+// Plain monospace: an inline <code> without the "chip" — monospace at the same
+// size as inline code, but no background/border/padding and inheriting the
+// surrounding text color. Used for data values in the image tables and lists,
+// where a wall of gray code-chips reads poorly. Bare <code> keeps the theme's
+// chip (and remains available where colored/emphasised code is wanted).
+code.plain {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+}

--- a/docs/layouts/shortcodes/base-catalog.html
+++ b/docs/layouts/shortcodes/base-catalog.html
@@ -5,7 +5,7 @@
 {{- range site.Data.images.backends }}
   <tr>
     <td>{{ .vendor }}</td>
-    <td><a href="{{ $.Page.RelPermalink }}{{ .name }}/"><tt>{{ .backend }}</tt></a></td>
+    <td><a href="{{ $.Page.RelPermalink }}{{ .name }}/"><code class="plain">{{ .backend }}</code></a></td>
   </tr>
 {{- end }}
 </tbody>

--- a/docs/layouts/shortcodes/base-image.html
+++ b/docs/layouts/shortcodes/base-image.html
@@ -5,23 +5,23 @@
 
 <h3>{{ T "contents" }}</h3>
 <ul>
-  <li><strong>{{ T "image" }}:</strong> <tt>{{ $b.image }}</tt></li>
-  <li><strong>{{ T "base_os" }}:</strong> <tt>{{ $b.os }}</tt></li>
-  <li><strong>{{ T "sdk_version" }}:</strong> <tt>{{ .sdk_version }}</tt></li>
+  <li><strong>{{ T "image" }}:</strong> <code class="plain">{{ $b.image }}</code></li>
+  <li><strong>{{ T "base_os" }}:</strong> <code class="plain">{{ $b.os }}</code></li>
+  <li><strong>{{ T "sdk_version" }}:</strong> <code class="plain">{{ .sdk_version }}</code></li>
 </ul>
 
 {{- with $b.sdk_packages }}
 <h4>{{ T "sdk_packages" }}</h4>
 <ul>
 {{- range . }}
-  <li><tt>{{ . }}</tt></li>
+  <li><code class="plain">{{ . }}</code></li>
 {{- end }}
 </ul>
 {{- end }}
 
 {{- with $b.system_packages }}
 <h4>{{ T "system_packages" }}</h4>
-<p>{{ range $i, $p := . }}{{ if $i }}, {{ end }}<tt>{{ $p }}</tt>{{ end }}</p>
+<p>{{ range $i, $p := . }}{{ if $i }}, {{ end }}<code class="plain">{{ $p }}</code>{{ end }}</p>
 {{- end }}
 
 {{- with $b.env }}
@@ -30,7 +30,7 @@
 <thead><tr><th>{{ T "env_var" }}</th><th>{{ T "env_value" }}</th></tr></thead>
 <tbody>
 {{- range $k, $v := . }}
-  <tr><td><tt>{{ $k }}</tt></td><td><tt>{{ $v }}</tt></td></tr>
+  <tr><td><code class="plain">{{ $k }}</code></td><td><code class="plain">{{ $v }}</code></td></tr>
 {{- end }}
 </tbody>
 </table>
@@ -43,5 +43,5 @@
 {{- end }}
 
 {{- else -}}
-<p><strong>Unknown backend: <tt>{{ $name }}</tt></strong></p>
+<p><strong>Unknown backend: <code class="plain">{{ $name }}</code></strong></p>
 {{- end -}}

--- a/docs/layouts/shortcodes/runtime-catalog.html
+++ b/docs/layouts/shortcodes/runtime-catalog.html
@@ -5,7 +5,7 @@
 {{- range site.Data.images.backends }}
   <tr>
     <td>{{ .vendor }}</td>
-    <td><a href="{{ $.Page.RelPermalink }}{{ .name }}/"><tt>{{ .backend }}</tt></a></td>
+    <td><a href="{{ $.Page.RelPermalink }}{{ .name }}/"><code class="plain">{{ .backend }}</code></a></td>
   </tr>
 {{- end }}
 </tbody>

--- a/docs/layouts/shortcodes/runtime-image.html
+++ b/docs/layouts/shortcodes/runtime-image.html
@@ -5,14 +5,14 @@
 
 <h3>{{ T "contents" }}</h3>
 <ul>
-  <li><strong>{{ T "image" }}:</strong> <tt>{{ $r.image }}</tt> <em>({{ T "runtime_tag_note" }})</em></li>
+  <li><strong>{{ T "image" }}:</strong> <code class="plain">{{ $r.image }}</code> <em>({{ T "runtime_tag_note" }})</em></li>
   <li><strong>{{ T "python" }}:</strong> {{ $r.python }}</li>
 </ul>
 
 <h4>{{ T "stack" }}</h4>
 <ul>
 {{- range $r.stack }}
-  <li><tt>{{ . }}</tt></li>
+  <li><code class="plain">{{ . }}</code></li>
 {{- end }}
 </ul>
 
@@ -22,7 +22,7 @@
 <thead><tr><th>{{ T "env_var" }}</th><th>{{ T "env_value" }}</th></tr></thead>
 <tbody>
 {{- range $k, $v := . }}
-  <tr><td><tt>{{ $k }}</tt></td><td><tt>{{ $v }}</tt></td></tr>
+  <tr><td><code class="plain">{{ $k }}</code></td><td><code class="plain">{{ $v }}</code></td></tr>
 {{- end }}
 </tbody>
 </table>
@@ -32,7 +32,7 @@
 <table>
 <tbody>
 {{- range $r.deps }}
-  <tr><td><tt>{{ . }}</tt></td></tr>
+  <tr><td><code class="plain">{{ . }}</code></td></tr>
 {{- end }}
 </tbody>
 </table>
@@ -44,5 +44,5 @@
 {{- end }}
 
 {{- else -}}
-<p><strong>Unknown backend: <tt>{{ $name }}</tt></strong></p>
+<p><strong>Unknown backend: <code class="plain">{{ $name }}</code></strong></p>
 {{- end -}}


### PR DESCRIPTION
## Problem

The environment-variable table read strangely: it used `<tt>`, an **obsolete HTML element** the hugo-book theme leaves unstyled, so it rendered quite differently from the theme-styled `<code>` chips elsewhere on the page (e.g. the docker run block right below it).

## Fix — two intentional monospace flavors

- **`code.plain`** (new): plain monospace, **same text color, no gray chip** — for data values in the image tables/lists (env var names+values, image names, deps, SDK/system packages, OS, sdk_version). Restores the clean plain-monospace look, styled deliberately.
- **bare `<code>`**: keeps the theme chip; available where colored/emphasised code is wanted, and still what markdown backticks produce site-wide. The docker run blocks stay highlighted `<pre><code>`.

Adds `docs/assets/_custom.scss` (overrides the theme’s empty `_custom.scss` via its `@import \"custom\"` import — submodule untouched) with:

```scss
code.plain { background: none; border: none; padding: 0; color: inherit; }
```

and replaces the `<tt>` tags in the four image shortcodes with `<code class=\"plain\">`.

## Verification

- `code.plain` compiled into the minified CSS.
- Built HTML: 17 `code.plain` elements on each backend page (en + zh-cn identical); only the two docker run blocks remain bare `<code>` (highlighted). Clean rebuild reproduces.