### PR TITLE
docs(base): add base operating system to image descriptions

### DIFF
--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -2,7 +2,9 @@
 title: "ascend-cann8.5.0"
 ---
 
-Base image: `ubuntu:22.04`
+## Base image
+
+`ubuntu:22.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -2,8 +2,6 @@
 title: "ascend-cann8.5.0"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1`
-
 Base image: `ubuntu:22.04`
 
 ## Prerequisites

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -6,6 +6,7 @@ title: "ascend-cann8.5.0"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:22.04`
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
 

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -4,9 +4,10 @@ title: "ascend-cann8.5.0"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1`
 
+Base image: `ubuntu:22.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:22.04`
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
 

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -2,8 +2,6 @@
 title: "ascend-cann9.0.0"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1`
-
 Base image: `ubuntu:22.04`
 
 ## Prerequisites

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -6,6 +6,7 @@ title: "ascend-cann9.0.0"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:22.04`
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
 

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -2,7 +2,9 @@
 title: "ascend-cann9.0.0"
 ---
 
-Base image: `ubuntu:22.04`
+## Base image
+
+`ubuntu:22.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -4,9 +4,10 @@ title: "ascend-cann9.0.0"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1`
 
+Base image: `ubuntu:22.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:22.04`
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
 

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -4,9 +4,10 @@ title: "cambricon-neuware4.4.3"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1`
 
+Base image: `ubuntu:22.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** Cambricon MLU590
 

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -2,8 +2,6 @@
 title: "cambricon-neuware4.4.3"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1`
-
 Base image: `ubuntu:22.04`
 
 ## Prerequisites

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -6,6 +6,7 @@ title: "cambricon-neuware4.4.3"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** Cambricon MLU590
 

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -2,7 +2,9 @@
 title: "cambricon-neuware4.4.3"
 ---
 
-Base image: `ubuntu:22.04`
+## Base image
+
+`ubuntu:22.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -2,8 +2,6 @@
 title: "enflame-tops1.9.10"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1`
-
 Base image: `ubuntu:24.04`
 
 ## Prerequisites

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -6,6 +6,7 @@ title: "enflame-tops1.9.10"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:24.04`
 - **Architecture:** x86_64
 - **Chip models:** Enflame Zixiao C200 (S60)
 

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -2,7 +2,9 @@
 title: "enflame-tops1.9.10"
 ---
 
-Base image: `ubuntu:24.04`
+## Base image
+
+`ubuntu:24.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -4,9 +4,10 @@ title: "enflame-tops1.9.10"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1`
 
+Base image: `ubuntu:24.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:24.04`
 - **Architecture:** x86_64
 - **Chip models:** Enflame Zixiao C200 (S60)
 

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -4,9 +4,10 @@ title: "hygon-dtk26.04"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1`
 
+Base image: `ubuntu:22.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** Hygon BW1000
 

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -2,8 +2,6 @@
 title: "hygon-dtk26.04"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1`
-
 Base image: `ubuntu:22.04`
 
 ## Prerequisites

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -2,7 +2,9 @@
 title: "hygon-dtk26.04"
 ---
 
-Base image: `ubuntu:22.04`
+## Base image
+
+`ubuntu:22.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -6,6 +6,7 @@ title: "hygon-dtk26.04"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** Hygon BW1000
 

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -4,9 +4,10 @@ title: "iluvatar-corex4.4.0"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1`
 
+Base image: `ubuntu:24.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:24.04`
 - **Architecture:** x86_64
 - **Chip models:** Iluvatar BI-V150
 - **Host container toolkit:** ix-container-toolkit >= 1.1.0

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -2,7 +2,9 @@
 title: "iluvatar-corex4.4.0"
 ---
 
-Base image: `ubuntu:24.04`
+## Base image
+
+`ubuntu:24.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -6,6 +6,7 @@ title: "iluvatar-corex4.4.0"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:24.04`
 - **Architecture:** x86_64
 - **Chip models:** Iluvatar BI-V150
 - **Host container toolkit:** ix-container-toolkit >= 1.1.0

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -2,8 +2,6 @@
 title: "iluvatar-corex4.4.0"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1`
