### PR TITLE
docs: curate per-backend sdk lists into readable entries

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -61,6 +61,8 @@ vendors:
         - torch==2.10.0+cu128
         - torchaudio==2.10.0+cu128
         - torchvision==0.25.0+cu128
+      sdk:
+        - CUDA 12.8 (x86_64)
 
     cuda13.3:
       extras: nvidia-cuda133
@@ -79,6 +81,8 @@ vendors:
         - torch==2.11.0+cu130
         - torchaudio==2.11.0+cu130
         - torchvision==0.26.0+cu130
+      sdk:
+        - CUDA 13.3 (x86_64)
 
   ascend:
     cann8.5.0:
@@ -95,8 +99,8 @@ vendors:
         - torch==2.9.0+cpu
         - torch-npu==2.9.0
       sdk:
-        - Ascend-cann-toolkit_8.5.0_linux-aarch64.run
-        - Ascend-cann-910b-ops_8.5.0_linux-aarch64.run
+        - CANN Toolkit 8.5.0 (aarch64)     # Ascend-cann-toolkit_8.5.0_linux-aarch64.run
+        - CANN 910B Ops 8.5.0 (aarch64)    # Ascend-cann-910b-ops_8.5.0_linux-aarch64.run
 
     cann9.0.0:
       extras: ascend-cann900
@@ -114,9 +118,9 @@ vendors:
         - torch==2.10.0+cpu
         - torch-npu==2.10.0
       sdk:
-        - Ascend-cann_9.0.0_linux-aarch64.run
-        - Ascend-cann-910b-ops_9.0.0_linux-aarch64.run
-        - Ascend-cann-nnal_9.0.0_linux-aarch64.run
+        - CANN Toolkit 9.0.0 (aarch64)  # Ascend-cann_9.0.0_linux-aarch64.run
+        - CANN 910B Ops 9.0.0 (aarch64) # Ascend-cann-910b-ops_9.0.0_linux-aarch64.run
+        - CANN NNAL 9.0.0 (aarch64)     # Ascend-cann-nnal_9.0.0_linux-aarch64.run
 
   cambricon:
     neuware4.4.3:
@@ -133,31 +137,31 @@ vendors:
         - torch-mlu==1.29.2+torch2.7.1
         - torch-mlu-ops==1.8.0+torch2.7.1
       sdk:
