### PR TITLE
runtime: install FlagGems from wheels instead of source

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -40,6 +40,7 @@
 base_image_prefix: "flagos-base"
 
 pypi_base: "https://resource.flagos.net/repository/flagos-pypi-{vendor}/simple"
+pypi_daily: "https://resource.flagos.net/repository/flagos-pypi-daily/simple"
 mirror: "https://mirrors.aliyun.com/pypi/simple"
 
 vendors:

--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -13,12 +13,14 @@ ARG INCLUDE_TESTS=true
 # ── Internal build arguments (set by build.py) ────────────────
 ARG PYTHON_VERSION=3.12
 ARG FLAGOS_PYPI=""
+ARG DAILY_PYPI=""
 ARG EXTRAS_GROUP=""
+ARG COMPILER=""
+ARG COMPILER_PKG=""
 ARG TRITON_POST_INSTALL=""
-# TODO: Remove FLAGGEMS_VERSION once we switch to wheel-based install.
-# Buildkit excludes .git from the build context, so setuptools-scm
-# cannot detect the version. build.py reads it from git describe and
-# passes it here.
+# FlagGems wheel version to pin (== exact). build.py derives it from the
+# FlagGems git describe; buildkit excludes .git from the context so the wheel
+# can't self-detect it.
 ARG FLAGGEMS_VERSION=0.0.0
 
 
@@ -29,8 +31,10 @@ FROM ${BASE_IMAGE} AS builder
 
 ARG PYTHON_VERSION
 ARG FLAGOS_PYPI
+ARG DAILY_PYPI
 ARG EXTRA_PYPI
 ARG EXTRAS_GROUP
+ARG COMPILER_PKG
 ARG TRITON_POST_INSTALL
 ARG INCLUDE_TESTS
 ARG FLAGGEMS_VERSION
@@ -45,48 +49,35 @@ RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
 ENV VIRTUAL_ENV=/flagos \
     PATH="/flagos/bin:${PATH}"
 
-# ── Python build dependencies ─────────────────────────────────
-RUN uv pip install --no-cache-dir \
-        --index ${EXTRA_PYPI} \
-        "setuptools>=64.0,<80.0" \
-        "scikit-build-core==0.12.2" \
-        "pybind11==3.0.3" \
-        "cmake>=3.20,<4.0" \
-        "ninja==1.13.0" \
-        "pip"
-
-# ── Build FlagGems ─────────────────────────────────────────────
-WORKDIR /build
-COPY . /build/FlagGems
-WORKDIR /build/FlagGems
-
-# TODO: Remove SETUPTOOLS_SCM_PRETEND_VERSION once we switch to
-# wheel-based install. See FLAGGEMS_VERSION ARG for details.
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=${FLAGGEMS_VERSION}
-
-RUN uv pip install --no-cache-dir ".[$EXTRAS_GROUP]" \
-      --default-index ${FLAGOS_PYPI} \
-      --index ${EXTRA_PYPI} \
+# ── Install FlagGems (prebuilt wheels) + compiler ─────────────
+# Wheel-based: no source tree, no inline C++ compile. Hermetic — only
+# resource.flagos.net. Two FlagOS indexes with uv's unsafe-first-match so a
+# dependency can resolve from EITHER index; uv's default first-index strategy
+# pins each package to a single index and won't fall through (which broke
+# cross-index deps like a pinned PyYAML).
+#   flag_gems + flag-gems-cpp-<backend>      -> flagos-pypi-daily  (DAILY_PYPI)
+#   torch / triton / flagtree / pinned deps  -> flagos-pypi-<vendor> (FLAGOS_PYPI)
+RUN uv pip install --no-cache-dir --prerelease=allow \
+      --index-strategy unsafe-first-match \
+      --index ${FLAGOS_PYPI} \
+      --index ${DAILY_PYPI} \
       --trusted-host resource.flagos.net \
-      --trusted-host mirrors.aliyun.com
+      "flag_gems[${EXTRAS_GROUP}]==${FLAGGEMS_VERSION}" ${COMPILER_PKG}
 
 # ── Triton post-install (e.g. triton_ascend) ─────────────────
 RUN if [ -n "${TRITON_POST_INSTALL}" ]; then \
       sh -c "${TRITON_POST_INSTALL}"; \
     fi
 
