### PR TITLE
Bump Kunlunxin base image ubuntu:22.04 → 24.04 (flagtree libstdc++)

### DIFF
--- a/base/kunlunxin-xre5.29.0
+++ b/base/kunlunxin-xre5.29.0
@@ -1,10 +1,14 @@
 # ============================================================
-# Base image for Kunlunxin XPU 5.29 on Ubuntu 22.04
+# Base image for Kunlunxin XPU 5.29 on Ubuntu 24.04
 # ============================================================
 # History:
 # - 20260608: Initial version
+# - 20260716: Bump base OS 22.04 -> 24.04 for flagtree (needs newer libstdc++).
+#   Kunlunxin's XRE/XCUDART packages carry no OS tag and are unchanged here:
+#   their binaries link older glibc/libstdc++ and run on 24.04's newer libs
+#   (forward-compatible), while the 24.04 base satisfies flagtree's GLIBCXX floor.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
@@ -24,12 +28,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
    && rm -rf /var/lib/apt/lists/*
 
 # ── Install CUDA ────────────────────────────────────────────────
-RUN curl -o /cuda.run ${FILE_STORE}/cuda/${CUDA_PACKAGE} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /cuda.run ${FILE_STORE}/cuda/${CUDA_PACKAGE} \
     && bash cuda.run --toolkit --silent \
     && rm /cuda.run
 
 # ── Install XRE ────────────────────────────────────────────────
-RUN curl -o /tmp/xre.run ${FILE_STORE}/kunlunxin/${XRE_PACKAGE} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/xre.run ${FILE_STORE}/kunlunxin/${XRE_PACKAGE} \
     && cd /tmp \
     && bash xre.run --extract-only \
     && cd /tmp/xre-Linux-x86_64 \
@@ -37,7 +41,7 @@ RUN curl -o /tmp/xre.run ${FILE_STORE}/kunlunxin/${XRE_PACKAGE} \
     && rm -fr /tmp/*
 
 # ── Install XCUDART ────────────────────────────────────────────
-RUN curl -o /xcudart.deb ${FILE_STORE}/kunlunxin/${XCUDART_PACKAGE} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /xcudart.deb ${FILE_STORE}/kunlunxin/${XCUDART_PACKAGE} \
     && dpkg -i --instdir /usr/local /xcudart.deb \
     && rm /xcudart.deb
 


### PR DESCRIPTION
Closes #113.

## What
Raise the Kunlunxin base image from `ubuntu:22.04` to `ubuntu:24.04` to lift the
libstdc++ baseline for flagtree, and harden the SDK downloads.

## Why — measured headroom
flagtree's XPU wheel `0.6.0+xpu3.6` demands (across all 22 `.so`, incl. the imported
`libtriton.so`):

| | flagtree `0.6.0+xpu3.6` needs | old 22.04 base (`libstdc++ 12.3.0`) | new 24.04 base |
|---|---|---|---|
| GLIBCXX | `3.4.30` | `3.4.30` (zero margin) | `3.4.33` |
| CXXABI  | `1.3.13` | `1.3.13` (zero margin) | `1.3.15` |
| GLIBC   | `2.34`   | `2.35` | `2.39` |

The 22.04 base met `0.6.0` with **zero margin** — a leaner/older 22.04 (gcc-11 →
GLIBCXX 3.4.29) would fail, and future flagtree versions will push past 3.4.30.
24.04 gives comfortable headroom.

## Forward-compat: SDK unchanged
Kunlunxin's XRE/XCUDART packages carry no OS tag and are kept as-is; their
22.04-built binaries link older glibc/libstdc++ and run on 24.04's newer libs. No
python in the base (the `3.10` pin is a runtime-venv concern). CUDA 12.9's toolkit
supports 24.04 natively.

## Verification
- **Build on 24.04:** ✅ CI (h20) **and** an independent rebuild on the P800 node.
- **Run on real hardware (P800, 8× XPU):** ✅ `xpu-smi` shows the accelerator —
  `P800 OAM, 34 °C, 84 W / 400 W, 98304 MiB, Driver 5.29.0.0, XPU-RT 5.29.0`.
  The 22.04-era XRE/XCUDART binaries run on 24.04 and talk to the silicon.
- Confined run flags (`--device /dev/xpu0 --device /dev/xpuctrl`, `xpu-smi` baked
  in — no host mount) verified; no run-flag change needed.

## Also
Harden the three filestore downloads (CUDA / XRE / XCUDART) with `curl --retry`.