-        - cnlicense_1.2.0-1.ubuntu22.04_amd64.deb
-        - cndev_6.5.25-1.ubuntu22.04_amd64.deb
-        - cnbin_2.4.2-1.ubuntu22.04_amd64.deb
-        - cndrv_3.4.3-1.ubuntu22.04_amd64.deb
-        - cndev-compat_6.5.25-1.ubuntu22.04_amd64.deb
-        - cnrt_7.4.0-1.ubuntu22.04_amd64.deb
-        - cnas_5.4.3-1.ubuntu22.04_amd64.deb
-        - cnpx_1.6.0-1.ubuntu22.04_amd64.deb
-        - cnpapi_4.4.2-1.ubuntu22.04_amd64.deb
-        - cnperf_6.4.3-1.ubuntu22.04_amd64.deb
-        - cngdb_4.4.2-1.ubuntu22.04_amd64.deb
-        - cncc_5.4.3-1.ubuntu22.04_amd64.deb
-        - cnrtc_0.7.4-1.ubuntu22.04_amd64.deb
-        - cnjpeg_0.5.1-1.ubuntu22.04_amd64.deb
-        - cncodec3_2.4.1-1.ubuntu22.04_amd64.deb
-        - cnsanitizer_0.12.3-1.ubuntu22.04_amd64.deb
-        - cntoolkit_4.4.3-1.ubuntu22.04_amd64.deb
-        - cnnl_2.1.829-20251127_150207-v2.1.12-0.rc0-3-g54aaee8.ubuntu22.04_amd64.deb
-        - cnnlextra_2.2.7-1.ubuntu22.04_amd64.deb
-        - mluops_1.8.1-1.ubuntu22.04_amd64.deb
-        - cncl_1.29.4-1.ubuntu22.04_amd64.deb
-        - cnstudio_1.2.1-1.ubuntu22.04_amd64.deb
-        - cntoolkit-cloud_4.4.3-1.ubuntu22.04_amd64.deb
-        - cnclep_1.1.1-1.ubuntu22.04_amd64.deb
-        - cnmon-6.2.15-x86_64.zip
+        - cndev 6.5.25 (amd64) # cnlicense_1.2.0-1.ubuntu22.04_amd64.deb
+                               # cndev_6.5.25-1.ubuntu22.04_amd64.deb
+                               # cndev-compat_6.5.25-1.ubuntu22.04_amd64.deb
+        - cnmon 6.2.15         # cnmon-6.2.15-x86_64.zip
+        - cnbin 2.4.2          # cnbin_2.4.2-1.ubuntu22.04_amd64.deb
+        - cndrv 3.4.3          # cndrv-3.4.3-1.ubuntu22.04_amd64.deb
+        - cnrt 7.4.0           # cnrt_7.4.0-1.ubuntu22.04_amd64.deb
+        - cnrtc 0.7.4          # cnrtc_0.7.4-1.ubuntu22.04_amd64.deb
+        - cncc/cnas 5.4.3      # cncc_5.4.3-1.ubuntu22.04_amd64.deb
+                               # cnas_5.4.3-1.ubuntu22.04_amd64.deb
+        - cngdb 4.4.2          # cngdb_4.4.2-1.ubuntu22.04_amd64.deb
+        - cnpapi 4.4.2         # cnpapi_4.4.2-1.ubuntu22.04_amd64.deb
+        - cnpx 1.6.0           # cnpx_1.6.0-1.ubuntu22.04_amd64.deb
+        - cnperf 6.4.3         # cnperf_6.4.3-1.ubuntu22.04_amd64.deb
+        - cnjpeg 0.5.1           # cnjpeg_0.5.1-1.ubuntu22.04_amd64.deb
+        - cncodec3 2.4.1         # cncodec3_2.4.1-1.ubuntu22.04_amd64.deb
+        - cnsanitizer 0.12.3     # cnsanitizer_0.12.3-1.ubuntu22.04_amd64.deb
+        - cnnl+extra 2.1.829     # cnnl_2.1.829-20251127_150207-v2.1.12-0.rc0-3-g54aaee8.ubuntu22.04_amd64.deb
+                                 # cnnlextra_2.2.7-1.ubuntu22.04_amd64.deb
+        - mluops 1.8.1           # mluops_1.8.1-1.ubuntu22.04_amd64.deb
+        - cncl 1.29.4            # cncl_1.29.4-1.ubuntu22.04_amd64.deb
+        - cnstudio 1.2.1         # cnstudio_1.2.1-1.ubuntu22.04_amd64.deb
+        - cntoolkit 4.4.3        # cntoolkit_4.4.3-1.ubuntu22.04_amd64.deb
+        - cntoolkit-cloud 4.4.3  # cntoolkit-cloud_4.4.3-1.ubuntu22.04_amd64.deb
+        - cnclep 1.1.1.          # cnclep_1.1.1-1.ubuntu22.04_amd64.deb
 
   enflame:
     tops1.9.10:
@@ -174,16 +178,16 @@ vendors:
         - torch-gcu==2.10.0+3.7.20260408
         - flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323
       sdk:
