### PR TITLE
docs: tiered launch commands (toolkit + raw/podman) per image

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -34,68 +34,85 @@ runners:
 #
 # TODO: confirm the exact device flags for each vendor. Only nvidia is filled in;
 # the rest are placeholders — replace the TODO strings with the real flags.
-# `docker run` flags needed to expose each vendor's accelerator to a container.
-# Used by the docs to render a concrete run command per image, and to launch a
-# base image for verification (e.g. `docker run <run> <image> <smi-tool>`).
+# How to launch each vendor's image, for the docs' per-image "Launch" section.
+# Each vendor may carry up to two launch styles; the docs render whichever exist,
+# "toolkit" first (recommended):
+#   toolkit:     flags added to `docker run` when the vendor's container toolkit is
+#                installed on the host (--gpus all, --runtime X, -e X_VISIBLE_DEVICES).
+#   toolkit_cmd: a full wrapper command ({image} placeholder) for launchers that
+#                REPLACE `docker run` entirely (e.g. metax-docker).
+#   raw:         device-passthrough flags that work with plain docker/podman + the
+#                vendor driver, no toolkit (used when the smi tool is baked into the
+#                image). Empty raw ("") = generic `docker run <image>`, no flags.
+# The toolkit's host prerequisite is named under `prereq` below.
 #
-# GOAL: the *minimal* flags per vendor — avoid the broad hammer
-# (`--privileged --cap-add=ALL -v /dev:/dev -v /lib/modules:/lib/modules
-# --pid=host --network host`), which works but is over-permissive.
-#
-# STATUS: VERIFIED = tried on real hardware here; DOC = from vendor/community
-# docs, confirm on hardware once the images exist. A vendor's smi tool needs a
-# host bind-mount ONLY when it's host-provided (from the driver, e.g. ascend
-# npu-smi); when it's baked into the base image (kunlunxin xpu-smi, metax
-# mx-smi) no mount is needed. Vendors with a container runtime (iluvatar,
-# mthreads) use that runtime + an env var, not raw --device flags (like NVIDIA).
+# STATUS: VERIFIED = tried on real hardware here, or maintainer-verified before
+# sharing; DOC = vendor/community docs, confirm on hardware.
 run:
   default: ""
   vendors:
-    # VERIFIED: nvidia-container-runtime exposes GPUs + driver + nvidia-smi
-    nvidia: "--gpus all"
-    # VERIFIED on metax124 (8x C550): umd base builds headless, and these
-    # confined flags run mx-smi in-container listing the devices. (The very
-    # first `mx-smi` run hung, then worked on subsequent runs — a transient
-    # cold-device first-touch init, not a flag problem.)
-    metax: "--device /dev/mxcd --device /dev/dri --group-add video"
-    # DOC: Ascend passthrough; npu-smi + driver are host-provided → bind-mount
-    ascend: "--device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi"
-    # VERIFIED on hygon25 (8x DCU): hygon is ROCm/HIP-based → needs BOTH kfd nodes
-    # (/dev/kfd major 501 + /dev/mkfd major 500) plus /dev/dri, and the host
-    # /opt/hyhal mounted. /dev/kfd alone enumerates devices (temp/vram) but hy-smi
-    # then errors "Open mkfd failed" and power/perf read N/A — /dev/mkfd carries that
-    # telemetry. With both, hy-smi shows full readings under these confined flags (no
-    # privileged needed).
-    hygon: "--device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined"
-    # VERIFIED on the MLU590 node: confined device passthrough is enough. cnmon is
-    # baked into the base image (unzipped in the containerfile) and runs against the
-    # MLU without the host -v /usr/bin/cnmon mount.
-    cambricon: "--device /dev/cambricon_dev0 --device /dev/cambricon_ctl"
-    # DOC + maintainer: Kunlunxin XPU device + control node; xpu-smi is baked in
-    # the base image (no mount needed). NOTE: vendor docs claim --privileged is
-    # also required to enumerate devices — verify whether --device alone suffices.
-    kunlunxin: "--device /dev/xpu0 --device /dev/xpuctrl"
-    # DOC: Enflame GCU device node; efsmi ships in the runtime stack
-    enflame: "--device /dev/gcu"
-    # DOC: MThreads uses its container runtime + env var; tool is mthreads-gmi.
-    # Host prerequisite: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0.
-    mthreads: "--runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all"
-    # VERIFIED: Iluvatar container runtime + env var; tool is ixsmi.
-    # Host prerequisite: ix-container-toolkit >= 1.1.0.
-    iluvatar: "--runtime iluvatar --env IX_VISIBLE_DEVICES=all"
-    # VERIFIED on the TX8110 node: confined device passthrough is enough — the two
-    # accel nodes, no --privileged/-v /dev needed. tsm_smi listed all 32 chips.
-    tsingmicro: "--device /dev/accel --device /dev/accel_drv_mgr"
-    # sunrise PTPU: device node unknown — no public docs found
-    sunrise: ""       # TODO: confirm device node / launch method on hardware
+    nvidia:
+      # VERIFIED: nvidia-container-toolkit injects the driver + nvidia-smi.
+      toolkit: "--gpus all"
+    ascend:
+      # VERIFIED on 910B (hw25): Ascend-docker-runtime. Use explicit device INDICES —
+      # ASCEND_VISIBLE_DEVICES=all trips the runtime's product-type enumeration on the
+      # 910 ("product type is not support"); =0 (or 0,1,...) works.
+      toolkit: "-e ASCEND_VISIBLE_DEVICES=0"
+      # VERIFIED on 910B: raw passthrough; npu-smi + driver are host-provided → mount.
+      raw: "--device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi"
+    hygon:
+      # VERIFIED (maintainer): DCU-Container-Toolkit injects hyhal.
+      toolkit: "-e DCU_VISIBLE_DEVICES=all"
+      # VERIFIED on hygon25 (8x DCU): needs BOTH kfd nodes (/dev/kfd major 501 +
+      # /dev/mkfd major 500) + /dev/dri + host /opt/hyhal. /dev/kfd alone enumerates
+      # devices but hy-smi errors "Open mkfd failed" and power/perf read N/A without
+      # /dev/mkfd.
+      raw: "--device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined"
+    metax:
+      # VERIFIED (maintainer): metax-docker is a wrapper launcher (replaces docker run).
+      toolkit_cmd: "metax-docker --gpus all {image} bash"
+      # VERIFIED on metax124 (8x C550): confined device flags run mx-smi.
+      raw: "--device /dev/mxcd --device /dev/dri --group-add video"
+    mthreads:
+      # VERIFIED on worker38024 (8x S5000): MT Container Toolkit runtime. mthreads-gmi +
+      # driver libs are injected by the runtime (not baked) → no raw tier yet (see #125).
+      toolkit: "--runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all"
+    iluvatar:
+      # VERIFIED: ix-container-toolkit runtime; tool is ixsmi.
+      toolkit: "--runtime iluvatar --env IX_VISIBLE_DEVICES=all"
+    cambricon:
+      # VERIFIED on MLU590: confined passthrough; cnmon is baked in the image (no host
+      # mount). No container toolkit/runtime known.
+      raw: "--device /dev/cambricon_dev0 --device /dev/cambricon_ctl"
+    kunlunxin:
+      # VERIFIED on P800 (both tiers): xpu-container-toolkit runtime. NOTE the env
+      # var is CXPU_VISIBLE_DEVICES (Container-XPU), NOT XPU_VISIBLE_DEVICES, and it
+      # wants explicit device indices. Host setup: `xpu-ctk runtime configure
+      # --runtime=docker` then restart docker (the .deb install skips this step).
+      toolkit: "--runtime xpu -e CXPU_VISIBLE_DEVICES=0"
+      # VERIFIED on P800: confined passthrough; xpu-smi baked in the image.
+      raw: "--device /dev/xpu0 --device /dev/xpuctrl"
+    tsingmicro:
+      # VERIFIED on TX8110 (32 chips): confined passthrough; tsm_smi baked in the image.
+      # TODO toolkit: checking with Tsingmicro (tracked in #128).
+      raw: "--device /dev/accel --device /dev/accel_drv_mgr"
+    enflame:
+      # DOC: Enflame GCU device node; efsmi ships in the runtime stack.
+      # TODO toolkit: awaiting response from Enflame (tracked in #128).
+      raw: "--device /dev/gcu"
+    sunrise:
+      # sunrise PTPU: generic launch only — no device flags / toolkit known.
+      raw: ""
 
