### PR TITLE
docs: system packages before SDK, as a sorted plain-code list

### DIFF
--- a/docs/i18n/zh-cn.toml
+++ b/docs/i18n/zh-cn.toml
@@ -16,10 +16,10 @@ other = "基础系统"
 other = "SDK 版本"
 
 [sdk_packages]
-other = "SDK 包"
+other = "SDK 软件包"
 
 [system_packages]
-other = "系统包"
+other = "系统软件包"
 
 [python]
 other = "Python"

--- a/docs/layouts/shortcodes/base-image.html
+++ b/docs/layouts/shortcodes/base-image.html
@@ -10,6 +10,15 @@
   <li><strong>{{ T "sdk_version" }}:</strong> <code class="plain">{{ .sdk_version }}</code></li>
 </ul>
 
+{{- with $b.system_packages }}
+<h4>{{ T "system_packages" }}</h4>
+<ul>
+{{- range sort . }}
+  <li><code class="plain">{{ . }}</code></li>
+{{- end }}
+</ul>
+{{- end }}
+
 {{- with $b.sdk }}
 <h4>{{ T "sdk_packages" }}</h4>
 <ul>
@@ -17,11 +26,6 @@
   <li>{{ . }}</li>
 {{- end }}
 </ul>
-{{- end }}
-
-{{- with $b.system_packages }}
-<h4>{{ T "system_packages" }}</h4>
-<p>{{ range $i, $p := . }}{{ if $i }}, {{ end }}<code class="plain">{{ $p }}</code>{{ end }}</p>
 {{- end }}
 
 {{- with $b.env }}


### PR DESCRIPTION
On the base image pages:

- Move the **system packages** section **above** the SDK packages section.
- Render system packages as an **alphabetically sorted list**, each package in **plain-code** format (was a comma-separated paragraph).
- Rename the zh labels: 系统包 -> **系统软件包**, and SDK 包 -> **SDK 软件包** (for parallelism).

Verified: h4 order is System -> SDK -> Environment; system list is sorted plain-code; zh labels render; build clean (EN+ZH).