### PR TITLE
Bump Hygon base image ubuntu:22.04 → 24.04 (flagtree libstdc++)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -60,9 +60,13 @@ run:
     metax: "--device /dev/mxcd --device /dev/dri --group-add video"
     # DOC: Ascend passthrough; npu-smi + driver are host-provided → bind-mount
     ascend: "--device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi"
-    # DOC + maintainer: hygon DCU is ROCm/HIP-based → kfd + dri; also needs the
-    # host /opt/hyhal mounted (maintainer-confirmed; exact purpose TBD)
-    hygon: "--device /dev/kfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined"
+    # VERIFIED on hygon25 (8x DCU): hygon is ROCm/HIP-based → needs BOTH kfd nodes
+    # (/dev/kfd major 501 + /dev/mkfd major 500) plus /dev/dri, and the host
+    # /opt/hyhal mounted. /dev/kfd alone enumerates devices (temp/vram) but hy-smi
+    # then errors "Open mkfd failed" and power/perf read N/A — /dev/mkfd carries that
+    # telemetry. With both, hy-smi shows full readings under these confined flags (no
+    # privileged needed).
+    hygon: "--device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined"
     # DOC: Cambricon MLU device + control node; cnmon is host-provided → mount
     cambricon: "--device /dev/cambricon_dev0 --device /dev/cambricon_ctl -v /usr/bin/cnmon:/usr/bin/cnmon"
     # DOC + maintainer: Kunlunxin XPU device + control node; xpu-smi is baked in
@@ -106,7 +110,9 @@ verify:
     metax: "mx-smi"
     cambricon: "cnmon"
     iluvatar: "ixsmi"
-    hygon: "hy-smi"
+    # VERIFIED on hygon25: hy-smi lives at /opt/dtk-26.04/.hyhal/bin/hy-smi and is
+    # only on PATH after sourcing the DTK env (not flattened into ENV yet).
+    hygon: "source /opt/dtk-26.04/env.sh && hy-smi"
     kunlunxin: "xpu-smi"
     mthreads: "mthreads-gmi"
     enflame: "efsmi"

--- a/base/hygon-dtk26.04
+++ b/base/hygon-dtk26.04
@@ -1,15 +1,20 @@
 # ============================================================
-# Base image for Hygon DTK 26.04 on Ubuntu 22.04
+# Base image for Hygon DTK 26.04 on Ubuntu 24.04
 # ============================================================
 # History:
 # - 20260607: Initial version, DTK 26.04 only support Ubuntu 22.04
+# - 20260716: Bump base OS 22.04 -> 24.04 for flagtree (needs newer libstdc++).
+#   Hygon has no Ubuntu-24.04 DTK release, so we keep the Ubuntu-22.04 DTK build:
+#   22.04 binaries link older glibc/libstdc++ and run on 24.04's newer libs
+#   (forward-compatible), while the 24.04 base satisfies flagtree's GLIBCXX floor.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG FILE_STORE=https://resource.flagos.net/repository/flagos-filestore
+# No Ubuntu-24.04 DTK yet — the 22.04 build runs on 24.04 (see header note).
 ARG SDK_PACKAGE=DTK-26.04-Ubuntu22.04-x86_64.tar.gz
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/base/hygon-dtk26.04
+++ b/base/hygon-dtk26.04
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Install DTK ────────────────────────────────────────────────
-RUN curl -o /dtk.tar.gz ${FILE_STORE}/hygon/${SDK_PACKAGE} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /dtk.tar.gz ${FILE_STORE}/hygon/${SDK_PACKAGE} \
     && tar xzf /dtk.tar.gz -C /opt \
     && rm /dtk.tar.gz
 


### PR DESCRIPTION
Closes #112.

## What
Bump the Hygon base image from `ubuntu:22.04` to `ubuntu:24.04` so flagtree
loads — flagtree is built on 24.04 and needs a newer `libstdc++` (GLIBCXX)
than 22.04 ships.

## Approach: forward-compat, keep the 22.04 DTK
Hygon publishes **no** ubuntu-24.04 DTK, so we keep the existing
`DTK-26.04-Ubuntu22.04-x86_64.tar.gz` on the 24.04 base. This is safe because
binary compatibility is one-way: the 22.04-built DTK links *older* glibc/libstdc++
and runs on 24.04's newer libs (forward-compatible), while the 24.04 base
satisfies flagtree's GLIBCXX floor. No Python install needed (unlike ascend,
hygon has no CANN-style python-artifact constraint). DTK download hardened with
`curl --retry`.

## Verification
- **Build on 24.04:** ✅ CI (h20) and an independent rebuild on the DCU node.
- **Run on real hardware (hygon25, 8× DCU):** ✅ `hy-smi` enumerated all 8 HCUs
  with full live telemetry (~50–53 °C, AvgPwr 71–91 W, PwrCap 1000 W, Normal).
  The 22.04-built binary loads, links against noble's libs, and reads the silicon
  — forward-compat demonstrated, not inferred.
- **Linkage floor:** `objdump -T` across all DTK binaries → max `GLIBCXX_3.4.26`,
  well under noble's `GLIBCXX_3.4.33`.

## Also included (surfaced by the hardware run)
`build-config.yml` run/verify refinements for hygon, now hardware-verified:
- Add **`/dev/mkfd`** to the run flags — there are two kfd nodes; without the
  second, `hy-smi` errors `Open mkfd failed` and power/perf read `N/A`. Both nodes
  give full telemetry under the confined flags (no `--privileged`).
- Verify **sources the DTK env** (`source /opt/dtk-26.04/env.sh && hy-smi`) since
  `hy-smi` is only on PATH afterward.