### PR TITLE
ci(descriptions): gate Harbor publication on PR merge (option B)

### DIFF
--- a/.github/workflows/base-descriptions-publish.yml
+++ b/.github/workflows/base-descriptions-publish.yml
@@ -1,0 +1,34 @@
+name: Publish base descriptions to Harbor
+
+# Publication is gated on review+merge (Option B): when reviewed per-image
+# descriptions land on main (a base-descriptions PR merged), push them to the
+# Harbor repository descriptions. Nothing goes live until the version diff — the
+# checkpoint for catching a disruptive change (e.g. a toolchain gcc bump) — has
+# been reviewed and merged.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/content/en/base/**'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      HARBOR_HOST: harbor.baai.ac.cn
+      HARBOR_USER: tengqm
+      HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --user pyyaml
+      - name: Build the image list
+        run: python3 docs/gen_data.py
+      - name: Upload descriptions to Harbor
+        run: python3 docs/upload_descriptions.py

--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -89,7 +89,6 @@ jobs:
       pull-requests: write
     env:
       IMAGE_VERSION: ${{ needs.set-matrix.outputs.version }}
-      HARBOR_HOST: harbor.baai.ac.cn
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
@@ -119,16 +118,9 @@ jobs:
             ln -sf "../docs/content/en/base/$n.md" "base/$n.md"
           done
 
-      # Publish to Harbor FIRST — it needs no git write, so descriptions go live
-      # regardless of how the PR/merge side goes.
-      - name: Upload descriptions to Harbor
-        env:
-          HARBOR_USER: tengqm
-          HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
-        run: python3 docs/upload_descriptions.py
-
-      # main requires a PR (repository ruleset) — open one and auto-merge instead
-      # of pushing directly. The version diff is then reviewable per refresh.
+      # Open a PR with the version-enriched descriptions and enable auto-merge.
+      # Publication (docs + Harbor) is gated on this PR merging — see
+      # base-descriptions-publish.yml. The version diff is the review checkpoint.
       - name: Open descriptions PR (auto-merge)
         run: |
           git config user.name "flagos-ci"
@@ -144,7 +136,7 @@ jobs:
           if ! gh pr view "$branch" >/dev/null 2>&1; then
             gh pr create --base "${GITHUB_REF_NAME}" --head "$branch" \
               --title "docs(base): refresh image descriptions for ${IMAGE_VERSION}" \
-              --body "Automated refresh of per-image descriptions (baked-in system-package versions) for ${IMAGE_VERSION}. Descriptions already pushed to Harbor."
+              --body "Automated refresh of per-image descriptions (baked-in system-package versions) for ${IMAGE_VERSION}. On merge, the descriptions publish to the docs site and Harbor."
           fi
           gh pr merge "$branch" --auto --squash || \
-            echo "auto-merge not enabled or blocked — PR left open for review"
+            echo "auto-merge queued/unavailable — PR left for review"


### PR DESCRIPTION
Hold description publication until the PR merges. compose only opens the PR (version diff = review checkpoint for disruptive drift); a new publish-on-merge workflow uploads to Harbor when the reviewed descriptions land on main.