### PR TITLE
docs(base): per-image descriptions (prereqs, baked versions, launch/verify)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -92,3 +92,21 @@ run:
     mthreads: "KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0"
     iluvatar: "ix-container-toolkit >= 1.1.0"
 
+# Device-enumeration command per vendor: shown in the docs/description sample
+# launch line (`docker run <run-flags> <image> <verify>`) to confirm the
+# accelerator is visible, and the eventual base-image release-gate check.
+# Vendors not listed fall back to `bash` in the sample.
+verify:
+  vendors:
+    nvidia: "nvidia-smi"
+    ascend: "npu-smi info"
+    metax: "mx-smi"
+    cambricon: "cnmon"
+    iluvatar: "ixsmi"
+    hygon: "hy-smi"
+    kunlunxin: "xpu-smi"
+    mthreads: "mthreads-gmi"
+    enflame: "efsmi"
+    sunrise: "pt_smi"
+    tsingmicro: "tsm-smi"
+

--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -1,0 +1,132 @@
+name: Base image descriptions
+
+# Post-build: capture the versions actually baked into each base image, compose a
+# per-image description markdown (single source for the docs site, the in-repo
+# base/<name>.md file, and the Harbor repository description), then commit + upload.
+#
+# Separate from the build (per the design): version extraction needs the built
+# image, and keeping this out of the build workflow keeps both simpler.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Released image tag to describe (e.g. 2.1.1). Blank = latest git tag.'
+        type: string
+        default: ''
+  workflow_run:
+    workflows: ["Base Image Build (manual)"]
+    types: [completed]
+
+permissions:
+  contents: write   # compose job commits the generated descriptions
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  set-matrix:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --user pyyaml
+      - id: m
+        run: |
+          python3 base/generate_matrix.py > matrix.json
+          echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+      - id: v
+        # Describe the released images: explicit input, else the latest tag.
+        run: |
+          ver="${{ inputs.version }}"
+          [ -n "$ver" ] || ver=$(git describe --tags --abbrev=0 | sed 's/^v//')
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          echo "describing image version: $ver"
+
+  extract:
+    needs: set-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    runs-on: ${{ fromJSON(matrix.runson) }}
+    env:
+      IMAGE_VERSION: ${{ needs.set-matrix.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Install PyYAML
+        run: |
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages pyyaml
+      - name: Harbor login (for image pull)
+        env:
+          HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
+        run: |
+          host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
+          printf '%s' "$HARBOR_PW" | docker login "$host" -u tengqm --password-stdin
+      - name: Extract baked-in system-package versions
+        run: |
+          python3 docs/gen_data.py
+          python3 docs/extract_versions.py "${{ matrix.name }}" versions
+      - uses: actions/upload-artifact@v4
+        with:
+          name: versions-${{ matrix.name }}
+          path: versions/${{ matrix.name }}.tsv
+          if-no-files-found: warn
+
+  compose:
+    needs: [set-matrix, extract]
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_VERSION: ${{ needs.set-matrix.outputs.version }}
+      HARBOR_HOST: harbor.baai.ac.cn
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --user pyyaml
+      - name: Download version artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: versions-dl
+          pattern: versions-*
+          merge-multiple: false
+      - name: Collect versions into one dir
+        run: |
+          mkdir -p versions
+          # each artifact is versions-dl/versions-<name>/<name>.tsv
+          find versions-dl -name '*.tsv' -exec cp {} versions/ \;
+          ls -1 versions/ || true
+      - name: Generate descriptions (with resolved versions)
+        run: |
+          python3 docs/gen_data.py
+          VERSIONS_DIR="$PWD/versions" python3 docs/gen_descriptions.py
+      - name: Refresh base/<name>.md symlinks
+        run: |
+          for md in docs/content/en/base/*.md; do
+            n=$(basename "$md" .md); [ "$n" = "_index" ] && continue
+            ln -sf "../docs/content/en/base/$n.md" "base/$n.md"
+          done
+      - name: Commit updated descriptions
+        run: |
+          git config user.name "flagos-ci"
+          git config user.email "noreply@flagos.net"
+          git add docs/content/en/base/*.md base/*.md
+          if git diff --cached --quiet; then
+            echo "no description changes"
+          else
+            git commit -m "docs(base): refresh image descriptions for ${IMAGE_VERSION}"
+            git push origin HEAD:${GITHUB_REF_NAME}
+          fi
+      - name: Upload descriptions to Harbor
+        env:
+          HARBOR_USER: tengqm
+          HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
+        run: python3 docs/upload_descriptions.py

--- a/base/ascend-cann8.5.0.md
+++ b/base/ascend-cann8.5.0.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/ascend-cann8.5.0.md

--- a/base/ascend-cann9.0.0.md
+++ b/base/ascend-cann9.0.0.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/ascend-cann9.0.0.md

--- a/base/cambricon-neuware4.4.3.md
+++ b/base/cambricon-neuware4.4.3.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/cambricon-neuware4.4.3.md

--- a/base/enflame-tops1.9.10.md
+++ b/base/enflame-tops1.9.10.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/enflame-tops1.9.10.md

--- a/base/hygon-dtk26.04.md
+++ b/base/hygon-dtk26.04.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/hygon-dtk26.04.md

--- a/base/iluvatar-corex4.4.0.md
+++ b/base/iluvatar-corex4.4.0.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/iluvatar-corex4.4.0.md

--- a/base/kunlunxin-xre5.29.0.md
+++ b/base/kunlunxin-xre5.29.0.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/kunlunxin-xre5.29.0.md

--- a/base/metax-maca3.7.2.1.md
+++ b/base/metax-maca3.7.2.1.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/metax-maca3.7.2.1.md

--- a/base/mthreads-musa4.3.6.md
+++ b/base/mthreads-musa4.3.6.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/mthreads-musa4.3.6.md

--- a/base/mthreads-musa5.2.0.md
+++ b/base/mthreads-musa5.2.0.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/mthreads-musa5.2.0.md

--- a/base/nvidia-cuda12.8.md
+++ b/base/nvidia-cuda12.8.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/nvidia-cuda12.8.md

--- a/base/nvidia-cuda13.3.md
+++ b/base/nvidia-cuda13.3.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/nvidia-cuda13.3.md

--- a/base/sunrise-tangrt1.2.0.md
+++ b/base/sunrise-tangrt1.2.0.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/sunrise-tangrt1.2.0.md

--- a/base/tsingmicro-tsm260604.md
+++ b/base/tsingmicro-tsm260604.md
@@ -1,0 +1,1 @@
+../docs/content/en/base/tsingmicro-tsm260604.md

--- a/configs.yaml
+++ b/configs.yaml
@@ -46,6 +46,7 @@ vendors:
   nvidia:
     cuda12.8:
       extras: nvidia-cuda128
+      hardware: ["NVIDIA H20"]   # TODO: add other validated NVIDIA GPUs
       python: "3.12"
       cmake_backend: CUDA
       triton: triton==3.6.0
@@ -66,6 +67,7 @@ vendors:
 
     cuda13.3:
       extras: nvidia-cuda133
+      hardware: ["NVIDIA H20"]   # TODO: add other validated NVIDIA GPUs
       python: "3.12"
       cmake_backend: CUDA
       triton: triton==3.6.0
@@ -87,6 +89,7 @@ vendors:
   ascend:
     cann8.5.0:
       extras: ascend-cann850
+      hardware: ["Ascend 910B"]   # TODO: confirm 910C
       python: "3.11"
       cmake_backend: NPU
       triton: triton-ascend==3.2.0
@@ -104,6 +107,7 @@ vendors:
 
     cann9.0.0:
       extras: ascend-cann900
+      hardware: ["Ascend 910B"]   # TODO: confirm 910C
       python: "3.11"
       cmake_backend: NPU
       triton: triton==3.5.0
@@ -125,6 +129,7 @@ vendors:
   cambricon:
     neuware4.4.3:
       extras: cambricon
+      hardware: ["Cambricon MLU590"]
       python: "3.10"
       triton: triton==3.2.0+mlu1.7.2
       env:
@@ -166,6 +171,7 @@ vendors:
   enflame:
     tops1.9.10:
       extras: enflame
+      hardware: ["Enflame Zixiao C200 (S60)"]
       python: "3.12"
       cmake_backend: GCU
       triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
@@ -192,6 +198,7 @@ vendors:
   hygon:
     dtk26.04:
       extras: hygon
+      hardware: ["Hygon BW1000"]
       python: "3.10"
       triton: triton==3.3.0+das.opt1.dtk2604.torch290
       flagtree: flagtree==0.5.1+hcu3.1
@@ -207,6 +214,7 @@ vendors:
   iluvatar:
     corex4.4.0:
       extras: iluvatar
+      hardware: ["Iluvatar BI-V150"]
       python: "3.10"
       cmake_backend: IX
       triton: triton==3.1.0+corex.4.4.0
@@ -227,6 +235,7 @@ vendors:
   kunlunxin:
     xre5.29.0:
       extras: kunlunxin
+      hardware: ["Kunlunxin P800"]
       python: "3.10"
       triton: triton==3.0.0+a48aedef
       flagtree: flagtree==0.5.1+xpu3.0
@@ -258,6 +267,7 @@ vendors:
   metax:
     maca3.7.2.1:
       extras: metax
+      hardware: ["MetaX C550"]
       python: "3.12"
       triton: triton==3.0.0+metax3.7.2.0
       flagtree: flagtree==3.1.0+metax3.7.2.0
@@ -278,6 +288,7 @@ vendors:
   mthreads:
     musa4.3.6:
       extras: mthreads-musa436
+      hardware: ["MThreads MTT S5000"]
       python: "3.10"
       cmake_backend: MUSA
       triton: triton==3.6.0+git89458660
@@ -301,6 +312,7 @@ vendors:
 
     musa5.2.0:
       extras: mthreads-musa520
+      hardware: ["MThreads MTT S5000"]
       python: "3.10"
       cmake_backend: MUSA
       triton: triton==3.6.0
@@ -335,6 +347,7 @@ vendors:
   sunrise:
     tangrt1.2.0:
       extras: sunrise
+      hardware: ["Sunrise SR-SUN-S2-X1"]
       python: "3.10"
       triton: triton==3.4.0.6+gite4f6d6e4
       # flagtree==0.4.0+sunrise3.4 — requires GLIBC_2.39, unavailable on current system
@@ -358,6 +371,7 @@ vendors:
   thead:
     ppu2.0.0:
       extras: thead
+      hardware: ["T-Head ZW810E"]
       python: "3.12"
       triton: triton==3.5.0+ppu2.0.0.oe
       env:
@@ -370,6 +384,7 @@ vendors:
   tsingmicro:
     tsm260604:
       extras: tsingmicro
+      hardware: ["Tsingmicro TX8110"]
       python: "3.10"
       triton: triton==3.3.0+gitfe2a28fa
       flagtree: flagtree==0.5.0.post20260612+git705a4064

--- a/docs/content/en/base/_content.gotmpl
+++ b/docs/content/en/base/_content.gotmpl
@@ -1,8 +1,0 @@
-{{ range site.Data.images.backends }}
-{{ $.AddPage (dict
-  "path" .name
-  "title" .name
-  "kind" "page"
-  "content" (dict "mediaType" "text/markdown" "value" (printf "{{< base-image name=%q >}}" .name))
-) }}
-{{ end }}

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -1,0 +1,50 @@
+---
+title: "ascend-cann8.5.0"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** aarch64
+- **Chip models:** Ascend 910B
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libpython3-dev`
+- `make`
+- `net-tools`
+- `pciutils`
+- `python3-pip`
+- `python3.11`
+- `python3.11-dev`
+- `unzip`
+
+## SDK components
+
+- CANN Toolkit 8.5.0 (aarch64)
+- CANN 910B Ops 8.5.0 (aarch64)
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+npu-smi info
+```

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -1,0 +1,51 @@
+---
+title: "ascend-cann9.0.0"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** aarch64
+- **Chip models:** Ascend 910B
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libpython3-dev`
+- `make`
+- `net-tools`
+- `pciutils`
+- `python3-pip`
+- `python3.11`
+- `python3.11-dev`
+- `unzip`
+
+## SDK components
+
+- CANN Toolkit 9.0.0 (aarch64)
+- CANN 910B Ops 9.0.0 (aarch64)
+- CANN NNAL 9.0.0 (aarch64)
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+npu-smi info
+```

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -1,0 +1,73 @@
+---
+title: "cambricon-neuware4.4.3"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Cambricon MLU590
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `gdb`
+- `libc6-dev-i386`
+- `libncurses5`
+- `libtinfo5`
+- `make`
+- `pciutils`
+- `unzip`
+
+## SDK components
+
+- cndev 6.5.25 (amd64)
+- cnmon 6.2.15
+- cnbin 2.4.2
+- cndrv 3.4.3
+- cnrt 7.4.0
+- cnrtc 0.7.4
+- cncc/cnas 5.4.3
+- cngdb 4.4.2
+- cnpapi 4.4.2
+- cnpx 1.6.0
+- cnperf 6.4.3
+- cnjpeg 0.5.1
+- cncodec3 2.4.1
+- cnsanitizer 0.12.3
+- cnnl+extra 2.1.829
+- mluops 1.8.1
+- cncl 1.29.4
+- cnstudio 1.2.1
+- cntoolkit 4.4.3
+- cntoolkit-cloud 4.4.3
+- cnclep 1.1.1.
+
+## Environment
+
+- `PATH=/usr/local/neuware/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/neuware/lib64`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl -v /usr/bin/cnmon:/usr/bin/cnmon harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+cnmon
+```

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -1,0 +1,50 @@
+---
+title: "enflame-tops1.9.10"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Enflame Zixiao C200 (S60)
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+
+## SDK components
+
+- Enflame driver 1.9.10
+- TOPS Runtime 1.9.10
+- TOPS CC 1.9.10
+- TOPS PTI 1.9.10
+- TOPSTX 1.9.10
+- TOPS ATen 3.7.20260514
+- EFML 1.9.10
+- ECCL 3.6.3.11
+- Triton GCU 3.6.0+1.0.20260521.cc.1.9.10
+- Gculare-perftest 1.9.10
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+efsmi
+```

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -1,0 +1,42 @@
+---
+title: "hygon-dtk26.04"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Hygon BW1000
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `pciutils`
+
+## SDK components
+
+- Hygon DTK 26.04
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --device /dev/kfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+hy-smi
+```

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -1,0 +1,49 @@
+---
+title: "iluvatar-corex4.4.0"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Iluvatar BI-V150
+- **Host container toolkit:** ix-container-toolkit >= 1.1.0
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `curl`
+- `g++`
+- `gcc`
+- `unzip`
+
+## SDK components
+
+- Corex Runtime 4.4.0
+- CUDA Header files 260604
+
+## Environment
+
+- `COREX_ROOT=/usr/local/corex`
+- `PATH=/usr/local/corex/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/corex/lib`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+ixsmi
+```

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -1,0 +1,50 @@
+---
+title: "kunlunxin-xre5.29.0"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Kunlunxin P800
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `kmod`
+- `pciutils`
+
+## SDK components
+
+- CUDA 12.9.0_575.51.03
+- XRE-CUDA12 5.29.0.0
+- XCUDART 5.13.0
+
+## Environment
+
+- `PATH=/usr/local/xpu/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/xpu/lib:/usr/local/xcudart/lib`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+xpu-smi
+```

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -1,0 +1,52 @@
+---
+title: "metax-maca3.7.2.1"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** MetaX C550
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libnuma1`
+- `libpython3-dev`
+- `make`
+
+## SDK components
+
+- MetaX Driver 3.7.2.30
+- MACA SDK 3.7.2.0
+
+## Environment
+
+- `PATH=/opt/maca/mxgpu_llvm/bin:/opt/maca/bin:${PATH}`
+- `MACA_PATH=/opt/maca`
+- `LD_LIBRARY_PATH=/opt/maca/lib:/opt/maca/mxgpu_llvm/lib`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+mx-smi
+```

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -1,0 +1,56 @@
+---
+title: "mthreads-musa4.3.6"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** MThreads MTT S5000
+- **Host container toolkit:** KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libgfortran5`
+- `libnuma-dev`
+- `libopenmpi-dev`
+- `libpython3-dev`
+- `openmpi-bin`
+
+## SDK components
+
+- MUSA Toolkits RC4.3.6
+- MCCL RC2.1.6
+- muDNN RC3.1.6
+
+## Environment
+
+- `MUSA_HOME=/usr/local/musa`
+- `PATH=/usr/local/musa/bin:${PATH}`
+- `LD_LIBRARY_PATH=/usr/local/musa/lib`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+mthreads-gmi
+```

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -1,0 +1,56 @@
+---
+title: "mthreads-musa5.2.0"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** MThreads MTT S5000
+- **Host container toolkit:** KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libgfortran5`
+- `libnuma-dev`
+- `libopenmpi-dev`
+- `libpython3-dev`
+- `openmpi-bin`
+
+## SDK components
+
+- MUSA Toolkits 5.2.0
+- MCCL 2.4.0
+- muDNN 3.4.0
+
+## Environment
+
+- `MUSA_HOME=/usr/local/musa`
+- `PATH=/usr/local/musa/bin:${PATH}`
+- `LD_LIBRARY_PATH=/usr/local/musa/lib`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+mthreads-gmi
+```

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -1,0 +1,51 @@
+---
+title: "nvidia-cuda12.8"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** NVIDIA H20
+- **Host container toolkit:** nvidia-container-toolkit
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libnuma1`
+- `libpython3-dev`
+- `make`
+
+## SDK components
+
+- CUDA 12.8 (x86_64)
+
+## Environment
+
+- `PATH=/usr/local/cuda/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+nvidia-smi
+```

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -1,0 +1,51 @@
+---
+title: "nvidia-cuda13.3"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** NVIDIA H20
+- **Host container toolkit:** nvidia-container-toolkit
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libnuma1`
+- `libpython3-dev`
+- `make`
+
+## SDK components
+
+- CUDA 13.3 (x86_64)
+
+## Environment
+
+- `PATH=/usr/local/cuda/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+nvidia-smi
+```

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -1,0 +1,51 @@
+---
+title: "sunrise-tangrt1.2.0"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Sunrise SR-SUN-S2-X1
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `pciutils`
+
+## SDK components
+
+- Tang Toolkit 1.2.0
+- PCCL 1.2.0
+- taDNN 1.2.0
+- taBLAS 1.2.0
+
+## Environment
+
+- `TANGRT_ROOT=/usr/local/tangrt`
+- `LIBRARY_PATH=/usr/local/tangrt/targets/linux-x86_64/lib:/usr/local/tangrt/lib/linux-x86_64`
+- `LD_LIBRARY_PATH=/usr/local/tangrt/targets/linux-x86_64/lib:/usr/local/tangrt/lib/linux-x86_64`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+pt_smi
+```

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -1,0 +1,64 @@
+---
+title: "tsingmicro-tsm260604"
+---
+
+`harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1`
+
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Tsingmicro TX8110
+
+## System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `clang`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libfmt-dev`
+- `libopenmpi3`
+- `libpython3-dev`
+- `libunwind8`
+- `sudo`
+
+## SDK components
+
+- TSM Runtime 260604163331
+- TSM Validation Suite 260604163331
+- TSM CCL 260604163331
+- TSM Profiler 260604163331
+- TX8 Compiler Dependencies 20260507
+- LLVM a66376b0
+
+## Environment
+
+- `KUIPER_PATH=/usr/local/kuiper`
+- `TX8_DEPS_ROOT=/usr/local/tx8_deps`
+- `LLVM_SYSPATH=/usr/local/llvm`
+- `PATH=/usr/local/kuiper/bin:${PATH}`
+- `LLVM_BINARY_DIR=/usr/local/llvm/bin`
+- `PYTHONPATH=/usr/local/llvm/python_packages/mlir_core`
+- `LD_LIBRARY_PATH=/usr/local/tx8_deps/lib:/usr/local/kuiper/lib:/usr/local/kuiper/tsm8-profiler/lib`
+- `USE_TORCH_XLA=0`
+- `TORCH_COMPILE_DISABLE=1`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it --privileged --ipc=host -v /dev:/dev -v /lib/modules:/lib/modules harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible (the first run may take a moment):
+
+```bash
+tsm-smi
+```

--- a/docs/extract_versions.py
+++ b/docs/extract_versions.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Extract the versions of a base image's explicitly-installed system packages,
+as actually baked into the built image, via dpkg-query inside the image.
+
+Writes <out-dir>/<name>.tsv with lines "package\tversion" (raw dpkg versions;
+gen_descriptions.py cleans them to upstream form). The image ref and the explicit
+package list both come from docs/data/images.yaml (run gen_data.py first).
+
+Usage: python docs/extract_versions.py <backend-name> <out-dir>
+Requires: docker able to run the image (auto-pulls if logged in and not cached).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("usage: extract_versions.py <backend-name> <out-dir>")
+    name, out_dir = sys.argv[1], Path(sys.argv[2])
+    root = Path(__file__).resolve().parent.parent
+    images = yaml.safe_load((root / "docs" / "data" / "images.yaml").read_text())
+    entry = next((b for b in images.get("backends", []) if b["name"] == name), None)
+    if not entry:
+        sys.exit(f"Error: '{name}' not in images.yaml")
+
+    image = entry["base"]["image"]
+    pkgs = entry["base"].get("system_packages") or []
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / f"{name}.tsv"
+
+    if not pkgs:
+        out.write_text("")
+        print(f"{name}: no explicit system packages")
+        return
+
+    # dpkg-query prints the found packages even when some are absent (it exits
+    # non-zero then) — capture stdout regardless.
+    cmd = [
+        "docker", "run", "--rm", image,
+        "dpkg-query", "-W", "-f=${Package}\t${Version}\n", *pkgs,
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    out.write_text(r.stdout)
+    n = len([l for l in r.stdout.splitlines() if "\t" in l])
+    print(f"{name}: {n}/{len(pkgs)} package versions from {image}")
+    if r.returncode != 0 and n == 0:
+        # A real failure (image unrunnable / not dpkg-based), not just a missing pkg.
+        sys.stderr.write(r.stderr)
+        sys.exit(f"Error: extraction produced no versions for {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -15,6 +15,7 @@ Each entry has a `base` section (from the containerfile) and a `runtime`
 section (the software stack from configs.yaml).
 """
 
+import os
 import re
 import subprocess
 import sys
@@ -31,12 +32,16 @@ def find_repo_root() -> Path:
 
 
 def git_version(repo_root: Path) -> str:
-    """Release version from the build-infra Git tag (`git describe --tags`).
+    """Release version for the image tags.
 
-    Matches base/build.py: "v2.1.0" -> "2.1.0", commits after -> "2.1.0-3-gsha".
-    Falls back to "latest" when no tag is reachable (e.g. a shallow checkout —
-    the docs workflow uses fetch-depth: 0).
+    An explicit IMAGE_VERSION env wins (the descriptions workflow feeds the
+    released tag so refs match the pushed images even when main has advanced
+    past the tag). Otherwise `git describe --tags`, matching base/build.py:
+    "v2.1.0" -> "2.1.0", commits after -> "2.1.0-3-gsha". Falls back to "latest".
     """
+    override = os.environ.get("IMAGE_VERSION")
+    if override:
+        return override.lstrip("v")
     try:
         r = subprocess.run(
             ["git", "describe", "--tags", "--always"],
@@ -189,6 +194,7 @@ def main():
     run_default = run_cfg.get("default", "")
     run_vendors = run_cfg.get("vendors") or {}
     run_prereq = run_cfg.get("prereq") or {}
+    verify_vendors = (build_config.get("verify") or {}).get("vendors") or {}
 
     def image(prefix, kind, name, tag):
         base = f"flagos-{kind}-{name}"
@@ -204,6 +210,10 @@ def main():
                 continue  # not buildable — no base image
             meta = parse_containerfile(cf, {"PYTHON_VERSION": spec.get("python", "")})
             env = spec.get("env") or {}
+            sdk = spec.get("sdk") or []
+            # Architecture from the SDK notes (they embed the target arch).
+            sdk_blob = " ".join(sdk).lower()
+            arch = "aarch64" if ("aarch64" in sdk_blob or "arm64" in sdk_blob) else "x86_64"
 
             backends.append(
                 {
@@ -212,11 +222,14 @@ def main():
                     "backend": backend,
                     "run": run_vendors.get(vendor, run_default),
                     "run_prereq": run_prereq.get(vendor, ""),
+                    "verify": verify_vendors.get(vendor, ""),
                     "base": {
                         "image": image(base_prefix, "base", name, version),
                         "os": meta["base_os"] or "",
+                        "arch": arch,
+                        "hardware": spec.get("hardware") or [],
                         "system_packages": meta["system_packages"],
-                        "sdk": spec.get("sdk") or [],
+                        "sdk": sdk,
                         "env": env.get("base") or {},
                     },
                     "runtime": {

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Generate a per-image description markdown — the single source rendered by the
+docs site, committed as an in-repo maintainer file, and pushed as the Harbor
+repository description.
+
+It combines STATIC data from docs/data/images.yaml (architecture, chip models,
+container toolkit, SDK components, env, launch command) with the RESOLVED
+system-package versions actually baked into the built image. Those versions come
+from a per-backend TSV (`<name>.tsv`, lines "package\tversion") produced in CI by
+`dpkg-query` inside the image — see .github/workflows/base-descriptions.yml.
+
+The body starts at H2 (no H1): Hugo supplies the page title from the front
+matter, and Harbor shows the repository name as the top heading — so the same
+body reads correctly in both once the front matter is stripped for Harbor.
+
+Usage:
+  python docs/gen_descriptions.py                    # all -> docs/content/en/base/<name>.md
+  python docs/gen_descriptions.py nvidia-cuda13.3    # one -> stdout
+  VERSIONS_DIR=/path python docs/gen_descriptions.py # resolve versions from <dir>/<name>.tsv
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def repo_root() -> Path:
+    d = Path(__file__).resolve().parent.parent
+    if (d / "configs.yaml").is_file():
+        return d
+    sys.exit("Error: cannot locate repository root")
+
+
+def clean_version(v: str) -> str:
+    """Debian version -> upstream version users recognise.
+
+    Strip the epoch ("4:") and the Debian/Ubuntu revision ("-1ubuntu1") — both
+    are packaging bookkeeping. "4:11.2.0-1ubuntu1" -> "11.2.0". Native packages
+    (no "-") keep their version as-is.
+    """
+    if ":" in v:
+        v = v.split(":", 1)[1]
+    if "-" in v:
+        v = v.rsplit("-", 1)[0]
+    return v
+
+
+def load_versions(versions_dir: Path | None, name: str) -> dict:
+    """package -> baked upstream version, from <versions_dir>/<name>.tsv."""
+    if not versions_dir:
+        return {}
+    f = versions_dir / f"{name}.tsv"
+    if not f.is_file():
+        return {}
+    out = {}
+    for line in f.read_text().splitlines():
+        if "\t" in line:
+            pkg, ver = line.split("\t", 1)
+            out[pkg.strip()] = clean_version(ver.strip())
+    return out
+
+
+def render(entry: dict, versions: dict) -> str:
+    """Compose the description markdown for one backend."""
+    base = entry["base"]
+    name = entry["name"]
+    lines: list[str] = []
+
+    # Hugo front matter (docs title/ordering). Stripped before Harbor upload.
+    lines += ["---", f'title: "{name}"', "---", ""]
+
+    lines += [f"`{base['image']}`", ""]
+
+    # ── Prerequisites ────────────────────────────────────────────
+    lines += ["## Prerequisites", ""]
+    lines.append(f"- **Architecture:** {base.get('arch', '')}")
+    hw = base.get("hardware") or []
+    if hw:
+        lines.append(f"- **Chip models:** {', '.join(hw)}")
+    toolkit = entry.get("run_prereq") or ""
+    if toolkit:
+        lines.append(f"- **Host container toolkit:** {toolkit}")
+    lines.append("")
+
+    # ── System packages (explicit apt, with baked-in versions) ──
+    pkgs = base.get("system_packages") or []
+    if pkgs:
+        lines += ["## System packages", ""]
+        lines += ["Explicitly installed; the version is the one baked into this image:", ""]
+        for p in sorted(pkgs):
+            ver = versions.get(p)
+            lines.append(f"- `{p}` — {ver}" if ver else f"- `{p}`")
+        lines.append("")
+
+    # ── SDK components (already versioned in configs) ───────────
+    sdk = base.get("sdk") or []
+    if sdk:
+        lines += ["## SDK components", ""]
+        for s in sdk:
+            lines.append(f"- {s}")
+        lines.append("")
+
+    # ── Environment ─────────────────────────────────────────────
+    env = base.get("env") or {}
+    if env:
+        lines += ["## Environment", ""]
+        for k, v in env.items():
+            lines.append(f"- `{k}={v}`")
+        lines.append("")
+
+    # ── Launch ──────────────────────────────────────────────────
+    run_flags = entry.get("run") or ""
+    flags = f"{run_flags} " if run_flags else ""
+    lines += ["## Launch", ""]
+    lines += ["Start an interactive shell in the container:", ""]
+    lines += ["```bash", f"docker run --rm -it {flags}{base['image']} bash", "```", ""]
+
+    # ── Verify ──────────────────────────────────────────────────
+    # Shown as a SEPARATE command to run INSIDE the launched container (not
+    # folded into the `docker run` line): some vendor runtimes take a moment or
+    # hang on the first container start, so users run the device check on its
+    # own and can retry it independently.
+    verify = entry.get("verify")
+    if verify:
+        lines += ["## Verify", ""]
+        lines += [
+            "Inside the container, confirm the accelerator is visible "
+            "(the first run may take a moment):",
+            "",
+        ]
+        lines += ["```bash", verify, "```", ""]
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main():
+    root = repo_root()
+    images = yaml.safe_load((root / "docs" / "data" / "images.yaml").read_text())
+    backends = {b["name"]: b for b in images.get("backends", [])}
+
+    vdir = os.environ.get("VERSIONS_DIR")
+    versions_dir = Path(vdir).resolve() if vdir else None
+
+    requested = sys.argv[1:]
+    if requested:
+        for name in requested:
+            if name not in backends:
+                sys.exit(f"Error: '{name}' not in images.yaml")
+            print(render(backends[name], load_versions(versions_dir, name)))
+        return
+
+    out_dir = root / "docs" / "content" / "en" / "base"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name, entry in backends.items():
+        md = render(entry, load_versions(versions_dir, name))
+        (out_dir / f"{name}.md").write_text(md)
+    print(f"Wrote {len(backends)} descriptions to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/upload_descriptions.py
+++ b/docs/upload_descriptions.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Push each generated base-image description to Harbor as the repository
+description. Strips the Hugo front matter — Harbor renders the description as
+markdown and shows the repository name as the top heading, so the H2-based body
+reads correctly on its own.
+
+Reads the generated markdown from docs/content/en/base/<name>.md for every
+backend in docs/data/images.yaml. The repository is flagos-base-<name> under the
+project taken from the image ref.
+
+Env: HARBOR_HOST, HARBOR_USER, HARBOR_PW (basic auth).
+Usage: python docs/upload_descriptions.py [--dry-run]
+"""
+
+import base64
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+
+def strip_front_matter(md: str) -> str:
+    if md.startswith("---"):
+        end = md.find("\n---", 3)
+        if end != -1:
+            md = md[end + 4:]
+    return md.lstrip("\n")
+
+
+def project_of(image_ref: str) -> str:
+    # harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1 -> flagos-base
+    path = image_ref.split("/", 1)[1] if "/" in image_ref else image_ref
+    return path.split("/", 1)[0]
+
+
+def main():
+    dry = "--dry-run" in sys.argv[1:]
+    host = os.environ["HARBOR_HOST"]
+    user = os.environ.get("HARBOR_USER", "")
+    pw = os.environ.get("HARBOR_PW", "")
+    auth = "Basic " + base64.b64encode(f"{user}:{pw}".encode()).decode()
+
+    root = Path(__file__).resolve().parent.parent
+    images = yaml.safe_load((root / "docs" / "data" / "images.yaml").read_text())
+    base_dir = root / "docs" / "content" / "en" / "base"
+
+    failures = 0
+    for entry in images.get("backends", []):
+        name = entry["name"]
+        md_path = base_dir / f"{name}.md"
+        if not md_path.is_file():
+            print(f"skip {name}: no description md")
+            continue
+        desc = strip_front_matter(md_path.read_text())
+        project = project_of(entry["base"]["image"])
+        repo = f"flagos-base-{name}"
+        url = f"https://{host}/api/v2.0/projects/{project}/repositories/{repo}"
+        if dry:
+            print(f"[dry-run] PUT {url}  ({len(desc)} chars)")
+            continue
+        body = json.dumps({"description": desc}).encode()
+        req = urllib.request.Request(url, data=body, method="PUT")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Authorization", auth)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                print(f"OK {repo}: http={r.status}")
+        except urllib.error.HTTPError as e:
+            print(f"FAIL {repo}: http={e.code} {e.read().decode()[:200]}")
+            failures += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"FAIL {repo}: {e}")
+            failures += 1
+
+    if failures:
+        sys.exit(f"{failures} description upload(s) failed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Generate a per-image **description markdown** for every base image — one source rendered three ways:
- the **docs site** per-image page (web visitors),
- an **in-repo** `base/<name>.md` file (maintainers track changes via `git diff`),
- the **Harbor repository description** (registry browsers).

Each description exposes: **prerequisites** (architecture, chip models, host container toolkit), the **explicitly-installed system packages with the versions actually baked into the built image**, **SDK components**, **environment**, a **Launch** command, and a separate **Verify** command.

## The point: baked-in versions

The containerfile says `apt-get install gcc` — unversioned. The value ("a sudden gcc upgrade broke the toolchain") requires the **resolved version from the built image**, captured via `dpkg-query`. So a gcc bump surfaces as a one-line `git diff` in the committed description. Versions are cleaned to upstream form (`4:11.2.0-1ubuntu1` → `11.2.0`).

## Pieces

- **`configs.yaml`** — `hardware:` (chip models) per backend (all 14 filled).
- **`.github/build-config.yml`** — `verify:` (device-enumeration command) per vendor.
- **`docs/gen_data.py`** — expose `arch`/`hardware`/`verify`; `IMAGE_VERSION` override so descriptions pin the **released tag** (`2.1.1`), not a drifted `git describe`.
- **`docs/gen_descriptions.py`** — compose the markdown. Front matter for Hugo; body starts at H2 so Harbor shows the repo name as the heading (no H1→H2 demotion needed). **Launch** = interactive `bash`; **Verify** = a *separate* command run **inside** the container (some vendor runtimes hang on first start — keep the device check independent).
- **`docs/extract_versions.py`** — `dpkg-query` the explicit packages inside the image.
- **`docs/upload_descriptions.py`** — PUT each description to Harbor (strips front matter).
- **Docs** — English base pages render the generated `.md` (single source); the content adapter is removed. `base/<name>.md` symlinks point at the docs md.
- **`.github/workflows/base-descriptions.yml`** — separate post-build workflow (`workflow_run` after the base build + `workflow_dispatch`): `extract` (h20/cann850 matrix, dpkg-query → version artifacts) → `compose` (generate, commit, Harbor upload).

## Verified locally

Generator output, `hugo build` (52 EN / 51 ZH pages, base pages render Prerequisites/System-packages/Launch/Verify), symlinks stored as symlinks (mode 120000), Harbor upload `--dry-run`.

## Not done here

The **workflow needs a real run** to shake out (image pull + `dpkg-query` on the runners, the commit-back, and live Harbor PUTs) — same as the base build did. Chip models are the maintainer-provided real values; `verify` commands confirmed per vendor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