-  # Host prerequisite for the run command, per vendor — listed ONLY when there is
-  # a specific, non-obvious requirement. Vendors using --gpus/--runtime need a
-  # container toolkit installed on the host (named + versioned here). The
-  # --device-passthrough vendors need only the vendor driver + the device nodes
-  # already shown in the run flags, so they carry no prereq (nothing rendered).
+  # Host prerequisite (container toolkit) for the toolkit tier, per vendor. Rendered
+  # only when the vendor has a toolkit/toolkit_cmd launch style.
   prereq:
     nvidia: "nvidia-container-toolkit"
+    ascend: "Ascend-docker-runtime >= 6.0.RC3"
+    hygon: "dcu-container-toolkit >= 1.3.0"
+    metax: "metax-docker >= 0.15.3"
+    kunlunxin: "xpu_container >= 1.0.13"
     mthreads: "KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0"
     iluvatar: "ix-container-toolkit >= 1.1.0"
 
@@ -112,9 +129,9 @@ verify:
     metax: "mx-smi"
     cambricon: "cnmon"
     iluvatar: "ixsmi"
-    # VERIFIED on hygon25: hy-smi lives at /opt/dtk-26.04/.hyhal/bin/hy-smi and is
-    # only on PATH after sourcing the DTK env (not flattened into ENV yet).
-    hygon: "source /opt/dtk-26.04/env.sh && hy-smi"
+    # VERIFIED on hygon25: hy-smi via the hyhal env. /opt/hyhal/env.sh works for both
+    # launch paths — host-mounted in the raw case, toolkit-injected with the DCU toolkit.
+    hygon: "source /opt/hyhal/env.sh && hy-smi"
     kunlunxin: "xpu-smi"
     mthreads: "mthreads-gmi"
     enflame: "efsmi"

--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -36,84 +36,59 @@ runners:
 # the rest are placeholders — replace the TODO strings with the real flags.
 # How to launch each vendor's image, for the docs' per-image "Launch" section.
 # Each vendor may carry up to two launch styles; the docs render whichever exist,
-# "toolkit" first (recommended):
+# toolkit first:
 #   toolkit:     flags added to `docker run` when the vendor's container toolkit is
 #                installed on the host (--gpus all, --runtime X, -e X_VISIBLE_DEVICES).
 #   toolkit_cmd: a full wrapper command ({image} placeholder) for launchers that
 #                REPLACE `docker run` entirely (e.g. metax-docker).
-#   raw:         device-passthrough flags that work with plain docker/podman + the
-#                vendor driver, no toolkit (used when the smi tool is baked into the
-#                image). Empty raw ("") = generic `docker run <image>`, no flags.
+#   raw:         device-passthrough flags for plain docker/podman + the vendor driver,
+#                no toolkit. Empty raw ("") = generic `docker run <image>`, no flags.
 # The toolkit's host prerequisite is named under `prereq` below.
-#
-# STATUS: VERIFIED = tried on real hardware here, or maintainer-verified before
-# sharing; DOC = vendor/community docs, confirm on hardware.
 run:
   default: ""
   vendors:
     nvidia:
-      # VERIFIED: nvidia-container-toolkit injects the driver + nvidia-smi.
       toolkit: "--gpus all"
-      # VERIFIED on h20 (runc, no toolkit): device nodes + host driver mounts
-      # (nvidia-smi + libnvidia-ml for smi, libcuda for CUDA). The toolkit automates
-      # exactly this; raw is the pre-toolkit / podman path.
+      # raw needs the host driver: nvidia-smi + libnvidia-ml (for smi) + libcuda (CUDA).
       raw: "--device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro"
     ascend:
-      # VERIFIED on 910B (hw25): Ascend-docker-runtime. Use explicit device INDICES —
-      # ASCEND_VISIBLE_DEVICES=all trips the runtime's product-type enumeration on the
+      # GOTCHA: explicit device indices only — ASCEND_VISIBLE_DEVICES=all fails on the
       # 910 ("product type is not support"); =0 (or 0,1,...) works.
       toolkit: "-e ASCEND_VISIBLE_DEVICES=0"
-      # VERIFIED on 910B: raw passthrough; npu-smi + driver are host-provided → mount.
       raw: "--device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi"
     hygon:
-      # VERIFIED (maintainer): DCU-Container-Toolkit injects hyhal.
       toolkit: "-e DCU_VISIBLE_DEVICES=all"
-      # VERIFIED on hygon25 (8x DCU): needs BOTH kfd nodes (/dev/kfd major 501 +
-      # /dev/mkfd major 500) + /dev/dri + host /opt/hyhal. /dev/kfd alone enumerates
-      # devices but hy-smi errors "Open mkfd failed" and power/perf read N/A without
-      # /dev/mkfd.
+      # GOTCHA: needs BOTH kfd nodes — /dev/kfd alone leaves power/perf N/A and hy-smi
+      # errors "Open mkfd failed"; /dev/mkfd carries that telemetry.
       raw: "--device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined"
     metax:
-      # VERIFIED (maintainer): metax-docker is a wrapper launcher (replaces docker run).
+      # metax-docker is a wrapper launcher (replaces `docker run`), not flags.
       toolkit_cmd: "metax-docker --gpus all {image} bash"
-      # VERIFIED on metax124 (8x C550): confined device flags run mx-smi.
       raw: "--device /dev/mxcd --device /dev/dri --group-add video"
     mthreads:
-      # VERIFIED on worker38024 (8x S5000): MT Container Toolkit runtime.
       toolkit: "--runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all"
-      # VERIFIED on worker38024 (runc, no toolkit): mthreads-gmi is self-contained
-      # (talks to /dev/mtgpu.* directly, no driver libs), so just the device nodes +
-      # a host mount of the tool. (Baking it into the image is the fuller podman story
-      # — see #125.)
+      # raw mounts the host mthreads-gmi (not baked); #125 would bake it and drop the mount.
       raw: "--device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro"
     iluvatar:
-      # VERIFIED: ix-container-toolkit runtime; tool is ixsmi.
       toolkit: "--runtime iluvatar --env IX_VISIBLE_DEVICES=all"
-      # VERIFIED on ix15 (runc, no toolkit): device node + host /usr/local/corex mount
-      # (carries ixsmi + its libixml.so). The base image's corex env puts ixsmi on PATH.
+      # raw mounts the host /usr/local/corex (carries ixsmi + its libixml.so).
       raw: "--device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro"
     cambricon:
-      # VERIFIED on MLU590: confined passthrough; cnmon is baked in the image (no host
-      # mount). No container toolkit/runtime known.
+      # No container toolkit/runtime known; cnmon is baked in the image.
       raw: "--device /dev/cambricon_dev0 --device /dev/cambricon_ctl"
     kunlunxin:
-      # VERIFIED on P800 (both tiers): xpu-container-toolkit runtime. NOTE the env
-      # var is CXPU_VISIBLE_DEVICES (Container-XPU), NOT XPU_VISIBLE_DEVICES, and it
-      # wants explicit device indices. Host setup: `xpu-ctk runtime configure
-      # --runtime=docker` then restart docker (the .deb install skips this step).
+      # GOTCHA: env var is CXPU_VISIBLE_DEVICES (not XPU_), explicit index. Host setup:
+      # `xpu-ctk runtime configure --runtime=docker` + restart docker (the .deb skips it).
       toolkit: "--runtime xpu -e CXPU_VISIBLE_DEVICES=0"
-      # VERIFIED on P800: confined passthrough; xpu-smi baked in the image.
       raw: "--device /dev/xpu0 --device /dev/xpuctrl"
     tsingmicro:
-      # VERIFIED on TX8110 (32 chips): confined passthrough; tsm_smi baked in the image.
-      # TODO toolkit: checking with Tsingmicro (tracked in #128).
+      # TODO toolkit: checking with Tsingmicro (#128).
       raw: "--device /dev/accel --device /dev/accel_drv_mgr"
     enflame:
-      # DOC: Enflame GCU device node; efsmi ships in the runtime stack.
-      # TODO toolkit: awaiting response from Enflame (tracked in #128).
+      # TODO toolkit: awaiting Enflame (#128).
       raw: "--device /dev/gcu"
     sunrise:
-      # sunrise PTPU: generic launch only — no device flags / toolkit known.
+      # generic launch only — no device flags / toolkit known.
       raw: ""
 
   # Host prerequisite (container toolkit) for the toolkit tier, per vendor. Rendered
@@ -134,20 +109,16 @@ run:
 verify:
   vendors:
     nvidia: "nvidia-smi"
-    # ascend: the driver/toolkit env is provided by sourcing set_env.sh (the
-    # base_source TODO — not yet flattened into ENV), so npu-smi needs it first.
+    # needs set_env.sh sourced first (env not baked into the image yet).
     ascend: "source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info"
     metax: "mx-smi"
     cambricon: "cnmon"
     iluvatar: "ixsmi"
-    # VERIFIED on hygon25: hy-smi via the hyhal env. /opt/hyhal/env.sh works for both
-    # launch paths — host-mounted in the raw case, toolkit-injected with the DCU toolkit.
+    # hyhal env works for both launch paths (host-mounted raw / toolkit-injected).
     hygon: "source /opt/hyhal/env.sh && hy-smi"
     kunlunxin: "xpu-smi"
     mthreads: "mthreads-gmi"
     enflame: "efsmi"
     sunrise: "pt_smi"
-    # VERIFIED on the TX8110 node: the tool is tsm_smi (underscore), on PATH via
-    # KUIPER_PATH/bin (/usr/local/kuiper/bin), no env-source needed.
     tsingmicro: "tsm_smi"
 

--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -54,6 +54,10 @@ run:
     nvidia:
       # VERIFIED: nvidia-container-toolkit injects the driver + nvidia-smi.
       toolkit: "--gpus all"
+      # VERIFIED on h20 (runc, no toolkit): device nodes + host driver mounts
+      # (nvidia-smi + libnvidia-ml for smi, libcuda for CUDA). The toolkit automates
+      # exactly this; raw is the pre-toolkit / podman path.
+      raw: "--device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro"
     ascend:
       # VERIFIED on 910B (hw25): Ascend-docker-runtime. Use explicit device INDICES —
       # ASCEND_VISIBLE_DEVICES=all trips the runtime's product-type enumeration on the
@@ -75,12 +79,19 @@ run:
       # VERIFIED on metax124 (8x C550): confined device flags run mx-smi.
       raw: "--device /dev/mxcd --device /dev/dri --group-add video"
     mthreads:
-      # VERIFIED on worker38024 (8x S5000): MT Container Toolkit runtime. mthreads-gmi +
-      # driver libs are injected by the runtime (not baked) → no raw tier yet (see #125).
+      # VERIFIED on worker38024 (8x S5000): MT Container Toolkit runtime.
       toolkit: "--runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all"
+      # VERIFIED on worker38024 (runc, no toolkit): mthreads-gmi is self-contained
+      # (talks to /dev/mtgpu.* directly, no driver libs), so just the device nodes +
+      # a host mount of the tool. (Baking it into the image is the fuller podman story
+      # — see #125.)
+      raw: "--device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro"
     iluvatar:
       # VERIFIED: ix-container-toolkit runtime; tool is ixsmi.
       toolkit: "--runtime iluvatar --env IX_VISIBLE_DEVICES=all"
+      # VERIFIED on ix15 (runc, no toolkit): device node + host /usr/local/corex mount
+      # (carries ixsmi + its libixml.so). The base image's corex env puts ixsmi on PATH.
+      raw: "--device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro"
     cambricon:
       # VERIFIED on MLU590: confined passthrough; cnmon is baked in the image (no host
       # mount). No container toolkit/runtime known.

--- a/configs.yaml
+++ b/configs.yaml
@@ -36,6 +36,10 @@
 #                        scripts should eventually be expanded into the base image as
 #                        ENV (so users need not source them), but are kept until then.
 #   "deps:"            — Python dependencies (torch stack, etc.).
+#   "hardware:"        — chip models the image targets (rendered as a prerequisite).
+#   "driver:"          — host driver version installed on the node — a prerequisite,
+#                        distinct from the in-container SDK. Probed from the vendor's
+#                        smi tool (nvidia-smi, npu-smi, ...).
 
 base_image_prefix: "flagos-base"
 
@@ -48,6 +52,7 @@ vendors:
     cuda12.8:
       extras: nvidia-cuda128
       hardware: ["NVIDIA H20"]   # TODO: add other validated NVIDIA GPUs
+      driver: "610.43.02"
       python: "3.12"
       cmake_backend: CUDA
       triton: triton==3.6.0
@@ -69,6 +74,7 @@ vendors:
     cuda13.3:
       extras: nvidia-cuda133
       hardware: ["NVIDIA H20"]   # TODO: add other validated NVIDIA GPUs
+      driver: "610.43.02"
       python: "3.12"
       cmake_backend: CUDA
       triton: triton==3.6.0
@@ -91,6 +97,7 @@ vendors:
     cann8.5.0:
       extras: ascend-cann850
       hardware: ["Ascend 910B"]   # TODO: confirm 910C
+      driver: "25.5.0"
       python: "3.11"
       cmake_backend: NPU
       triton: triton-ascend==3.2.0
@@ -109,6 +116,7 @@ vendors:
     cann9.0.0:
       extras: ascend-cann900
       hardware: ["Ascend 910B"]   # TODO: confirm 910C
+      driver: "26.0.rc1"
       python: "3.11"
       cmake_backend: NPU
       triton: triton==3.5.0
@@ -131,6 +139,7 @@ vendors:
     neuware4.4.3:
       extras: cambricon
       hardware: ["Cambricon MLU590"]
+      driver: "6.2.15"
       python: "3.10"
       triton: triton==3.2.0+mlu1.7.2
       env:
@@ -173,6 +182,7 @@ vendors:
     tops1.9.10:
       extras: enflame
       hardware: ["Enflame Zixiao C200 (S60)"]
+      driver: "1.9.10"
       python: "3.12"
       cmake_backend: GCU
       triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
@@ -200,6 +210,7 @@ vendors:
     dtk26.04:
       extras: hygon
       hardware: ["Hygon BW1000"]
+      driver: "6.3.30-V1.4.1a"
       python: "3.10"
       triton: triton==3.3.0+das.opt1.dtk2604.torch290
       flagtree: flagtree==0.5.1+hcu3.1
@@ -216,6 +227,7 @@ vendors:
     corex4.4.0:
       extras: iluvatar
       hardware: ["Iluvatar BI-V150"]
+      driver: "4.4.0"
       python: "3.10"
       cmake_backend: IX
       triton: triton==3.1.0+corex.4.4.0
@@ -237,6 +249,7 @@ vendors:
     xre5.29.0:
       extras: kunlunxin
       hardware: ["Kunlunxin P800"]
+      driver: "5.29.0.0"
       python: "3.10"
       triton: triton==3.0.0+a48aedef
       flagtree: flagtree==0.5.1+xpu3.0
@@ -269,6 +282,7 @@ vendors:
     maca3.7.2.1:
       extras: metax
       hardware: ["MetaX C550"]
+      driver: "3.8.30"
       python: "3.12"
       triton: triton==3.0.0+metax3.7.2.0
       flagtree: flagtree==3.1.0+metax3.7.2.0
@@ -290,6 +304,7 @@ vendors:
     musa4.3.6:
       extras: mthreads-musa436
       hardware: ["MThreads MTT S5000"]
+      driver: "5.2.0-server"
       python: "3.10"
       cmake_backend: MUSA
       triton: triton==3.6.0+git89458660
@@ -314,6 +329,7 @@ vendors:
     musa5.2.0:
       extras: mthreads-musa520
       hardware: ["MThreads MTT S5000"]
+      driver: "5.2.0-server"
       python: "3.10"
       cmake_backend: MUSA
       triton: triton==3.6.0
@@ -349,6 +365,7 @@ vendors:
     tangrt1.2.0:
       extras: sunrise
       hardware: ["Sunrise SR-SUN-S2-X1"]
+      driver: "0.24.0"
       python: "3.10"
       triton: triton==3.4.0.6+gite4f6d6e4
       # flagtree==0.4.0+sunrise3.4 — requires GLIBC_2.39, unavailable on current system
@@ -386,6 +403,7 @@ vendors:
     tsm260604:
       extras: tsingmicro
       hardware: ["Tsingmicro TX8110"]