-# ── Test dependencies ──────────────────────────────────────────
-RUN uv pip install --no-cache-dir ".[test]" \
-      --index ${EXTRA_PYPI} \
-      --trusted-host mirrors.aliyun.com
-
-# ── Copy test suite ───────────────────────────────────────────
-RUN mkdir -p /app && \
-    if [ "${INCLUDE_TESTS}" = "true" ]; then \
-      cp -r /build/FlagGems/tests /app/tests \
-      && cp -r /build/FlagGems/benchmark /app/benchmark \
-      && cp /build/FlagGems/pytest.ini /app; \
-    fi
+# ── Tests — deferred (image not finalized) ────────────────────
+# Tests are NOT shipped yet: FlagGems' [test] extra installs only frameworks,
+# not the tests/ + benchmark/ sources, and wheel-based install has no source
+# tree to copy from. Left out until FlagGems ships tests as package-data (the
+# [test] fix). INCLUDE_TESTS stays as the switch for when that lands.
+RUN mkdir -p /app \
+    && if [ "${INCLUDE_TESTS}" = "true" ]; then \
+         echo "NOTE: tests requested but not shipped yet — pending FlagGems [test] package-data"; \
+       fi
 
 
 # ════════════════════════════════════════════════════════════════
@@ -95,6 +86,7 @@ RUN mkdir -p /app && \
 FROM ${BASE_IMAGE} AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG COMPILER
 
 # ── Copy uv and venv from builder ─────────────────────────────
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
@@ -106,6 +98,12 @@ COPY --from=builder /app /app
 
 ENV VIRTUAL_ENV=/flagos \
     PATH="/flagos/bin:${PATH}"
+
+# Compiler backend FlagGems uses (flagtree, or triton fallback), and enable the
+# C++ operator extensions (the flag-gems-cpp-<backend> .so files won't load
+# without this).
+ENV COMPILER=${COMPILER} \
+    USE_C_EXTENSION=1
 
 WORKDIR /app
 ENTRYPOINT ["bash"]

--- a/runtime/build.py
+++ b/runtime/build.py
@@ -15,7 +15,6 @@ Examples:
 """
 
 import argparse
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -98,38 +97,64 @@ def resolve_backend(backend_arg: str, configs: dict):
     sys.exit(f"Error: '{backend_arg}' not found in configs.yaml vendors")
 
 
-def parse_labels(containerfile: Path) -> dict[str, str]:
-    """Extract OCI LABEL values from a containerfile."""
-    labels = {}
-    with open(containerfile) as f:
-        for line in f:
-            m = re.match(
-                r'LABEL\s+org\.opencontainers\.image\.(\w+)\s*=\s*"([^"]*)"', line
-            )
-            if m:
-                labels[m.group(1)] = m.group(2)
-    return labels
+def git_describe(repo_root: Path) -> str | None:
+    """build-infra release version via `git describe --tags` ("v" stripped).
+
+    Same scheme base/build.py stamps onto the base image tag.
+    """
+    try:
+        r = subprocess.run(
+            ["git", "describe", "--tags", "--always"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+    if r.returncode != 0:
+        return None
+    desc = r.stdout.strip()
+    if desc[:1] == "v" and desc[1:2].isdigit():
+        desc = desc[1:]
+    return desc or None
+
+
+def base_registry(repo_root: Path) -> str | None:
+    """Base-image registry prefix ({host}/{prefixes.base}) from build-config.yml."""
+    cfg_path = repo_root / ".github" / "build-config.yml"
+    if not cfg_path.exists():
+        return None
+    with open(cfg_path) as f:
+        cfg = yaml.safe_load(f) or {}
+    reg = cfg.get("registry") or {}
+    host = reg.get("host")
+    prefix = (reg.get("prefixes") or {}).get("base")
+    return f"{host}/{prefix}" if host and prefix else None
 
 
 def resolve_base_image(
     vendor: str, backend: str, configs: dict, repo_root: Path
 ) -> str:
-    """Derive base image name by reading version/revision from the base containerfile.
+    """Full base image ref for the runtime FROM.
 
-    Image name: {prefix}-{vendor}-{backend}:{version}-{revision}
+    {registry}/{prefix}-{vendor}-{backend}:{git-version}
+
+    The tag comes from build-infra's `git describe --tags` — the SAME version
+    base/build.py stamps onto the pushed base image. (PR #99 removed the
+    version/revision LABELs, so this no longer reads them.) Falls back to :latest
+    with a warning when no tag is reachable (shallow checkout — use fetch-depth: 0).
     """
     prefix = configs.get("base_image_prefix", "flagos-base")
