### PR TITLE
Bump Cambricon base image ubuntu:22.04 → 24.04 (fleet uniformity)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -67,8 +67,10 @@ run:
     # telemetry. With both, hy-smi shows full readings under these confined flags (no
     # privileged needed).
     hygon: "--device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined"
-    # DOC: Cambricon MLU device + control node; cnmon is host-provided → mount
-    cambricon: "--device /dev/cambricon_dev0 --device /dev/cambricon_ctl -v /usr/bin/cnmon:/usr/bin/cnmon"
+    # VERIFIED on the MLU590 node: confined device passthrough is enough. cnmon is
+    # baked into the base image (unzipped in the containerfile) and runs against the
+    # MLU without the host -v /usr/bin/cnmon mount.
+    cambricon: "--device /dev/cambricon_dev0 --device /dev/cambricon_ctl"
     # DOC + maintainer: Kunlunxin XPU device + control node; xpu-smi is baked in
     # the base image (no mount needed). NOTE: vendor docs claim --privileged is
     # also required to enumerate devices — verify whether --device alone suffices.

--- a/base/cambricon-neuware4.4.3
+++ b/base/cambricon-neuware4.4.3
@@ -1,10 +1,15 @@
 # ============================================================
-# Base image for Cambricon Neuware 4.4.3 Ubuntu 22.04
+# Base image for Cambricon Neuware 4.4.3 Ubuntu 24.04
 # ============================================================
 # History:
 # - 20260624: Initial version
+# - 20260716: Bump base OS 22.04 -> 24.04 for fleet uniformity (cambricon is
+#   triton-only, so this is not needed for flagtree, but keeps all bases on one
+#   OS). Neuware .debs are ubuntu22.04-tagged; their 22.04-built binaries run on
+#   24.04 (forward-compatible). noble dropped libncurses5/libtinfo5 (.so.5) —
+#   use libncurses6/libtinfo6 instead.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
@@ -32,7 +37,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
   && apt-get install -f -y pciutils curl ca-certificates unzip\
     gcc g++ gdb build-essential cmake make \
-    libncurses5 libtinfo5 libc6-dev-i386 \
+    libncurses6 libtinfo6 libc6-dev-i386 \
   && ln -fs /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
@@ -65,7 +70,7 @@ ENV PKGS="cnlicense_1.2.0-1.ubuntu22.04_amd64.deb \
 
 RUN set -eux ; \
   for pkg in ${PKGS}; do \
-    curl -o ${pkg} ${FILE_STORE}/${pkg}; \
+    curl --retry 5 --retry-delay 5 --retry-all-errors -o ${pkg} ${FILE_STORE}/${pkg}; \
     dpkg -i ${pkg}; \
     rm -f ${pkg}; \
   done \
@@ -73,7 +78,7 @@ RUN set -eux ; \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -o ${CNMON_PKG} ${FILE_STORE}/${CNMON_PKG}; \
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o ${CNMON_PKG} ${FILE_STORE}/${CNMON_PKG}; \
   unzip ${CNMON_PKG} -d /usr/bin; \
   rm -f ${CNMON_PKG}
 


### PR DESCRIPTION
Closes #111.

## What
Bump the Cambricon base image from `ubuntu:22.04` to `ubuntu:24.04`, putting the
**entire 14-backend fleet on one base OS**.

## Why (and why it's different from the flagtree bumps)
Cambricon is **triton-only** — its config has no `flagtree:` entry — so unlike the
other seven backends it doesn't need the libstdc++/GLIBCXX floor that flagtree
imposes. This bump is purely for **fleet uniformity** (one base OS to maintain).

It was also the riskiest bump: every neuware package is an explicit
`.ubuntu22.04_amd64.deb`, and noble **dropped** `libncurses5`/`libtinfo5`. So this
was tested on hardware before committing.

## The one substitution
`libncurses5 libtinfo5` → `libncurses6 libtinfo6` (noble provides only `.so.6`).
The 22.04-built neuware binaries link against `.so.6` fine — `ldd cnmon` and
`ldd libcnrt.so` both fully resolve, no `.so.5` needed.

## Verification (MLU590 node)
- **Build on 24.04:** succeeds; **`dpkg --audit` clean** — all 23 neuware `.deb`s
  install without broken dependencies.
- **`libcnrt.so.7.4.0` → ALL_RESOLVED.**
- **`cnmon` runs on the MLU590:** CNMON v6.2.15, MLU590-M9DE, 52 °C, 81920 MiB.

## build-config.yml
- Confined device flags verified: `--device /dev/cambricon_dev0 --device
  /dev/cambricon_ctl`. The host **`-v /usr/bin/cnmon` mount is dropped** — `cnmon`
  is baked into the image (unzipped in the containerfile) and runs without it.

## Also
Harden the neuware `.deb` + cnmon downloads with `curl --retry`.
