### PR TITLE
Bump Tsingmicro base image ubuntu:22.04 → 24.04 (flagtree libstdc++)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -81,9 +81,9 @@ run:
     # VERIFIED: Iluvatar container runtime + env var; tool is ixsmi.
     # Host prerequisite: ix-container-toolkit >= 1.1.0.
     iluvatar: "--runtime iluvatar --env IX_VISIBLE_DEVICES=all"
-    # DOC: Tsingmicro TX8 — vendor docs only show a permissive privileged launch;
-    # a tighter set of device nodes is TBD (verify on hardware)
-    tsingmicro: "--privileged --ipc=host -v /dev:/dev -v /lib/modules:/lib/modules"
+    # VERIFIED on the TX8110 node: confined device passthrough is enough — the two
+    # accel nodes, no --privileged/-v /dev needed. tsm_smi listed all 32 chips.
+    tsingmicro: "--device /dev/accel --device /dev/accel_drv_mgr"
     # sunrise PTPU: device node unknown — no public docs found
     sunrise: ""       # TODO: confirm device node / launch method on hardware
 
@@ -117,5 +117,7 @@ verify:
     mthreads: "mthreads-gmi"
     enflame: "efsmi"
     sunrise: "pt_smi"
-    tsingmicro: "tsm-smi"
+    # VERIFIED on the TX8110 node: the tool is tsm_smi (underscore), on PATH via
+    # KUIPER_PATH/bin (/usr/local/kuiper/bin), no env-source needed.
+    tsingmicro: "tsm_smi"
 

--- a/base/tsingmicro-tsm260604
+++ b/base/tsingmicro-tsm260604
@@ -1,10 +1,17 @@
 # ============================================================
-# Base image for TsingMicro TSM 260604163331 on Ubuntu 22.04
+# Base image for TsingMicro TSM 260604163331 on Ubuntu 24.04
 # ============================================================
 # History:
 # - 20260608: Initial version
+# - 20260716: Bump base OS 22.04 -> 24.04 for flagtree (needs newer libstdc++).
+#   TSM runtime/compiler packages carry no OS tag and are unchanged: their
+#   22.04-built binaries link older glibc/libstdc++ and run on 24.04's newer libs
+#   (forward-compatible), while the 24.04 base satisfies flagtree's GLIBCXX floor.
+#   The base has no python interpreter; the prebuilt cp310 MLIR bindings on
+#   PYTHONPATH are consumed by the runtime venv's python 3.10, so noble's system
+#   python is irrelevant here.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
@@ -34,17 +41,17 @@ ENV PACKAGE_NAME="Tsm_validation_suite Tsm_runtime Tsm_ccl Tsm_profiler"
 RUN set -eux ; \
   for pkg in ${PACKAGE_NAME}; do \
     fn="${pkg}_${SDK_RELEASE}_x86_64_installer.run"; \
-    curl -o "${fn}" "${FILE_STORE}/${fn}"; \
+    curl --retry 5 --retry-delay 5 --retry-all-errors -o "${fn}" "${FILE_STORE}/${fn}"; \
     chmod +x "${fn}"; \
     ./"${fn}"; \
     rm -f "${fn}"; \
   done
 
 # ── TsingMicro Compiler depdendencies ─────────────────────────────
-RUN curl -o /tmp/tx8.tar.gz ${FILE_STORE}/tx8_depends_dev_20260507_104051.tar.gz \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/tx8.tar.gz ${FILE_STORE}/tx8_depends_dev_20260507_104051.tar.gz \
     && tar xf /tmp/tx8.tar.gz -C /usr/local \
     && rm /tmp/tx8.tar.gz
-RUN curl -o /tmp/llvm.tar.gz ${FILE_STORE}/llvm-a66376b0-ubuntu-x64.tgz \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/llvm.tar.gz ${FILE_STORE}/llvm-a66376b0-ubuntu-x64.tgz \
     && tar xf /tmp/llvm.tar.gz -C /usr/local \
     && rm /tmp/llvm.tar.gz
  

--- a/base/tsingmicro-tsm260604
+++ b/base/tsingmicro-tsm260604
@@ -3,13 +3,7 @@
 # ============================================================
 # History:
 # - 20260608: Initial version
-# - 20260716: Bump base OS 22.04 -> 24.04 for flagtree (needs newer libstdc++).
-#   TSM runtime/compiler packages carry no OS tag and are unchanged: their
-#   22.04-built binaries link older glibc/libstdc++ and run on 24.04's newer libs
-#   (forward-compatible), while the 24.04 base satisfies flagtree's GLIBCXX floor.
-#   The base has no python interpreter; the prebuilt cp310 MLIR bindings on
-#   PYTHONPATH are consumed by the runtime venv's python 3.10, so noble's system
-#   python is irrelevant here.
+# - 20260716: Bump base OS 22.04 -> 24.04
 
 FROM ubuntu:24.04
 
@@ -48,10 +42,12 @@ RUN set -eux ; \
   done
 
 # ── TsingMicro Compiler depdendencies ─────────────────────────────
-RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/tx8.tar.gz ${FILE_STORE}/tx8_depends_dev_20260507_104051.tar.gz \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/tx8.tar.gz \
+      ${FILE_STORE}/tx8_depends_dev_20260507_104051.tar.gz \
     && tar xf /tmp/tx8.tar.gz -C /usr/local \
     && rm /tmp/tx8.tar.gz
-RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/llvm.tar.gz ${FILE_STORE}/llvm-a66376b0-ubuntu-x64.tgz \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/llvm.tar.gz \
+      ${FILE_STORE}/llvm-a66376b0-ubuntu-x64.tgz \
     && tar xf /tmp/llvm.tar.gz -C /usr/local \
     && rm /tmp/llvm.tar.gz
  


### PR DESCRIPTION
Closes #115.

## What
Raise the Tsingmicro base image from `ubuntu:22.04` to `ubuntu:24.04` (flagtree's
libstdc++ floor), harden the SDK downloads with `curl --retry`, and fix two
hardware-verified `build-config.yml` entries for tsingmicro.

## Forward-compat: SDK unchanged, python is a non-issue
TSM runtime/compiler packages (Tsm_*, tx8_deps, llvm) carry no OS tag and are kept
as-is; their 22.04-built binaries link older glibc/libstdc++ and run on 24.04.

The `cp310` MLIR bindings are **not** a bump hazard: the base has **no python
interpreter** — the bindings are prebuilt files on `PYTHONPATH`, consumed by the
runtime venv's python 3.10. `objdump` confirms they carry no `libpython3.x` NEEDED
entry (they resolve libpython via the loading interpreter), so noble's system python
(3.12) never enters the picture.

## Verification
- **Build on 24.04:** CI (h20) and an independent rebuild on the TX8110 node.
- **Run on real hardware (TX8110):** `tsm_smi` listed all **32 chips** (45-56 C,
  ~65 W/200 W, 64 GB each) under **confined** device flags — no `--privileged`.
- **Linkage check:** max GLIBCXX required by the MLIR/kuiper/tx8 libs is `3.4.30`
  (noble provides `3.4.33`); max GLIBC `2.34` (noble `2.39`). Bump clears the floor.

## build-config.yml corrections (were DOC/unverified)
- Verify tool is **`tsm_smi`** (underscore), on PATH via `KUIPER_PATH/bin` — the old
  `tsm-smi` was a wrong guess.
- Run flags: **`--device /dev/accel --device /dev/accel_drv_mgr`** (confined,
  verified) replaces the `--privileged --ipc=host -v /dev:/dev` hammer.

## Also
Harden the TSM installer loop + tx8/llvm tarball downloads with `curl --retry`.