-    base_file = repo_root / "base" / f"{vendor}-{backend}"
-
-    if base_file.exists():
-        labels = parse_labels(base_file)
-        version = labels.get("version", "latest")
-        revision = labels.get("revision", "0")
-        tag = f"{version}-{revision}"
-    else:
-        tag = "latest"
-
-    return f"{prefix}-{vendor}-{backend}:{tag}"
+    version = git_describe(repo_root)
+    if not version:
+        print(
+            "warning: no git tag reachable — base image tag defaults to :latest",
+            file=sys.stderr,
+        )
+        version = "latest"
+    name = f"{prefix}-{vendor}-{backend}:{version}"
+    registry = base_registry(repo_root)
+    return f"{registry}/{name}" if registry else name
 
 
 def resolve_build_args(
@@ -146,22 +171,49 @@ def resolve_build_args(
     """Resolve all docker build-arg values for a given backend."""
 
     pypi_base = configs.get("pypi_base", "")
+    pypi_daily = configs.get("pypi_daily", "")
     mirror = configs.get("mirror", "https://mirrors.aliyun.com/pypi/simple")
+
+    # Install spec: fold the per-vendor C++ operators extra into the FlagGems
+    # extras when the backend supports C++ (cmake_backend set). The C++ extra
+    # token is the cmake backend lowercased (CUDA -> cuda -> cpp-cuda), NOT the
+    # vendor name. The extras resolve flag_gems + flag-gems-cpp-<backend> wheels.
+    extras = backend_info.get("extras", "")
+    cpp_backend = str(backend_info.get("cmake_backend", "")).lower()
+    if cpp_backend:
+        extras_spec = f"{extras},cpp-{cpp_backend}" if extras else f"cpp-{cpp_backend}"
+    else:
+        extras_spec = extras
+
+    # Compiler: prefer flagtree (the blessed default); fall back to triton only
+    # when the backend has no flagtree entry (flagtree unsupported for it).
+    # A single compiler is baked; the flagtree<->triton switch is a later task.
+    flagtree = backend_info.get("flagtree", "")
+    triton = backend_info.get("triton", "")
+    if flagtree:
+        compiler, compiler_pkg = "flagtree", flagtree
+    elif triton:
+        compiler, compiler_pkg = "triton", triton
+    else:
+        compiler, compiler_pkg = "", ""
 
     args = {
         "BASE_IMAGE": base_image_override
         or resolve_base_image(vendor, backend, configs, repo_root),
         "PYTHON_VERSION": backend_info.get("python", "3.12"),
         "FLAGOS_PYPI": pypi_base.format(vendor=vendor) if pypi_base else "",
+        "DAILY_PYPI": pypi_daily,
         "EXTRA_PYPI": extra_pypi_override or mirror,
-        "EXTRAS_GROUP": backend_info.get("extras", ""),
-        "INCLUDE_TESTS": include_tests_override or "true",
+        "EXTRAS_GROUP": extras_spec,
+        "COMPILER": compiler,
+        "COMPILER_PKG": compiler_pkg,
+        "INCLUDE_TESTS": include_tests_override or "false",
     }
 
     # Optional triton-specific post-install packages from configs.yaml.
-    # These are only needed when using triton (not flagtree).
+    # Only relevant when the baked compiler is triton — skip under flagtree.
     triton_post = backend_info.get("triton_post_install", [])
-    if isinstance(triton_post, list) and triton_post:
+    if compiler == "triton" and isinstance(triton_post, list) and triton_post:
         pkgs = " ".join(triton_post)
         flagos_pypi = args["FLAGOS_PYPI"]
         extra_pypi = args["EXTRA_PYPI"]
@@ -189,7 +241,8 @@ def main():
     parser.add_argument(
         "--flaggems-dir",
         required=True,
-        help="Path to FlagGems source tree (used as the docker build context)",
+        help="Path to FlagGems source tree — used ONLY to derive the wheel "
+        "version (git describe); no longer the docker build context.",
     )
     parser.add_argument("--base-image", help="Override base image")
     parser.add_argument("--extra-pypi", help="Override extra PyPI mirror URL")
@@ -253,7 +306,10 @@ def main():
     cmd = ["docker", "build"]
     for key, value in build_args.items():
         cmd.extend(["--build-arg", f"{key}={value}"])
-    cmd.extend(["-f", str(containerfile), "-t", tag, str(flaggems_dir)])
+    # Wheel-based install: the image installs FlagGems from PyPI, so the build
+    # context no longer needs the FlagGems source tree (no COPY). Use runtime/
+    # as a trivial context. --flaggems-dir is kept only to derive the version.
+    cmd.extend(["-f", str(containerfile), "-t", tag, str(script_dir)])
 
     if args.dry_run:
         print("Would run:")


### PR DESCRIPTION
## What

Revise the runtime image build to install FlagGems from **prebuilt wheels** instead of from source, folding in the recipe validated by the nvidia-cuda13.3 end-to-end test (base → wheels → runtime → Harbor → cold-pull → GPU verify on H20).

Minimal, structure-preserving diff — the hand-tuned uv / multi-stage layout is kept; only what wheel-install requires changed.

## Changes

**`runtime/Containerfile`**
- Source install (`COPY . FlagGems` + `uv pip install ".[extras]"`, inline C++ compile) → wheel install:
  ```
  uv pip install flag_gems[<extras>,cpp-<backend>]==<ver> <compiler_pkg>
      --index-strategy unsafe-first-match --index <vendor> --index <daily>
  ```
- **Hermetic**: only `resource.flagos.net`; no external mirror in the FlagGems install path.
- **uv `unsafe-first-match`** so cross-index pinned deps (e.g. `PyYAML==6.0.1`) resolve from *either* FlagOS index — uv's default first-index strategy pins each package to one index and won't fall through.
- Dropped the C++ build-deps (scikit-build-core/pybind11/cmake/ninja) — no inline compile now.
- Bake `USE_C_EXTENSION=1` (the `flag-gems-cpp-<backend>` `.so` files need it) + `COMPILER`.

**`runtime/build.py`**
- Compiler: **flagtree** when the backend has a `flagtree:` entry, else **triton** (single compiler baked; the flagtree↔triton switch is a follow-up). `triton_post_install` now only fires under `COMPILER=triton`.
- cpp extra token = `cmake_backend` lowercased (CUDA→`cuda`→`cpp-cuda`), folded into `EXTRAS_GROUP`; omitted for backends without `cmake_backend`.
- **Fix `resolve_base_image`**: derive the base tag from build-infra `git describe` (the scheme `base/build.py` stamps) + registry from `build-config.yml`, instead of reading `version`/`revision` LABELs that #99 removed (was yielding a wrong `:latest-0`).
- Build context is now `runtime/` (no source COPY); `--flaggems-dir` kept only to derive the wheel version.

**`configs.yaml`** — add `pypi_daily` (the `flagos-pypi-daily` index).

## Verified

`--dry-run` across the fallback matrix:
- **nvidia-cuda13.3** → flagtree, `cpp-cuda`, both indexes, base tag `…/flagbase/flagos-base-nvidia-cuda13.3:<git-version>`
- **ascend** → flagtree, `cpp-npu`, triton_post correctly skipped
- **cambricon** → triton fallback, no cpp extra
- **metax** → flagtree, no cpp

## Not done here (follow-ups)

- **Real build verification on h20** is pending the base-image refresh to Harbor (the runtime `FROM`s `harbor.baai.ac.cn/flagbase/flagos-base-…`, which isn't pushed yet). Will also flush out whether `flagtree==0.6.0` is on the vendor index (the flagtree analogue of the PyYAML seeding round).
- **Tests** left out — FlagGems `[test]` is framework-only and wheel-install has no source tree to copy; deferred until FlagGems ships tests as package-data. Image explicitly **not finalized**.
- **flagtree↔triton switch** — separate task; a single compiler is baked for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
