### PR TITLE
feat(flaggems-builder): daily pure-Python flag_gems wheel

### DIFF
--- a/.github/workflows/flaggems-wheel.yml
+++ b/.github/workflows/flaggems-wheel.yml
@@ -1,0 +1,76 @@
+name: FlagGems daily wheel
+
+# Build the pure-Python flag_gems wheel from FlagGems source and (optionally)
+# upload it to the internal PyPI. The wheel is versioned by FlagGems'
+# setuptools_scm (git tags): a dev build looks like 5.4.0.dev580+gb89e0aeb8.
+#
+# NOTE: FLAGGEMS_REF defaults to the under-review wheel-packaging-split branch,
+# which carries the pure-Python setuptools packaging. Change the default to the
+# FlagGems default branch once that branch merges.
+
+on:
+  workflow_dispatch:
+    inputs:
+      flaggems_ref:
+        description: 'FlagGems git ref to build'
+        type: string
+        default: wheel-packaging-split
+      upload:
+        description: 'upload the wheel to the internal PyPI'
+        type: boolean
+        default: false
+      pypi_repo:
+        description: 'Nexus PyPI-hosted repo to upload to'
+        type: string
+        default: flagos-pypi-daily
+  schedule:
+    # Daily at 01:17 UTC. Builds + uploads (see the guard in the upload step).
+    - cron: '17 1 * * *'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      FLAGGEMS_REPO: https://github.com/flagos-ai/FlagGems.git
+      FLAGGEMS_REF: ${{ inputs.flaggems_ref || 'wheel-packaging-split' }}
+      PYPI_REPO: ${{ inputs.pypi_repo || 'flagos-pypi-daily' }}
+    steps:
+      - name: Checkout build-infra
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build the wheel
+        run: OUTDIR="${GITHUB_WORKSPACE}/wheels" bash flaggems-builder/build.sh
+
+      - name: Upload wheel as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: flag_gems-wheel
+          path: wheels/*.whl
+
+      # Upload to the internal PyPI on the schedule, or when manually requested.
+      # Manual dispatch defaults upload=false so building from a branch is safe.
+      - name: Upload to internal PyPI
+        if: ${{ github.event_name == 'schedule' || inputs.upload }}
+        env:
+          NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEXUS_TOKEN:-}" ]; then
+            echo "ERROR: NEXUS_TOKEN secret is empty or unset" >&2
+            exit 1
+          fi
+          python3 -m pip install --quiet twine
+          python3 -m twine upload \
+            --repository-url "https://resource.flagos.net/repository/${PYPI_REPO}/" \
+            -u "${NEXUS_TOKEN%%:*}" -p "${NEXUS_TOKEN#*:}" \
+            --non-interactive \
+            wheels/*.whl

--- a/flaggems-builder/README.md
+++ b/flaggems-builder/README.md
@@ -1,0 +1,55 @@
+# flaggems-builder
+
+Builds the **pure-Python `flag_gems` wheel** from FlagGems source and uploads it
+to the internal PyPI, daily.
+
+Unlike `flagtree-builder/` (which needs an old-glibc container to compile
+native code), the pure-Python wheel is platform-independent (`py3-none-any`) and
+needs **no vendor toolchain** — so this is a plain script plus a workflow.
+
+The wheel version comes from **FlagGems' own `setuptools_scm`** (its git tags),
+e.g. `flag_gems-5.4.0.dev580+gb89e0aeb8-py3-none-any.whl`. We do not inject a
+version; the checkout just has to include tags.
+
+> The per-vendor **C++ operator** wheels (`flag-gems-cpp-<vendor>`) are a
+> separate, rarely-rebuilt artifact that *does* need a base image to compile —
+> not built here. See the design doc (§3).
+
+## Build
+
+`build.sh` only builds (uploading is the workflow's job):
+
+```sh
+# from a ref (default: wheel-packaging-split — see note below)
+FLAGGEMS_REF=wheel-packaging-split ./build.sh
+
+# from a local clone, offline
+FLAGGEMS_REPO=/path/to/FlagGems ./build.sh
+
+OUTDIR=/tmp/wheels ./build.sh        # choose the output dir (default ./wheels)
+```
+
+It clones FlagGems (with tags), runs `pip wheel . --no-deps`, and fails loudly
+if the result isn't a `py3-none-any` wheel (a platform tag would mean the build
+hit the C++ backend — wrong ref or packaging).
+
+## Daily workflow
+
+`.github/workflows/flaggems-wheel.yml`:
+
+- **Schedule** (daily) → builds and **uploads** to the internal PyPI.
+- **Manual dispatch** → inputs `flaggems_ref`, `pypi_repo`, and `upload`
+  (default `false`, so building from a branch is safe). Always uploads the wheel
+  as a GitHub Actions artifact for inspection.
+- Upload target: **`flagos-pypi-daily`** (the daily/dev repo; releases go to
+  `flagos-pypi-hosted`). Auth via the org secret `NEXUS_TOKEN` (`user:token`).
+
+## ⚠️ Temporary: FlagGems ref
+
+`FLAGGEMS_REF` defaults to the **under-review `wheel-packaging-split` branch**,
+which carries the pure-Python setuptools packaging (`build-backend =
+setuptools.build_meta`). On the FlagGems default branch today, `pip wheel .`
+still uses scikit-build and tries to compile C++.
+
+**Once `wheel-packaging-split` merges, change the default ref to the FlagGems
+default branch** (in `build.sh` and the workflow) and delete this note.

--- a/flaggems-builder/build.sh
+++ b/flaggems-builder/build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Build the pure-Python flag_gems wheel from FlagGems source.
+#
+# The wheel is platform-independent (py3-none-any) — no vendor toolchain needed,
+# so this is a plain script, not a container build. The version comes from
+# FlagGems' own setuptools_scm (git tags), so the checkout must include tags.
+#
+# Uploading is the workflow's job; this only builds. Output: $OUTDIR/*.whl.
+#
+#   FLAGGEMS_REF=<ref> ./build.sh          # build from a ref
+#   OUTDIR=/tmp/wheels ./build.sh          # choose output dir
+#   FLAGGEMS_REPO=/path/to/FlagGems ./build.sh   # build from a local clone
+set -euo pipefail
+
+FLAGGEMS_REPO="${FLAGGEMS_REPO:-https://github.com/flagos-ai/FlagGems.git}"
+# TODO: default to the FlagGems default branch once wheel-packaging-split merges.
+# The pure-Python setuptools packaging (build-backend = setuptools.build_meta)
+# lives on that under-review branch for now; on master today `pip wheel .` still
+# uses scikit-build (tries to compile C++). Drop this ref once it lands.
+FLAGGEMS_REF="${FLAGGEMS_REF:-wheel-packaging-split}"
+OUTDIR="${OUTDIR:-$(pwd)/wheels}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+src="$workdir/FlagGems"
+
+echo ">>> cloning FlagGems @ ${FLAGGEMS_REF} (with tags, for setuptools_scm)"
+git clone --quiet "$FLAGGEMS_REPO" "$src"
+git -C "$src" fetch --quiet --tags --force origin || true
+git -C "$src" checkout --quiet "$FLAGGEMS_REF"
+
+echo ">>> version: $(git -C "$src" describe --tags 2>/dev/null || echo '(no tag)')"
+
+echo ">>> building pure-Python wheel"
+mkdir -p "$OUTDIR"
+python3 -m pip wheel "$src" --no-deps -w "$OUTDIR"
+
+wheel="$(ls -t "$OUTDIR"/flag_gems-*.whl 2>/dev/null | head -1)"
+if [ -z "$wheel" ]; then
+  echo "ERROR: no flag_gems wheel produced" >&2
+  exit 1
+fi
+# Sanity: the pure-Python wheel must be py3-none-any. A platform tag means the
+# build hit the C++ backend (wrong ref / packaging) — fail loudly.
+case "$wheel" in
+  *-py3-none-any.whl) : ;;
+  *) echo "ERROR: expected a py3-none-any wheel, got $(basename "$wheel")" >&2
+     echo "       (is FLAGGEMS_REF on the pure-Python packaging branch?)" >&2
+     exit 1 ;;
+esac
+
+echo ">>> built: $(basename "$wheel")"


### PR DESCRIPTION
Second step of the wheel spine (after #99 git-tag versioning): the **daily pure-Python `flag_gems` wheel** builder — the upstream artifact the runtime-image migration will consume.

## What

- **`flaggems-builder/build.sh`** — clones FlagGems (with tags) at a ref, runs `pip wheel . --no-deps`, and fails loudly if the result isn't `py3-none-any` (a platform tag would mean it hit the C++/scikit-build backend). Version comes from **FlagGems' own `setuptools_scm`** (git tags) — no injection. Platform-independent → plain script, no container/toolchain (unlike `flagtree-builder`).
- **`.github/workflows/flaggems-wheel.yml`** — daily `schedule` builds + uploads to **`flagos-pypi-daily`** via twine (auth `NEXUS_TOKEN`); `workflow_dispatch` takes `flaggems_ref` / `pypi_repo` / `upload` (default `false`, so building from a branch is safe) and always saves the wheel as an artifact. `schedule` only fires from the default branch, so the cron activates on merge.

## Distribution

- Daily/dev wheels → **`flagos-pypi-daily`** (new repo). Releases stay on `flagos-pypi-hosted`. PEP 440 keeps `…dev…` out of a default `pip install` anyway.
- The per-vendor **C++ wheels** (`flag-gems-cpp-<vendor>`) are a separate, rarely-rebuilt artifact needing a base image — not built here (design §3).

## ⚠️ Temporary branch dependency

The pure-Python setuptools packaging (`build-backend = setuptools.build_meta`) lives on the **under-review `wheel-packaging-split`** FlagGems branch; on the default branch today `pip wheel .` still compiles C++. So `FLAGGEMS_REF` **defaults to `wheel-packaging-split`** for now — **switch to the default branch once it merges** (noted in `build.sh`, README, and the design doc). The pure-Python path is insulated from that branch's cpp/metax churn.

## Verify

Built locally against the branch → `flag_gems-5.4.0.dev580+gb89e0aeb8-py3-none-any.whl` (pure-Python, setuptools_scm version). Workflow + script pass YAML/syntax checks.

Prereqs before the daily upload works: create `flagos-pypi-daily` (in progress) and ensure `NEXUS_TOKEN` is set.