+      driver: "260604163331.01"
       python: "3.10"
       triton: triton==3.3.0+gitfe2a28fa
       flagtree: flagtree==0.5.0.post20260612+git705a4064

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -10,7 +10,7 @@ title: "ascend-cann8.5.0"
 
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
-- **Host container toolkit:** Ascend-docker-runtime >= 6.0.RC3
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: Ascend-docker-runtime >= 6.0.RC3
 
 ## System packages
 
@@ -26,16 +26,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**Recommended** — with the container toolkit (`Ascend-docker-runtime >= 6.0.RC3`):
+**With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-16-gac22f59 bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g78c7264 bash
 ```
 
-**Without the toolkit / podman** — raw device passthrough:
+**Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-16-gac22f59 bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -29,13 +29,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g78c7264 bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -4,31 +4,20 @@ title: "ascend-cann8.5.0"
 
 ## Base image
 
-`ubuntu:22.04`
+`ubuntu:24.04`
 
 ## Prerequisites
 
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
+- **Host container toolkit:** Ascend-docker-runtime >= 6.0.RC3
 
 ## System packages
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.9ubuntu3
-- `ca-certificates` — 20260601~22.04.1
-- `curl` — 7.81.0
-- `g++` — 11.2.0
-- `gcc` — 11.2.0
-- `libelf1` — 0.186
-- `libpython3-dev` — 3.10.6
-- `make` — 4.3
-- `net-tools` — 1.60+git20181103.0eebece
-- `pciutils` — 3.7.0
-- `python3-pip` — 22.0.2+dfsg
-- `python3.11` — 3.11.0~rc1
-- `python3.11-dev` — 3.11.0~rc1
-- `unzip` — 6.0
+- `ca-certificates`
+- `software-properties-common`
 
 ## SDK components
 
@@ -37,10 +26,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+**Recommended** — with the container toolkit (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1 bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-16-gac22f59 bash
+```
+
+**Without the toolkit / podman** — raw device passthrough:
+
+```bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify
@@ -48,5 +43,5 @@ docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --devic
 Inside the container, confirm the accelerator is visible (the first run may take a moment):
 
 ```bash
-npu-smi info
+source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
 ```

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -10,6 +10,7 @@ title: "ascend-cann8.5.0"
 
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
+- **Host driver:** 25.5.0
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: Ascend-docker-runtime >= 6.0.RC3
 
 ## System packages
@@ -29,13 +30,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -10,6 +10,7 @@ title: "ascend-cann9.0.0"
 
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
+- **Host driver:** 26.0.rc1
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: Ascend-docker-runtime >= 6.0.RC3
 
 ## System packages
@@ -30,13 +31,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -10,7 +10,7 @@ title: "ascend-cann9.0.0"
 
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
-- **Host container toolkit:** Ascend-docker-runtime >= 6.0.RC3
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: Ascend-docker-runtime >= 6.0.RC3
 
 ## System packages
 
@@ -27,16 +27,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**Recommended** — with the container toolkit (`Ascend-docker-runtime >= 6.0.RC3`):
+**With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-16-gac22f59 bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g78c7264 bash
 ```
 
-**Without the toolkit / podman** — raw device passthrough:
+**Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-16-gac22f59 bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -30,13 +30,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g78c7264 bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -4,31 +4,20 @@ title: "ascend-cann9.0.0"
 
 ## Base image
 
-`ubuntu:22.04`
+`ubuntu:24.04`
 
 ## Prerequisites
 
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
+- **Host container toolkit:** Ascend-docker-runtime >= 6.0.RC3
 
 ## System packages
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.9ubuntu3
-- `ca-certificates` — 20260601~22.04.1
-- `curl` — 7.81.0
-- `g++` — 11.2.0
-- `gcc` — 11.2.0
-- `libelf1` — 0.186
-- `libpython3-dev` — 3.10.6
-- `make` — 4.3
-- `net-tools` — 1.60+git20181103.0eebece
-- `pciutils` — 3.7.0
-- `python3-pip` — 22.0.2+dfsg
-- `python3.11` — 3.11.0~rc1
-- `python3.11-dev` — 3.11.0~rc1
-- `unzip` — 6.0
+- `ca-certificates`
+- `software-properties-common`
 
 ## SDK components
 
@@ -38,10 +27,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+**Recommended** — with the container toolkit (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1 bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-16-gac22f59 bash
+```
+
+**Without the toolkit / podman** — raw device passthrough:
+
+```bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify
@@ -49,5 +44,5 @@ docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --devic
 Inside the container, confirm the accelerator is visible (the first run may take a moment):
 
 ```bash
-npu-smi info
+source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
 ```

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -4,7 +4,7 @@ title: "cambricon-neuware4.4.3"
 
 ## Base image
 
-`ubuntu:22.04`
+`ubuntu:24.04`
 
 ## Prerequisites
 
@@ -15,19 +15,19 @@ title: "cambricon-neuware4.4.3"
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.9ubuntu3
-- `ca-certificates` — 20260601~22.04.1
-- `cmake` — 3.22.1
-- `curl` — 7.81.0
-- `g++` — 11.2.0
-- `gcc` — 11.2.0
-- `gdb` — 12.1
-- `libc6-dev-i386` — 2.35
-- `libncurses5` — 6.3
-- `libtinfo5` — 6.3
-- `make` — 4.3
-- `pciutils` — 3.7.0
-- `unzip` — 6.0
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `gdb`
+- `libc6-dev-i386`
+- `libncurses6`
+- `libtinfo6`
+- `make`
+- `pciutils`
+- `unzip`
 
 ## SDK components
 
@@ -60,10 +60,10 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl -v /usr/bin/cnmon:/usr/bin/cnmon harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1 bash
+docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -10,6 +10,7 @@ title: "cambricon-neuware4.4.3"
 
 - **Architecture:** x86_64
 - **Chip models:** Cambricon MLU590
+- **Host driver:** 6.2.15
 
 ## System packages
 
@@ -63,7 +64,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -63,7 +63,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -63,7 +63,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-16-gac22f59 bash
+docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -10,6 +10,7 @@ title: "enflame-tops1.9.10"
 
 - **Architecture:** x86_64
 - **Chip models:** Enflame Zixiao C200 (S60)
+- **Host driver:** 1.9.10
 
 ## System packages
 
@@ -40,7 +41,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -40,7 +40,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-16-gac22f59 bash
+docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -15,12 +15,12 @@ title: "enflame-tops1.9.10"
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.10ubuntu1
-- `ca-certificates` — 20260601~24.04.1
-- `cmake` — 3.28.3
-- `curl` — 8.5.0
-- `g++` — 13.2.0
-- `gcc` — 13.2.0
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
 
 ## SDK components
 
@@ -37,10 +37,10 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1 bash
+docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -40,7 +40,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -10,6 +10,7 @@ title: "hygon-dtk26.04"
 
 - **Architecture:** x86_64
 - **Chip models:** Hygon BW1000
+- **Host driver:** 6.3.30-V1.4.1a
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: dcu-container-toolkit >= 1.3.0
 
 ## System packages
@@ -33,13 +34,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`dcu-container-toolkit >= 1.3.0`):
 
 ```bash
-docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-18-gb92aab6 bash
+docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -10,7 +10,7 @@ title: "hygon-dtk26.04"
 
 - **Architecture:** x86_64
 - **Chip models:** Hygon BW1000
-- **Host container toolkit:** dcu-container-toolkit >= 1.3.0
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: dcu-container-toolkit >= 1.3.0
 
 ## System packages
 
@@ -30,16 +30,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**Recommended** — with the container toolkit (`dcu-container-toolkit >= 1.3.0`):
+**With the container toolkit** *(optional)* (`dcu-container-toolkit >= 1.3.0`):
 
 ```bash
-docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-16-gac22f59 bash
+docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g78c7264 bash
 ```
 
-**Without the toolkit / podman** — raw device passthrough:
+**Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-16-gac22f59 bash
+docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -4,24 +4,25 @@ title: "hygon-dtk26.04"
 
 ## Base image
 
-`ubuntu:22.04`
+`ubuntu:24.04`
 
 ## Prerequisites
 
 - **Architecture:** x86_64
 - **Chip models:** Hygon BW1000
+- **Host container toolkit:** dcu-container-toolkit >= 1.3.0
 
 ## System packages
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.9ubuntu3
-- `ca-certificates` — 20260601~22.04.1
-- `cmake` — 3.22.1
-- `curl` — 7.81.0
-- `g++` — 11.2.0
-- `gcc` — 11.2.0
-- `pciutils` — 3.7.0
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `pciutils`
 
 ## SDK components
 
@@ -29,10 +30,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+**Recommended** — with the container toolkit (`dcu-container-toolkit >= 1.3.0`):
 
 ```bash
-docker run --rm -it --device /dev/kfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1 bash
+docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-16-gac22f59 bash
+```
+
+**Without the toolkit / podman** — raw device passthrough:
+
+```bash
+docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify
@@ -40,5 +47,5 @@ docker run --rm -it --device /dev/kfd --device /dev/dri --group-add video -v /op
 Inside the container, confirm the accelerator is visible (the first run may take a moment):
 
 ```bash
-hy-smi
+source /opt/hyhal/env.sh && hy-smi
 ```

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -33,13 +33,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`dcu-container-toolkit >= 1.3.0`):
 
 ```bash
-docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g78c7264 bash
+docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -16,12 +16,12 @@ title: "iluvatar-corex4.4.0"
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.10ubuntu1
-- `ca-certificates` — 20260601~24.04.1
-- `curl` — 8.5.0
-- `g++` — 13.2.0
-- `gcc` — 13.2.0
-- `unzip` — 6.0
+- `build-essential`
+- `ca-certificates`
+- `curl`
+- `g++`
+- `gcc`
+- `unzip`
 
 ## SDK components
 
@@ -36,10 +36,10 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+Launch with the container toolkit (`ix-container-toolkit >= 1.1.0`):
 
 ```bash
-docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1 bash
+docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -10,6 +10,7 @@ title: "iluvatar-corex4.4.0"
 
 - **Architecture:** x86_64
 - **Chip models:** Iluvatar BI-V150
+- **Host driver:** 4.4.0
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: ix-container-toolkit >= 1.1.0
 
 ## System packages
@@ -39,13 +40,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`ix-container-toolkit >= 1.1.0`):
 
 ```bash
-docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -39,13 +39,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`ix-container-toolkit >= 1.1.0`):
 
 ```bash
-docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g78c7264 bash
+docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -10,7 +10,7 @@ title: "iluvatar-corex4.4.0"
 
 - **Architecture:** x86_64
 - **Chip models:** Iluvatar BI-V150
-- **Host container toolkit:** ix-container-toolkit >= 1.1.0
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: ix-container-toolkit >= 1.1.0
 
 ## System packages
 
@@ -36,10 +36,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Launch with the container toolkit (`ix-container-toolkit >= 1.1.0`):
+**With the container toolkit** *(optional)* (`ix-container-toolkit >= 1.1.0`):
 
 ```bash
-docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-16-gac22f59 bash
+docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g78c7264 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it --device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -4,25 +4,26 @@ title: "kunlunxin-xre5.29.0"
 
 ## Base image
 
-`ubuntu:22.04`
+`ubuntu:24.04`
 
 ## Prerequisites
 
 - **Architecture:** x86_64
 - **Chip models:** Kunlunxin P800
+- **Host container toolkit:** xpu_container >= 1.0.13
 
 ## System packages
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.9ubuntu3
-- `ca-certificates` — 20260601~22.04.1
-- `cmake` — 3.22.1
-- `curl` — 7.81.0
-- `g++` — 11.2.0
-- `gcc` — 11.2.0
-- `kmod` — 29
-- `pciutils` — 3.7.0
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `kmod`
+- `pciutils`
 
 ## SDK components
 
@@ -37,10 +38,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+**Recommended** — with the container toolkit (`xpu_container >= 1.0.13`):
 
 ```bash
-docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1 bash
+docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-16-gac22f59 bash
+```
+
+**Without the toolkit / podman** — raw device passthrough:
+
+```bash
+docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -41,13 +41,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`xpu_container >= 1.0.13`):
 
 ```bash
-docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g78c7264 bash
+docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -10,7 +10,7 @@ title: "kunlunxin-xre5.29.0"
 
 - **Architecture:** x86_64
 - **Chip models:** Kunlunxin P800
-- **Host container toolkit:** xpu_container >= 1.0.13
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: xpu_container >= 1.0.13
 
 ## System packages
 
@@ -38,16 +38,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**Recommended** — with the container toolkit (`xpu_container >= 1.0.13`):
+**With the container toolkit** *(optional)* (`xpu_container >= 1.0.13`):
 
 ```bash
-docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-16-gac22f59 bash
+docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g78c7264 bash
 ```
 
-**Without the toolkit / podman** — raw device passthrough:
+**Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-16-gac22f59 bash
+docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -10,6 +10,7 @@ title: "kunlunxin-xre5.29.0"
 
 - **Architecture:** x86_64
 - **Chip models:** Kunlunxin P800
+- **Host driver:** 5.29.0.0
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: xpu_container >= 1.0.13
 
 ## System packages
@@ -41,13 +42,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`xpu_container >= 1.0.13`):
 
 ```bash
-docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -10,6 +10,7 @@ title: "metax-maca3.7.2.1"
 
 - **Architecture:** x86_64
 - **Chip models:** MetaX C550
+- **Host driver:** 3.8.30
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: metax-docker >= 0.15.3
 
 ## System packages
@@ -43,13 +44,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`metax-docker >= 0.15.3`):
 
 ```bash
-metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-18-gb92aab6 bash
+metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -10,7 +10,7 @@ title: "metax-maca3.7.2.1"
 
 - **Architecture:** x86_64
 - **Chip models:** MetaX C550
-- **Host container toolkit:** metax-docker >= 0.15.3
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: metax-docker >= 0.15.3
 
 ## System packages
 
@@ -40,16 +40,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**Recommended** — with the container toolkit (`metax-docker >= 0.15.3`):
+**With the container toolkit** *(optional)* (`metax-docker >= 0.15.3`):
 
 ```bash
-metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-16-gac22f59 bash
+metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g78c7264 bash
 ```
 
-**Without the toolkit / podman** — raw device passthrough:
+**Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-16-gac22f59 bash
+docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -43,13 +43,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`metax-docker >= 0.15.3`):
 
 ```bash
-metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g78c7264 bash
+metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -10,21 +10,22 @@ title: "metax-maca3.7.2.1"
 
 - **Architecture:** x86_64
 - **Chip models:** MetaX C550
+- **Host container toolkit:** metax-docker >= 0.15.3
 
 ## System packages
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.10ubuntu1
-- `ca-certificates` — 20260601~24.04.1
-- `cmake` — 3.28.3
-- `curl` — 8.5.0
-- `g++` — 13.2.0
-- `gcc` — 13.2.0
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
 - `libelf1`
-- `libnuma1` — 2.0.18
-- `libpython3-dev` — 3.12.3
-- `make` — 4.3
+- `libnuma1`
+- `libpython3-dev`
+- `make`
 
 ## SDK components
 
@@ -39,10 +40,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+**Recommended** — with the container toolkit (`metax-docker >= 0.15.3`):
 
 ```bash
-docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1 bash
+metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-16-gac22f59 bash
+```
+
+**Without the toolkit / podman** — raw device passthrough:
+
+```bash
+docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -4,7 +4,7 @@ title: "mthreads-musa4.3.6"
 
 ## Base image
 
-`ubuntu:22.04`
+`ubuntu:24.04`
 
 ## Prerequisites
 
@@ -16,18 +16,18 @@ title: "mthreads-musa4.3.6"
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.9ubuntu3
-- `ca-certificates` — 20260601~22.04.1
-- `cmake` — 3.22.1
-- `curl` — 7.81.0
-- `g++` — 11.2.0
-- `gcc` — 11.2.0
-- `libelf1` — 0.186
-- `libgfortran5` — 12.3.0
-- `libnuma-dev` — 2.0.14
-- `libopenmpi-dev` — 4.1.2
-- `libpython3-dev` — 3.10.6
-- `openmpi-bin` — 4.1.2
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libgfortran5`
+- `libnuma-dev`
+- `libopenmpi-dev`
+- `libpython3-dev`
+- `openmpi-bin`
 
 ## SDK components
 