-
 Base image: `ubuntu:24.04`
 
 ## Prerequisites

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -2,8 +2,6 @@
 title: "kunlunxin-xre5.29.0"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1`
-
 Base image: `ubuntu:22.04`
 
 ## Prerequisites

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -4,9 +4,10 @@ title: "kunlunxin-xre5.29.0"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1`
 
+Base image: `ubuntu:22.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** Kunlunxin P800
 

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -6,6 +6,7 @@ title: "kunlunxin-xre5.29.0"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** Kunlunxin P800
 

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -2,7 +2,9 @@
 title: "kunlunxin-xre5.29.0"
 ---
 
-Base image: `ubuntu:22.04`
+## Base image
+
+`ubuntu:22.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -4,9 +4,10 @@ title: "metax-maca3.7.2.1"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1`
 
+Base image: `ubuntu:24.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:24.04`
 - **Architecture:** x86_64
 - **Chip models:** MetaX C550
 

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -6,6 +6,7 @@ title: "metax-maca3.7.2.1"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:24.04`
 - **Architecture:** x86_64
 - **Chip models:** MetaX C550
 

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -2,8 +2,6 @@
 title: "metax-maca3.7.2.1"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1`
-
 Base image: `ubuntu:24.04`
 
 ## Prerequisites

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -2,7 +2,9 @@
 title: "metax-maca3.7.2.1"
 ---
 
-Base image: `ubuntu:24.04`
+## Base image
+
+`ubuntu:24.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -2,7 +2,9 @@
 title: "mthreads-musa4.3.6"
 ---
 
-Base image: `ubuntu:22.04`
+## Base image
+
+`ubuntu:22.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -6,6 +6,7 @@ title: "mthreads-musa4.3.6"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
 - **Host container toolkit:** KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -2,8 +2,6 @@
 title: "mthreads-musa4.3.6"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1`
-
 Base image: `ubuntu:22.04`
 
 ## Prerequisites

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -4,9 +4,10 @@ title: "mthreads-musa4.3.6"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1`
 
+Base image: `ubuntu:22.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
 - **Host container toolkit:** KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -6,6 +6,7 @@ title: "mthreads-musa5.2.0"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
 - **Host container toolkit:** KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -4,9 +4,10 @@ title: "mthreads-musa5.2.0"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1`
 
+Base image: `ubuntu:22.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
 - **Host container toolkit:** KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -2,7 +2,9 @@
 title: "mthreads-musa5.2.0"
 ---
 
-Base image: `ubuntu:22.04`
+## Base image
+
+`ubuntu:22.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -2,8 +2,6 @@
 title: "mthreads-musa5.2.0"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1`
-
 Base image: `ubuntu:22.04`
 
 ## Prerequisites

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -6,6 +6,7 @@ title: "nvidia-cuda12.8"
 
 ## Prerequisites
 
+- **Operating system:** `nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04`
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
 - **Host container toolkit:** nvidia-container-toolkit

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -4,9 +4,10 @@ title: "nvidia-cuda12.8"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1`
 
+Base image: `nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04`
+
 ## Prerequisites
 
-- **Operating system:** `nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04`
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
 - **Host container toolkit:** nvidia-container-toolkit

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -2,7 +2,9 @@
 title: "nvidia-cuda12.8"
 ---
 
-Base image: `nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04`
+## Base image
+
+`nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -2,8 +2,6 @@
 title: "nvidia-cuda12.8"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1`
-
 Base image: `nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04`
 
 ## Prerequisites

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -2,8 +2,6 @@
 title: "nvidia-cuda13.3"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1`
-
 Base image: `nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04`
 
 ## Prerequisites

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -4,9 +4,10 @@ title: "nvidia-cuda13.3"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1`
 
+Base image: `nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04`
+
 ## Prerequisites
 
-- **Operating system:** `nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04`
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
 - **Host container toolkit:** nvidia-container-toolkit

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -6,6 +6,7 @@ title: "nvidia-cuda13.3"
 
 ## Prerequisites
 
+- **Operating system:** `nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04`
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
 - **Host container toolkit:** nvidia-container-toolkit

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -2,7 +2,9 @@
 title: "nvidia-cuda13.3"
 ---
 
-Base image: `nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04`
+## Base image
+
+`nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -2,8 +2,6 @@
 title: "sunrise-tangrt1.2.0"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1`
-
 Base image: `ubuntu:24.04`
 
 ## Prerequisites

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -4,9 +4,10 @@ title: "sunrise-tangrt1.2.0"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1`
 
