### PR TITLE
docs: set site title to "Release Info"

### DIFF
--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -1,9 +1,9 @@
 ---
-title: build-infra
+title: Release Info
 type: docs
 ---
 
-# build-infra
+# Release Info
 
 FlagOS container image build infrastructure. FlagOS ships images in layers — a
 vendor **base** image, a FlagGems **runtime** image on top of it, and (soon)

--- a/docs/content/zh-cn/_index.md
+++ b/docs/content/zh-cn/_index.md
@@ -1,9 +1,9 @@
 ---
-title: build-infra
+title: Release Info
 type: docs
 ---
 
-# build-infra
+# Release Info
 
 FlagOS 容器镜像构建基础设施。FlagOS 的镜像是分层发布的——厂商 **base** 镜像、
 其上的 FlagGems **runtime** 镜像，以及（即将推出的）**application** 镜像。

--- a/docs/content/zh-cn/_index.md
+++ b/docs/content/zh-cn/_index.md
@@ -1,9 +1,9 @@
 ---
-title: Release Info
+title: 发布信息
 type: docs
 ---
 
-# Release Info
+# 发布信息
 
 FlagOS 容器镜像构建基础设施。FlagOS 的镜像是分层发布的——厂商 **base** 镜像、
 其上的 FlagGems **runtime** 镜像，以及（即将推出的）**application** 镜像。

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -47,7 +47,7 @@ languages:
     weight: 1
     languagedirection: ltr
   zh-cn:
-    title: Release Info
+    title: 发布信息
     languageName: 简体中文
     contentDir: content/zh-cn
     weight: 2

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -1,5 +1,5 @@
 baseURL: https://flagos-ai.github.io/release-info/
-title: build-infra
+title: Release Info
 languageCode: en-us
 theme:
   - hugo-book
@@ -41,13 +41,13 @@ menus:
 # Chinese later is purely additive (translate content/zh-cn + i18n/zh-cn.toml).
 languages:
   en:
-    title: build-infra
+    title: Release Info
     languageName: English
     contentDir: content/en
     weight: 1
     languagedirection: ltr
   zh-cn:
-    title: build-infra
+    title: Release Info
     languageName: 简体中文
     contentDir: content/zh-cn
     weight: 2


### PR DESCRIPTION
The docs site (published at flagos-ai.github.io/release-info/) still showed **build-infra** in the left-nav brand and the landing-page H1.

## Change

- `docs/hugo.yaml`: `title: build-infra` → **Release Info** (top-level + both language blocks) — drives the left-nav brand and browser tab.
- Landing page `_index.md` (en + zh-cn): front-matter `title` and the `#` H1 → **Release Info**.

The repo/project stays **build-infra**; only the GitHub repo URL and commit-link in `hugo.yaml` keep that name (correct — that is the repo).

## Verification

Built locally: left-nav brand renders `<span>Release Info</span>` (en + zh), main-page heading is `<h1>Release Info</h1>`. Clean rebuild reproduces.