@@ -43,10 +43,10 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+Launch with the container toolkit (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1 bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -10,7 +10,7 @@ title: "mthreads-musa4.3.6"
 
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
-- **Host container toolkit:** KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
 ## System packages
 
@@ -43,10 +43,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Launch with the container toolkit (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
+**With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-16-gac22f59 bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g78c7264 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -10,6 +10,7 @@ title: "mthreads-musa4.3.6"
 
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
+- **Host driver:** 5.2.0-server
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
 ## System packages
@@ -46,13 +47,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-18-gb92aab6 bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -46,13 +46,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g78c7264 bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -10,6 +10,7 @@ title: "mthreads-musa5.2.0"
 
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
+- **Host driver:** 5.2.0-server
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
 ## System packages
@@ -46,13 +47,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -46,13 +46,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g78c7264 bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -10,7 +10,7 @@ title: "mthreads-musa5.2.0"
 
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
-- **Host container toolkit:** KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
 ## System packages
 
@@ -43,10 +43,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Launch with the container toolkit (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
+**With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-16-gac22f59 bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g78c7264 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -4,7 +4,7 @@ title: "mthreads-musa5.2.0"
 
 ## Base image
 
-`ubuntu:22.04`
+`ubuntu:24.04`
 
 ## Prerequisites
 
@@ -16,18 +16,18 @@ title: "mthreads-musa5.2.0"
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.9ubuntu3
-- `ca-certificates` — 20260601~22.04.1
-- `cmake` — 3.22.1
-- `curl` — 7.81.0
-- `g++` — 11.2.0
-- `gcc` — 11.2.0
-- `libelf1` — 0.186
-- `libgfortran5` — 12.3.0
-- `libnuma-dev` — 2.0.14
-- `libopenmpi-dev` — 4.1.2
-- `libpython3-dev` — 3.10.6
-- `openmpi-bin` — 4.1.2
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libgfortran5`
+- `libnuma-dev`
+- `libopenmpi-dev`
+- `libpython3-dev`
+- `openmpi-bin`
 
 ## SDK components
 
@@ -43,10 +43,10 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+Launch with the container toolkit (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1 bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -41,13 +41,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g78c7264 bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -10,6 +10,7 @@ title: "nvidia-cuda12.8"
 
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
+- **Host driver:** 610.43.02
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: nvidia-container-toolkit
 
 ## System packages
@@ -41,13 +42,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-18-gb92aab6 bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -16,16 +16,16 @@ title: "nvidia-cuda12.8"
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.10ubuntu1
-- `ca-certificates` — 20260601~24.04.1
-- `cmake` — 3.28.3
-- `curl` — 8.5.0
-- `g++` — 13.2.0
-- `gcc` — 13.2.0
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
 - `libelf1`
-- `libnuma1` — 2.0.18
-- `libpython3-dev` — 3.12.3
-- `make` — 4.3
+- `libnuma1`
+- `libpython3-dev`
+- `make`
 
 ## SDK components
 
@@ -38,10 +38,10 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+Launch with the container toolkit (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1 bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -10,7 +10,7 @@ title: "nvidia-cuda12.8"
 
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
-- **Host container toolkit:** nvidia-container-toolkit
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: nvidia-container-toolkit
 
 ## System packages
 
@@ -38,10 +38,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Launch with the container toolkit (`nvidia-container-toolkit`):
+**With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-16-gac22f59 bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g78c7264 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -16,16 +16,16 @@ title: "nvidia-cuda13.3"
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.10ubuntu1
-- `ca-certificates` — 20260601~24.04.1
-- `cmake` — 3.28.3
-- `curl` — 8.5.0
-- `g++` — 13.2.0
-- `gcc` — 13.2.0
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
 - `libelf1`
-- `libnuma1` — 2.0.18
-- `libpython3-dev` — 3.12.3
-- `make` — 4.3
+- `libnuma1`
+- `libpython3-dev`
+- `make`
 
 ## SDK components
 
@@ -38,10 +38,10 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+Launch with the container toolkit (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1 bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -10,6 +10,7 @@ title: "nvidia-cuda13.3"
 
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
+- **Host driver:** 610.43.02
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: nvidia-container-toolkit
 
 ## System packages
@@ -41,13 +42,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-18-gb92aab6 bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-19-ge0c6cbb bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -41,13 +41,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g78c7264 bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-18-gb92aab6 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -10,7 +10,7 @@ title: "nvidia-cuda13.3"
 
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
-- **Host container toolkit:** nvidia-container-toolkit
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: nvidia-container-toolkit
 
 ## System packages
 
@@ -38,10 +38,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Launch with the container toolkit (`nvidia-container-toolkit`):
+**With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-16-gac22f59 bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g78c7264 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -41,7 +41,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell in the container:
 
 ```bash
-docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-16-gac22f59 bash
+docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -15,13 +15,13 @@ title: "sunrise-tangrt1.2.0"
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.10ubuntu1
-- `ca-certificates` — 20260601~24.04.1
-- `cmake` — 3.28.3
-- `curl` — 8.5.0
-- `g++` — 13.2.0
-- `gcc` — 13.2.0
-- `pciutils` — 3.10.0
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `pciutils`
 
 ## SDK components
 
@@ -41,7 +41,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell in the container:
 
 ```bash
-docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1 bash
+docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -41,7 +41,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell in the container:
 
 ```bash
-docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-17-g78c7264 bash
+docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -10,6 +10,7 @@ title: "sunrise-tangrt1.2.0"
 
 - **Architecture:** x86_64
 - **Chip models:** Sunrise SR-SUN-S2-X1
+- **Host driver:** 0.24.0
 
 ## System packages
 
@@ -41,7 +42,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell in the container:
 
 ```bash
-docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-18-gb92aab6 bash
+docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -54,7 +54,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-16-gac22f59 bash
+docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-17-g78c7264 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -10,6 +10,7 @@ title: "tsingmicro-tsm260604"
 
 - **Architecture:** x86_64
 - **Chip models:** Tsingmicro TX8110
+- **Host driver:** 260604163331.01
 
 ## System packages
 
@@ -54,7 +55,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-18-gb92aab6 bash
+docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-19-ge0c6cbb bash
 ```
 
 ## Verify

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -54,7 +54,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-17-g78c7264 bash
+docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-18-gb92aab6 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -4,7 +4,7 @@ title: "tsingmicro-tsm260604"
 
 ## Base image
 
-`ubuntu:22.04`
+`ubuntu:24.04`
 
 ## Prerequisites
 
@@ -15,18 +15,18 @@ title: "tsingmicro-tsm260604"
 
 Explicitly installed; the version is the one baked into this image:
 
-- `build-essential` — 12.9ubuntu3
-- `ca-certificates` — 20260601~22.04.1
-- `clang` — 14.0
-- `cmake` — 3.22.1
-- `curl` — 7.81.0
-- `g++` — 11.2.0
-- `gcc` — 11.2.0
-- `libfmt-dev` — 8.1.1+ds1
-- `libopenmpi3` — 4.1.2
-- `libpython3-dev` — 3.10.6
-- `libunwind8` — 1.3.2
-- `sudo` — 1.9.9
+- `build-essential`
+- `ca-certificates`
+- `clang`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libfmt-dev`
+- `libopenmpi3`
+- `libpython3-dev`
+- `libunwind8`
+- `sudo`
 
 ## SDK components
 
@@ -51,10 +51,10 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell in the container:
+Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --privileged --ipc=host -v /dev:/dev -v /lib/modules:/lib/modules harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1 bash
+docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-16-gac22f59 bash
 ```
 
 ## Verify
@@ -62,5 +62,5 @@ docker run --rm -it --privileged --ipc=host -v /dev:/dev -v /lib/modules:/lib/mo
 Inside the container, confirm the accelerator is visible (the first run may take a moment):
 
 ```bash
-tsm-smi
+tsm_smi
 ```

--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -196,6 +196,40 @@ def main():
     run_prereq = run_cfg.get("prereq") or {}
     verify_vendors = (build_config.get("verify") or {}).get("vendors") or {}
 
+    def launch_tiers(vendor):
+        """Ordered launch tiers for a vendor: a list of {kind, template}. `kind`
+        is 'toolkit' (recommended, needs the container toolkit), 'raw' (device
+        passthrough, docker/podman), or 'generic' (plain run, no device flags).
+        `template` carries an `{image}` placeholder so each renderer can drop in
+        the base or runtime image. Renderers map `kind` to a label (English in
+        gen_descriptions, i18n in the Hugo shortcodes), so the list is
+        language-neutral.
+
+        Presence rules on the vendor's run entry (a map): a `toolkit`/`toolkit_cmd`
+        key -> toolkit tier; a `raw` key -> raw tier (empty string -> generic);
+        no `raw` key -> no raw tier (toolkit-only). A legacy bare string is raw
+        flags; an unlisted vendor gets a generic tier from the default."""
+        rv = run_vendors.get(vendor)
+        d = rv if isinstance(rv, dict) else {}
+        tiers = []
+        if d.get("toolkit_cmd"):
+            tiers.append({"kind": "toolkit", "template": d["toolkit_cmd"]})
+        elif d.get("toolkit"):
+            tiers.append({"kind": "toolkit", "template": f"docker run --rm -it {d['toolkit']} {{image}} bash"})
+        if isinstance(rv, dict) and "raw" in d:
+            raw = d["raw"]
+        elif isinstance(rv, str):
+            raw = rv
+        elif rv is None:
+            raw = run_default  # unlisted vendor -> generic
+        else:
+            raw = None         # dict without a raw key -> toolkit-only
+        if raw is not None:
+            flags = f"{raw} " if raw else ""
+            tiers.append({"kind": "raw" if raw else "generic",
+                          "template": f"docker run --rm -it {flags}{{image}} bash"})
+        return tiers
+
     def image(prefix, kind, name, tag):
         base = f"flagos-{kind}-{name}"
         base = f"{prefix}/{base}" if prefix else base
@@ -220,7 +254,7 @@ def main():
                     "name": name,
                     "vendor": vendor,
                     "backend": backend,
-                    "run": run_vendors.get(vendor, run_default),
+                    "launch": launch_tiers(vendor),
                     "run_prereq": run_prereq.get(vendor, ""),
                     "verify": verify_vendors.get(vendor, ""),
                     "base": {

--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -262,6 +262,7 @@ def main():
                         "os": meta["base_os"] or "",
                         "arch": arch,
                         "hardware": spec.get("hardware") or [],
+                        "driver": spec.get("driver", ""),
                         "system_packages": meta["system_packages"],
                         "sdk": sdk,
                         "env": env.get("base") or {},

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -114,11 +114,27 @@ def render(entry: dict, versions: dict) -> str:
         lines.append("")
 
     # ── Launch ──────────────────────────────────────────────────
-    run_flags = entry.get("run") or ""
-    flags = f"{run_flags} " if run_flags else ""
-    lines += ["## Launch", ""]
-    lines += ["Start an interactive shell in the container:", ""]
-    lines += ["```bash", f"docker run --rm -it {flags}{base['image']} bash", "```", ""]
+    # One block per launch tier (see gen_data.launch_tiers). When a vendor has both
+    # a toolkit and a raw tier, the toolkit one is labelled "Recommended" and the raw
+    # one is the no-toolkit/podman fallback; a lone tier gets a plain header.
+    image = base["image"]
+    tiers = entry.get("launch") or []
+    prereq = entry.get("run_prereq") or ""
+    both = any(t["kind"] == "toolkit" for t in tiers) and any(t["kind"] == "raw" for t in tiers)
+    if tiers:
+        lines += ["## Launch", ""]
+        for t in tiers:
+            cmd = t["template"].replace("{image}", image)
+            if t["kind"] == "toolkit":
+                tk = f" (`{prereq}`)" if prereq else ""
+                hdr = (f"**Recommended** — with the container toolkit{tk}:" if both
+                       else f"Launch with the container toolkit{tk}:")
+            elif t["kind"] == "raw":
+                hdr = ("**Without the toolkit / podman** — raw device passthrough:" if both
+                       else "Start an interactive shell (works with docker or podman):")
+            else:  # generic
+                hdr = "Start an interactive shell in the container:"
+            lines += [hdr, "", "```bash", cmd, "```", ""]
 
     # ── Verify ──────────────────────────────────────────────────
     # Shown as a SEPARATE command to run INSIDE the launched container (not

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -84,7 +84,14 @@ def render(entry: dict, versions: dict) -> str:
         lines.append(f"- **Chip models:** {', '.join(hw)}")
     toolkit = entry.get("run_prereq") or ""
     if toolkit:
-        lines.append(f"- **Host container toolkit:** {toolkit}")
+        # The container toolkit is only needed for the recommended (toolkit) launch.
+        # Where a raw/generic tier also exists it's optional — the raw command needs
+        # no toolkit; it's only truly required for toolkit-only backends.
+        has_raw = any(t["kind"] in ("raw", "generic") for t in (entry.get("launch") or []))
+        if has_raw:
+            lines.append(f"- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: {toolkit}")
+        else:
+            lines.append(f"- **Container toolkit:** {toolkit}")
     lines.append("")
 
     # ── System packages (explicit apt, with baked-in versions) ──
@@ -127,10 +134,10 @@ def render(entry: dict, versions: dict) -> str:
             cmd = t["template"].replace("{image}", image)
             if t["kind"] == "toolkit":
                 tk = f" (`{prereq}`)" if prereq else ""
-                hdr = (f"**Recommended** — with the container toolkit{tk}:" if both
-                       else f"Launch with the container toolkit{tk}:")
+                opt = " *(optional)*" if both else ""
+                hdr = f"**With the container toolkit**{opt}{tk}:"
             elif t["kind"] == "raw":
-                hdr = ("**Without the toolkit / podman** — raw device passthrough:" if both
+                hdr = ("**Without a toolkit** — plain docker / podman:" if both
                        else "Start an interactive shell (works with docker or podman):")
             else:  # generic
                 hdr = "Start an interactive shell in the container:"

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -82,6 +82,9 @@ def render(entry: dict, versions: dict) -> str:
     hw = base.get("hardware") or []
     if hw:
         lines.append(f"- **Chip models:** {', '.join(hw)}")
+    drv = base.get("driver") or ""
+    if drv:
+        lines.append(f"- **Host driver:** {drv}")
     toolkit = entry.get("run_prereq") or ""
     if toolkit:
         # The container toolkit is only needed for the recommended (toolkit) launch.

--- a/docs/i18n/en.toml
+++ b/docs/i18n/en.toml
@@ -52,5 +52,20 @@ other = "Run"
 [run_todo]
 other = "Device flags for this vendor aren't finalized yet — this generic command may need vendor-specific --device / --gpus flags."
 
+[run_recommended]
+other = "Recommended — with the container toolkit"
+
+[run_toolkit_only]
+other = "Launch with the container toolkit"
+
+[run_raw]
+other = "Without the toolkit / podman — raw device passthrough"
+
+[run_raw_only]
+other = "Launch (works with docker or podman)"
+
+[run_generic]
+other = "Start an interactive shell in the container"
+
 [runtime_tag_note]
 other = "tag scheme being finalized"

--- a/docs/i18n/en.toml
+++ b/docs/i18n/en.toml
@@ -67,5 +67,8 @@ other = "Launch (works with docker or podman)"
 [run_generic]
 other = "Start an interactive shell in the container"
 
+[host_driver]
+other = "Host driver"
+
 [runtime_tag_note]
 other = "tag scheme being finalized"

--- a/docs/i18n/en.toml
+++ b/docs/i18n/en.toml
@@ -53,13 +53,13 @@ other = "Run"
 other = "Device flags for this vendor aren't finalized yet — this generic command may need vendor-specific --device / --gpus flags."
 
 [run_recommended]
-other = "Recommended — with the container toolkit"
+other = "With the container toolkit (optional)"
 
 [run_toolkit_only]
-other = "Launch with the container toolkit"
+other = "With the container toolkit"
 
 [run_raw]
-other = "Without the toolkit / podman — raw device passthrough"
+other = "Without a toolkit — plain docker / podman"
 
 [run_raw_only]
 other = "Launch (works with docker or podman)"

--- a/docs/i18n/zh-cn.toml
+++ b/docs/i18n/zh-cn.toml
@@ -66,5 +66,8 @@ other = "启动（docker 或 podman 均可）"
 [run_generic]
 other = "在容器中启动交互式 shell"
 
+[host_driver]
+other = "宿主机驱动"
+
 [runtime_tag_note]
 other = "tag 方案待定"

--- a/docs/i18n/zh-cn.toml
+++ b/docs/i18n/zh-cn.toml
@@ -52,13 +52,13 @@ other = "运行"
 other = "该厂商的设备标志尚未最终确定——这条通用命令可能需要补充厂商特定的 --device / --gpus 标志。"
 
 [run_recommended]
-other = "推荐 —— 使用容器工具包"
+other = "使用容器工具包（可选）"
 
 [run_toolkit_only]
-other = "使用容器工具包启动"
+other = "使用容器工具包"
 
 [run_raw]
-other = "不使用工具包 / podman —— 原始设备直通"
+other = "无需工具包 —— 直接使用 docker / podman"
 
 [run_raw_only]
 other = "启动（docker 或 podman 均可）"

--- a/docs/i18n/zh-cn.toml
+++ b/docs/i18n/zh-cn.toml
@@ -51,5 +51,20 @@ other = "运行"
 [run_todo]
 other = "该厂商的设备标志尚未最终确定——这条通用命令可能需要补充厂商特定的 --device / --gpus 标志。"
 
+[run_recommended]
+other = "推荐 —— 使用容器工具包"
+
+[run_toolkit_only]
+other = "使用容器工具包启动"
+
+[run_raw]
+other = "不使用工具包 / podman —— 原始设备直通"
+
+[run_raw_only]
+other = "启动（docker 或 podman 均可）"
+
+[run_generic]
+other = "在容器中启动交互式 shell"
+
 [runtime_tag_note]
 other = "tag 方案待定"

--- a/docs/layouts/shortcodes/base-image.html
+++ b/docs/layouts/shortcodes/base-image.html
@@ -37,9 +37,20 @@
 {{- end }}
 
 <h3>{{ T "run" }}</h3>
-<pre><code>{{ with .run_prereq }}# {{ T "run_prereq" }} {{ . }}
-{{ end }}docker run --rm -it {{ with .run }}{{ . }} {{ end }}{{ $b.image }} bash</code></pre>
-{{- if not .run }}
+{{- $bk := . -}}
+{{- $img := $b.image -}}
+{{- $both := and (gt (len (where .launch "kind" "toolkit")) 0) (gt (len (where .launch "kind" "raw")) 0) -}}
+{{- range .launch }}
+  {{- if eq .kind "toolkit" }}
+<p>{{ if $both }}{{ T "run_recommended" }}{{ else }}{{ T "run_toolkit_only" }}{{ end }}{{ with $bk.run_prereq }} (<code class="plain">{{ . }}</code>){{ end }}:</p>
+  {{- else if eq .kind "raw" }}
+<p>{{ if $both }}{{ T "run_raw" }}{{ else }}{{ T "run_raw_only" }}{{ end }}:</p>
+  {{- else }}
+<p>{{ T "run_generic" }}:</p>
+  {{- end }}
+<pre><code>{{ replace .template "{image}" $img }}</code></pre>
+{{- end }}
+{{- if not .launch }}
 <p><em>{{ T "run_todo" }}</em></p>
 {{- end }}
 

--- a/docs/layouts/shortcodes/base-image.html
+++ b/docs/layouts/shortcodes/base-image.html
@@ -7,6 +7,9 @@
 <ul>
   <li><strong>{{ T "image" }}:</strong> <code class="plain">{{ $b.image }}</code></li>
   <li><strong>{{ T "base_os" }}:</strong> <code class="plain">{{ $b.os }}</code></li>
+  {{- with $b.driver }}
+  <li><strong>{{ T "host_driver" }}:</strong> <code class="plain">{{ . }}</code></li>
+  {{- end }}
 </ul>
 
 {{- with $b.system_packages }}

--- a/docs/layouts/shortcodes/runtime-image.html
+++ b/docs/layouts/shortcodes/runtime-image.html
@@ -7,6 +7,9 @@
 <ul>
   <li><strong>{{ T "image" }}:</strong> <code class="plain">{{ $r.image }}</code> <em>({{ T "runtime_tag_note" }})</em></li>
   <li><strong>{{ T "python" }}:</strong> {{ $r.python }}</li>
+  {{- with .base.driver }}
+  <li><strong>{{ T "host_driver" }}:</strong> <code class="plain">{{ . }}</code></li>
+  {{- end }}
 </ul>
 
 <h4>{{ T "major_packages" }}</h4>

--- a/docs/layouts/shortcodes/runtime-image.html
+++ b/docs/layouts/shortcodes/runtime-image.html
@@ -29,9 +29,20 @@
 {{- end }}
 
 <h3>{{ T "run" }}</h3>
-<pre><code>{{ with .run_prereq }}# {{ T "run_prereq" }} {{ . }}
-{{ end }}docker run --rm -it {{ with .run }}{{ . }} {{ end }}{{ $r.image }} bash</code></pre>
-{{- if not .run }}
+{{- $bk := . -}}
+{{- $img := $r.image -}}
+{{- $both := and (gt (len (where .launch "kind" "toolkit")) 0) (gt (len (where .launch "kind" "raw")) 0) -}}
+{{- range .launch }}
+  {{- if eq .kind "toolkit" }}
+<p>{{ if $both }}{{ T "run_recommended" }}{{ else }}{{ T "run_toolkit_only" }}{{ end }}{{ with $bk.run_prereq }} (<code class="plain">{{ . }}</code>){{ end }}:</p>
+  {{- else if eq .kind "raw" }}
+<p>{{ if $both }}{{ T "run_raw" }}{{ else }}{{ T "run_raw_only" }}{{ end }}:</p>
+  {{- else }}
+<p>{{ T "run_generic" }}:</p>
+  {{- end }}
+<pre><code>{{ replace .template "{image}" $img }}</code></pre>
+{{- end }}
+{{- if not .launch }}
 <p><em>{{ T "run_todo" }}</em></p>
 {{- end }}
 


### PR DESCRIPTION
## What
The per-image **Launch** section (docs site, in-repo `.md`, Harbor descriptions) now
shows up to **two launch styles** per image:
- **Recommended** — using the vendor's container toolkit (`--gpus all`, `--runtime X`,
  `-e X_VISIBLE_DEVICES`, or a wrapper like `metax-docker`), with its host prerequisite.
- **Without the toolkit / podman** — raw device passthrough that works with plain
  docker/podman + the vendor driver (used where the smi tool is baked into the image).

Each image renders whichever tiers apply; a lone raw tier gets a plain header, sunrise
gets a generic `docker run`.

## How (docs-pipeline only — zero CI risk)
- `.github/build-config.yml`: `run.vendors.<v>` becomes a map of `{toolkit | toolkit_cmd | raw}`
  (was a single flag string). `toolkit_cmd` handles wrapper launchers that replace `docker run`.
- `docs/gen_data.py` (`launch_tiers`): emits an ordered, image-agnostic `launch[]` list
  (`kind` + `{image}`-placeholder template) into `images.yaml`.
- Renderers map `kind` → label: `gen_descriptions.py` (English base `.md`, hardcoded English),
  `base-image.html` (zh-cn base) and `runtime-image.html` (runtime pages) via new i18n keys.

## Per-vendor coverage (all hardware- or maintainer-verified)
| Tier shape | Vendors |
|---|---|
| both (toolkit + raw) | ascend, hygon, metax, kunlunxin |
| toolkit-only (smi runtime-injected) | nvidia, mthreads, iluvatar |
| raw-only | cambricon (no toolkit), tsingmicro, enflame |
| generic | sunrise |

Toolkit prerequisites are version-pinned where known (`dcu-container-toolkit >= 1.3.0`,
`metax-docker >= 0.15.3`, `xpu_container >= 1.0.13`, `Ascend-docker-runtime >= 6.0.RC3`, …).

## Notes
- **kunlunxin toolkit** was debugged + verified this session: the `.deb` install skips
  `xpu-ctk runtime configure --runtime=docker` (+ docker restart), and the device env var is
  **`CXPU_VISIBLE_DEVICES`** (explicit index), not the `XPU_VISIBLE_DEVICES=all` the vendor docs imply.
- **enflame + tsingmicro** stay raw-only pending vendor confirmation of a toolkit — tracked in #128
  (adding a tier later is one line in build-config).