+Base image: `ubuntu:24.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:24.04`
 - **Architecture:** x86_64
 - **Chip models:** Sunrise SR-SUN-S2-X1
 

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -2,7 +2,9 @@
 title: "sunrise-tangrt1.2.0"
 ---
 
-Base image: `ubuntu:24.04`
+## Base image
+
+`ubuntu:24.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -6,6 +6,7 @@ title: "sunrise-tangrt1.2.0"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:24.04`
 - **Architecture:** x86_64
 - **Chip models:** Sunrise SR-SUN-S2-X1
 

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -2,7 +2,9 @@
 title: "tsingmicro-tsm260604"
 ---
 
-Base image: `ubuntu:22.04`
+## Base image
+
+`ubuntu:22.04`
 
 ## Prerequisites
 

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -2,8 +2,6 @@
 title: "tsingmicro-tsm260604"
 ---
 
-`harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1`
-
 Base image: `ubuntu:22.04`
 
 ## Prerequisites

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -4,9 +4,10 @@ title: "tsingmicro-tsm260604"
 
 `harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1`
 
+Base image: `ubuntu:22.04`
+
 ## Prerequisites
 
-- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** Tsingmicro TX8110
 

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -6,6 +6,7 @@ title: "tsingmicro-tsm260604"
 
 ## Prerequisites
 
+- **Operating system:** `ubuntu:22.04`
 - **Architecture:** x86_64
 - **Chip models:** Tsingmicro TX8110
 

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -73,10 +73,12 @@ def render(entry: dict, versions: dict) -> str:
 
     lines += [f"`{base['image']}`", ""]
 
+    # Base OS of the container (a fact about the image, not a host prerequisite).
+    if base.get("os"):
+        lines += [f"Base image: `{base['os']}`", ""]
+
     # ── Prerequisites ────────────────────────────────────────────
     lines += ["## Prerequisites", ""]
-    if base.get("os"):
-        lines.append(f"- **Operating system:** `{base['os']}`")
     lines.append(f"- **Architecture:** {base.get('arch', '')}")
     hw = base.get("hardware") or []
     if hw:

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -71,8 +71,6 @@ def render(entry: dict, versions: dict) -> str:
     # Hugo front matter (docs title/ordering). Stripped before Harbor upload.
     lines += ["---", f'title: "{name}"', "---", ""]
 
-    lines += [f"`{base['image']}`", ""]
-
     # Base OS of the container (a fact about the image, not a host prerequisite).
     if base.get("os"):
         lines += [f"Base image: `{base['os']}`", ""]

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -71,9 +71,10 @@ def render(entry: dict, versions: dict) -> str:
     # Hugo front matter (docs title/ordering). Stripped before Harbor upload.
     lines += ["---", f'title: "{name}"', "---", ""]
 
-    # Base OS of the container (a fact about the image, not a host prerequisite).
+    # Base OS of the container, as its own section (a fact about the image, not
+    # a host prerequisite — and not a floating line above the first heading).
     if base.get("os"):
-        lines += [f"Base image: `{base['os']}`", ""]
+        lines += ["## Base image", "", f"`{base['os']}`", ""]
 
     # ── Prerequisites ────────────────────────────────────────────
     lines += ["## Prerequisites", ""]

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -75,6 +75,8 @@ def render(entry: dict, versions: dict) -> str:
 
     # ── Prerequisites ────────────────────────────────────────────
     lines += ["## Prerequisites", ""]
+    if base.get("os"):
+        lines.append(f"- **Operating system:** `{base['os']}`")
     lines.append(f"- **Architecture:** {base.get('arch', '')}")
     hw = base.get("hardware") or []
     if hw:


### PR DESCRIPTION
Render the base OS (FROM) as the first Prerequisites line — it was extracted but never shown. Surfaces OS-level constraints (e.g. ubuntu:22.04's old libstdc++ vs flagtree's C++ runtime needs). Versions preserved; only the OS line added.