-        - enflame-x86_64-gcc-1.9.10-20260520104313.run
-        - topsruntime_1.9.10-1_amd64.deb
-        - topscc_1.9.10-1_amd64.deb
-        - efml_1.9.10-1_amd64.deb
-        - topspti_1.9.10-1_amd64.deb
-        - gculare-perftest_1.9.10-1_amd64.deb
-        - topsaten_3.7.20260514-1_amd64.deb
-        - eccl_3.6.3.11-1_amd64.deb
-        - triton-gcu_3.6.0+1.0.20260521.cc.1.9.10-1_amd64.deb
-        - topstx_1.9.10-1_amd64.deb
+        - Enflame driver 1.9.10   # enflame-x86_64-gcc-1.9.10-20260520104313.run
+        - TOPS Runtime 1.9.10     # topsruntime_1.9.10-1_amd64.deb
+        - TOPS CC 1.9.10          # topscc_1.9.10-1_amd64.deb
+        - TOPS PTI 1.9.10         # topspti_1.9.10-1_amd64.deb
+        - TOPSTX 1.9.10           # topstx_1.9.10-1_amd64.deb
+        - TOPS ATen 3.7.20260514  # topsaten_3.7.20260514-1_amd64.deb
+        - EFML 1.9.10             # efml_1.9.10-1_amd64.deb
+        - ECCL 3.6.3.11           # eccl_3.6.3.11-1_amd64.deb
+        - Triton GCU 3.6.0+1.0.20260521.cc.1.9.10  # triton-gcu_3.6.0+1.0.20260521.cc.1.9.10-1_amd64.deb
+        - Gculare-perftest 1.9.10 # gculare-perftest_1.9.10-1_amd64.deb
 
   hygon:
     dtk26.04:
@@ -198,7 +202,7 @@ vendors:
       deps:
         - torch==2.9.0+das.opt1.dtk2604
       sdk:
-        - DTK-26.04-Ubuntu22.04-x86_64.tar.gz
+        - Hygon DTK 26.04      # DTK-26.04-Ubuntu22.04-x86_64.tar.gz
 
   iluvatar:
     corex4.4.0:
@@ -217,8 +221,8 @@ vendors:
         - torchaudio==2.7.1+corex.4.4.0
         - torchvision==0.22.1+corex.4.4.0
       sdk:
-        - cuda-header-260604.zip
-        - corex-installer-linux64-4.4.0_x86_64_10.2.run
+        - Corex Runtime 4.4.0      # corex-installer-linux64-4.4.0_x86_64_10.2.run
+        - CUDA Header files 260604 # cuda-header-260604.zip
 
   kunlunxin:
     xre5.29.0:
@@ -247,9 +251,9 @@ vendors:
         - xformers==0.0.29+1e7a8ec.d20260114
         - xmlir==1.0.0.1
       sdk:
-        - cuda_12.9.0_575.51.03_linux.run
-        - xre-Linux-x86_64-cuda12-5.29.0.0.run
-        - xcudart-5.13.0_amd64.deb
+        - CUDA 12.9.0_575.51.03     # cuda_12.9.0_575.51.03_linux.run
+        - XRE-CUDA12 5.29.0.0       # xre-Linux-x86_64-cuda12-5.29.0.0.run
+        - XCUDART 5.13.0            # xcudart-5.13.0_amd64.deb
 
   metax:
     maca3.7.2.1:
@@ -268,8 +272,8 @@ vendors:
         - torchvision==0.15.1+metax3.7.2.0
         - flash_attn==2.6.3+metax3.7.2.0torch2.8
       sdk:
-        - metax-driver-3.7.2.30-deb-x86_64.run
-        - maca-sdk-3.7.2.0-deb-x86_64.tar.xz
+        - MetaX Driver 3.7.2.30   # metax-driver-3.7.2.30-deb-x86_64.run
+        - MACA SDK 3.7.2.0        # maca-sdk-3.7.2.0-deb-x86_64.tar.xz
 
   mthreads:
     musa4.3.6:
@@ -290,12 +294,11 @@ vendors:
         - torch==2.9.0+musa.4.3.6
         - torch_musa==2.9.0
         - mkl==2024.0.0
-
-    # No base image yet — dependency spec kept as source of truth.
       sdk:
