### PR TITLE
Finalize base image descriptions: toolkit tiers + page refactor

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -82,10 +82,11 @@ run:
       toolkit: "--runtime xpu -e CXPU_VISIBLE_DEVICES=0"
       raw: "--device /dev/xpu0 --device /dev/xpuctrl"
     tsingmicro:
-      # TODO toolkit: checking with Tsingmicro (#128).
+      toolkit: "--runtime=tsingmicro -e TSINGMICRO_VISIBLE_DEVICES=all"
       raw: "--device /dev/accel --device /dev/accel_drv_mgr"
     enflame:
-      # TODO toolkit: awaiting Enflame (#128).
+      # gotcha: toolkit uses --network host + env var, no --runtime flag.
+      toolkit: "--network host -e TENCENT_VISIBLE_DEVICES=all"
       raw: "--device /dev/gcu"
     sunrise:
       # generic launch only — no device flags / toolkit known.
@@ -101,6 +102,8 @@ run:
     kunlunxin: "xpu_container >= 1.0.13"
     mthreads: "KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0"
     iluvatar: "ix-container-toolkit >= 1.1.0"
+    tsingmicro: "tx-container-toolkit >= 2.5.0"
+    enflame: "tencent-container-toolkit >= 2.0.52"
 
 # Device-enumeration command per vendor: shown in the docs/description sample
 # launch line (`docker run <run-flags> <image> <verify>`) to confirm the

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -30,13 +30,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -31,13 +31,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -64,7 +64,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -11,6 +11,7 @@ title: "enflame-tops1.9.10"
 - **Architecture:** x86_64
 - **Chip models:** Enflame Zixiao C200 (S60)
 - **Host driver:** 1.9.10
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: tencent-container-toolkit >= 2.0.52
 
 ## System packages
 
@@ -38,10 +39,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell (works with docker or podman):
+**With the container toolkit** *(optional)* (`tencent-container-toolkit >= 2.0.52`):
 
 ```bash
-docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --network host -e TENCENT_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-17-g361735c bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -34,13 +34,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`dcu-container-toolkit >= 1.3.0`):
 
 ```bash
-docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-19-ge0c6cbb bash
+docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -40,13 +40,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`ix-container-toolkit >= 1.1.0`):
 
 ```bash
-docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -42,13 +42,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`xpu_container >= 1.0.13`):
 
 ```bash
-docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -44,13 +44,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`metax-docker >= 0.15.3`):
 
 ```bash
-metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-19-ge0c6cbb bash
+metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -47,13 +47,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -47,13 +47,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -42,13 +42,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -42,13 +42,13 @@ Explicitly installed; the version is the one baked into this image:
 **With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -42,7 +42,7 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell in the container:
 
 ```bash
-docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-19-ge0c6cbb bash
+docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -11,6 +11,7 @@ title: "tsingmicro-tsm260604"
 - **Architecture:** x86_64
 - **Chip models:** Tsingmicro TX8110
 - **Host driver:** 260604163331.01
+- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: tx-container-toolkit >= 2.5.0
 
 ## System packages
 
@@ -52,10 +53,16 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-Start an interactive shell (works with docker or podman):
+**With the container toolkit** *(optional)* (`tx-container-toolkit >= 2.5.0`):
 
 ```bash
-docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-19-ge0c6cbb bash
+docker run --rm -it --runtime=tsingmicro -e TSINGMICRO_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-17-g361735c bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-17-g361735c bash
 ```
 
 ## Verify


### PR DESCRIPTION
Adds the last two container-toolkit launch tiers, closing the tiered-launch gaps.

- **tsingmicro**: `--runtime=tsingmicro -e TSINGMICRO_VISIBLE_DEVICES=all` (`tx-container-toolkit >= 2.5.0`) — verified on the TX8110 node (runtime injects `/dev/accel*`, `tsm_smi` sees 32 chips).
- **enflame**: `--network host -e TENCENT_VISIBLE_DEVICES=all` (`tencent-container-toolkit >= 2.0.52`; no `--runtime` flag — Tencent backs Enflame) — maintainer-verified.

Every device backend now renders both a toolkit tier and a raw/podman tier; only cambricon (no toolkit) and sunrise (generic) differ.

Closes #128.