### PR TITLE
fix(base): tsingmicro FILESTORE typo (completes 12/12 x86_64 builds)

### DIFF
--- a/base/tsingmicro-tsm260604
+++ b/base/tsingmicro-tsm260604
@@ -41,10 +41,10 @@ RUN set -eux ; \
   done
 
 # ── TsingMicro Compiler depdendencies ─────────────────────────────
-RUN curl -o /tmp/tx8.tar.gz ${FILESTORE}/tx8_depends_dev_20260507_104051.tar.gz \
+RUN curl -o /tmp/tx8.tar.gz ${FILE_STORE}/tx8_depends_dev_20260507_104051.tar.gz \
     && tar xf /tmp/tx8.tar.gz -C /usr/local \
     && rm /tmp/tx8.tar.gz
-RUN curl -o /tmp/llvm.tar.gz ${FILESTORE}/llvm-a66376b0-ubuntu-x64.tgz \
+RUN curl -o /tmp/llvm.tar.gz ${FILE_STORE}/llvm-a66376b0-ubuntu-x64.tgz \
     && tar xf /tmp/llvm.tar.gz -C /usr/local \
     && rm /tmp/llvm.tar.gz
  


### PR DESCRIPTION
One-char fix found by building all x86_64 base images on h20.

tsingmicro lines 44/47 referenced `${FILESTORE}` but the env var is `FILE_STORE`, so the tx8_depends + llvm downloads resolved to an empty URL → `curl: (3) ... missing URL`. The Tsm SDK installers (which use the correct `${FILE_STORE}`) were fine.

**Verified on h20**: with the fix, `tsingmicro-tsm260604` builds clean.

## Milestone: all 12 x86_64 base images build centrally

Built every x86_64 backend on h20 (no push, feasibility test): cambricon, enflame, hygon, iluvatar, kunlunxin, metax (umd fix), mthreads×2, nvidia×2, sunrise all OK on the first pass; tsingmicro OK after this typo fix. Confirms the arch-based central build model — the precondition for the C++ operator wheels (built inside these base images). ascend×2 (aarch64) still to build on an arm node.