-        - musa_toolkits_rc4.3.6.tar.gz
-        - mccl_rc2.1.6.PH1.tar.gz
-        - mudnn_rc3.1.6.PH1.tar.gz
+        - MUSA Toolkits RC4.3.6     # musa_toolkits_rc4.3.6.tar.gz
+        - MCCL RC2.1.6              # mccl_rc2.1.6.PH1.tar.gz
+        - muDNN RC3.1.6             # mudnn_rc3.1.6.PH1.tar.gz
+
     musa5.2.0:
       extras: mthreads-musa520
       python: "3.10"
@@ -315,11 +318,12 @@ vendors:
         - torch_musa==2.9.1
         - mkl==2024.0.0
 
-  # No base image yet — dependency spec kept as source of truth.
       sdk:
-        - musa_toolkits_5.2.0.tar.gz
-        - mccl.2.4.0.PH1.tar.gz
-        - mudnn.3.4.0.PH1.tar.gz
+        - MUSA Toolkits 5.2.0     # musa_toolkits_5.2.0.tar.gz
+        - MCCL 2.4.0              # mccl.2.4.0.PH1.tar.gz
+        - muDNN 3.4.0             # mudnn.3.4.0.PH1.tar.gz
+
+  # No base image yet
   spacemit:
     spacemit:
       extras: spacemit
@@ -345,11 +349,12 @@ vendors:
         - torchvision==0.26.0+cpu
         - torch-ptpu==0.2.3+torch2.11
       sdk:
-        - tangtk-v1.2.0-linux-x86_64.run
-        - pccl-v1.2.0-linux_x86_64.run
-        - tadnn-v1.2.0-linux-x86_64.tar.gz
-        - tablas-v1.2.0-linux-x86_64.tar.gz
+        - Tang Toolkit 1.2.0   # tangtk-v1.2.0-linux-x86_64.run
+        - PCCL 1.2.0           # pccl-v1.2.0-linux_x86_64.run
+        - taDNN 1.2.0          # tadnn-v1.2.0-linux-x86_64.tar.gz
+        - taBLAS 1.2.0         # tablas-v1.2.0-linux-x86_64.tar.gz
 
+  # No base image yet. Has to run on PAI using Aliyun images
   thead:
     ppu2.0.0:
       extras: thead
@@ -389,9 +394,9 @@ vendors:
         - torch_txda==0.1.0+20260615.37ba6bbd
         - txops==0.1.0+20260508.60287151
       sdk:
-        - Tsm_validation_suite_260604163331_x86_64_installer.run
-        - Tsm_runtime_260604163331_x86_64_installer.run
-        - Tsm_ccl_260604163331_x86_64_installer.run
-        - Tsm_profiler_260604163331_x86_64_installer.run
-        - tx8_depends_dev_20260507_104051.tar.gz
-        - llvm-a66376b0-ubuntu-x64.tgz
+        - TSM Runtime 260604163331           # Tsm_runtime_260604163331_x86_64_installer.run
+        - TSM Validation Suite 260604163331  # Tsm_validation_suite_260604163331_x86_64_installer.run
+        - TSM CCL 260604163331               # Tsm_ccl_260604163331_x86_64_installer.run
+        - TSM Profiler 260604163331          # Tsm_profiler_260604163331_x86_64_installer.run
+        - TX8 Compiler Dependencies 20260507 # tx8_depends_dev_20260507_104051.tar.gz
+        - LLVM a66376b0                      # llvm-a66376b0-ubuntu-x64.tgz


### PR DESCRIPTION
Replace the seeded raw package filenames with hand-curated, human-readable SDK component names (with versions) in each backend `sdk:` list in configs.yaml.

Example: mthreads/musa4.3.6 -> MUSA Toolkits RC4.3.6 / MCCL RC2.1.6 / muDNN RC3.1.6.

Verified: configs.yaml is valid YAML; gen_data.py + hugo build clean; base-image pages render the curated lists.