### PR TITLE
Bump MThreads base images ubuntu:22.04 → 24.04 (flagtree libstdc++)

### DIFF
--- a/base/mthreads-musa4.3.6
+++ b/base/mthreads-musa4.3.6
@@ -1,7 +1,12 @@
 # ============================================================
-# Base image for MooreThreads MUSA 4.3.6 on Ubuntu 22.04
+# Base image for MooreThreads MUSA 4.3.6 on Ubuntu 24.04
 # ============================================================
-FROM ubuntu:22.04
+# History:
+# - 20260716: Bump base OS 22.04 -> 24.04 for flagtree (needs newer libstdc++).
+#   MUSA/MCCL/muDNN packages carry no OS tag and are unchanged: their 22.04-built
+#   binaries link older glibc/libstdc++ and run on 24.04's newer libs
+#   (forward-compatible), while the 24.04 base satisfies flagtree's GLIBCXX floor.
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
@@ -22,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Toolkit
-RUN curl -o /toolkits.tar.gz ${FILE_STORE}/${TOOKIT_PKG} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /toolkits.tar.gz ${FILE_STORE}/${TOOKIT_PKG} \
     && tar xzvf /toolkits.tar.gz -C /tmp \
     && cd /tmp/musa_toolkits_install \
     && ./install.sh \
@@ -34,7 +39,7 @@ ENV PATH="${MUSA_HOME}/bin:${PATH}"
 ENV LD_LIBRARY_PATH="${MUSA_HOME}/lib"
 
 # Install MCCL
-RUN curl -o /mccl.tar.gz ${FILE_STORE}/${MCCL_PKG} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /mccl.tar.gz ${FILE_STORE}/${MCCL_PKG} \
   && tar xzf /mccl.tar.gz -C /tmp \
   && cd /tmp/mccl \
   && ./install.sh \
@@ -42,7 +47,7 @@ RUN curl -o /mccl.tar.gz ${FILE_STORE}/${MCCL_PKG} \
   && rm /mccl.tar.gz
 
 # Install MuDNN
-RUN curl -o /mudnn.tar.gz ${FILE_STORE}/${MUDNN_PKG} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /mudnn.tar.gz ${FILE_STORE}/${MUDNN_PKG} \
   && tar xzvf /mudnn.tar.gz -C /tmp \
   && cd /tmp/mudnn \
   && ./install_mudnn.sh \

--- a/base/mthreads-musa5.2.0
+++ b/base/mthreads-musa5.2.0
@@ -1,7 +1,12 @@
 # ============================================================
-# Base image for MooreThreads MUSA 5.2.0 on Ubuntu 22.04
+# Base image for MooreThreads MUSA 5.2.0 on Ubuntu 24.04
 # ============================================================
-FROM ubuntu:22.04
+# History:
+# - 20260716: Bump base OS 22.04 -> 24.04 for flagtree (needs newer libstdc++).
+#   MUSA/MCCL/muDNN packages carry no OS tag and are unchanged: their 22.04-built
+#   binaries link older glibc/libstdc++ and run on 24.04's newer libs
+#   (forward-compatible), while the 24.04 base satisfies flagtree's GLIBCXX floor.
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
@@ -22,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Toolkit
-RUN curl -o /toolkits.tar.gz ${FILE_STORE}/${TOOKIT_PKG} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /toolkits.tar.gz ${FILE_STORE}/${TOOKIT_PKG} \
     && tar xzvf /toolkits.tar.gz -C /tmp \
     && cd /tmp/musa_toolkits_install \
     && ./install.sh \
@@ -34,7 +39,7 @@ ENV PATH="${MUSA_HOME}/bin:${PATH}"
 ENV LD_LIBRARY_PATH="${MUSA_HOME}/lib"
 
 # Install MCCL
-RUN curl -o /mccl.tar.gz ${FILE_STORE}/${MCCL_PKG} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /mccl.tar.gz ${FILE_STORE}/${MCCL_PKG} \
   && tar xzf /mccl.tar.gz -C /tmp \
   && cd /tmp/mccl \
   && ./install.sh \
@@ -42,7 +47,7 @@ RUN curl -o /mccl.tar.gz ${FILE_STORE}/${MCCL_PKG} \
   && rm /mccl.tar.gz
 
 # Install MuDNN
-RUN curl -o /mudnn.tar.gz ${FILE_STORE}/${MUDNN_PKG} \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /mudnn.tar.gz ${FILE_STORE}/${MUDNN_PKG} \
   && tar xzvf /mudnn.tar.gz -C /tmp \
   && cd /tmp/mudnn \
   && ./install_mudnn.sh \


### PR DESCRIPTION
Closes #114.

## What
Raise both MThreads base images (`musa4.3.6` + `musa5.2.0`) from `ubuntu:22.04`
to `ubuntu:24.04`, and harden the SDK downloads.

## Why
Both backends target **`flagtree==0.6.0+mthreads3.6`**, which needs a newer
libstdc++ (GLIBCXX) than 22.04 ships. Bumping the base clears that floor.

## Forward-compat: SDK unchanged
MUSA Toolkit / MCCL / muDNN packages carry no OS tag and are kept as-is; their
22.04-built binaries link older glibc/libstdc++ and run on 24.04's newer libs. No
python in the base (the `3.10` pin is a runtime-venv concern).

## Verification
- **Build on 24.04:** CI (h20) for **both** images, **and** independent rebuilds
  on the MThreads node (`worker38024`, 8x MTT S5000).
- **Run on real hardware:** `mthreads-gmi` (via the mthreads container runtime)
  in **both** images lists all MTT S5000s — `81920 MiB, 35 C, Driver 5.2.0-server`.
- Run flags unchanged: `--runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all`,
  verify tool `mthreads-gmi` (on PATH at `/usr/bin`, no env-source needed). Note:
  `mthreads-gmi` + driver libs are injected by the runtime, not baked into the
  image — so mthreads is toolkit-only (no raw device-passthrough equivalent).

## Also
Harden the toolkit / MCCL / muDNN filestore downloads with `curl --retry`.
