### PR TITLE
docs: refactor base image description page

### DIFF
--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -2,10 +2,6 @@
 title: "ascend-cann8.5.0"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** aarch64
@@ -13,35 +9,51 @@ title: "ascend-cann8.5.0"
 - **Host driver:** 25.5.0
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: Ascend-docker-runtime >= 6.0.RC3
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
 - `ca-certificates`
 - `software-properties-common`
 
-## SDK components
+### SDK components
 
 - CANN Toolkit 8.5.0 (aarch64)
 - CANN 910B Ops 8.5.0 (aarch64)
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  -e ASCEND_VISIBLE_DEVICES=0 \
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/davinci0 \
+  --device /dev/davinci_manager \
+  --device /dev/devmm_svm \
+  --device /dev/hisi_hdc \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -2,10 +2,6 @@
 title: "ascend-cann9.0.0"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** aarch64
@@ -13,14 +9,20 @@ title: "ascend-cann9.0.0"
 - **Host driver:** 26.0.rc1
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: Ascend-docker-runtime >= 6.0.RC3
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
 - `ca-certificates`
 - `software-properties-common`
 
-## SDK components
+### SDK components
 
 - CANN Toolkit 9.0.0 (aarch64)
 - CANN 910B Ops 9.0.0 (aarch64)
@@ -28,21 +30,31 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`Ascend-docker-runtime >= 6.0.RC3`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it -e ASCEND_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  -e ASCEND_VISIBLE_DEVICES=0 \
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/davinci0 --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc -v /usr/local/Ascend/driver:/usr/local/Ascend/driver -v /usr/local/dcmi:/usr/local/dcmi -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/davinci0 \
+  --device /dev/davinci_manager \
+  --device /dev/devmm_svm \
+  --device /dev/hisi_hdc \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -2,17 +2,19 @@
 title: "cambricon-neuware4.4.3"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
 - **Chip models:** Cambricon MLU590
 - **Host driver:** 6.2.15
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -30,7 +32,7 @@ Explicitly installed; the version is the one baked into this image:
 - `pciutils`
 - `unzip`
 
-## SDK components
+### SDK components
 
 - cndev 6.5.25 (amd64)
 - cnmon 6.2.15
@@ -64,12 +66,15 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell (works with docker or podman):
 
 ```bash
-docker run --rm -it --device /dev/cambricon_dev0 --device /dev/cambricon_ctl harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/cambricon_dev0 \
+  --device /dev/cambricon_ctl \
+  harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 cnmon

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -2,10 +2,6 @@
 title: "enflame-tops1.9.10"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "enflame-tops1.9.10"
 - **Host driver:** 1.9.10
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: tencent-container-toolkit >= 2.0.52
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -24,7 +26,7 @@ Explicitly installed; the version is the one baked into this image:
 - `g++`
 - `gcc`
 
-## SDK components
+### SDK components
 
 - Enflame driver 1.9.10
 - TOPS Runtime 1.9.10
@@ -39,21 +41,26 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`tencent-container-toolkit >= 2.0.52`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it --network host -e TENCENT_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --network host \
+  -e TENCENT_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/gcu harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/gcu \
+  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 efsmi

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -2,10 +2,6 @@
 title: "hygon-dtk26.04"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "hygon-dtk26.04"
 - **Host driver:** 6.3.30-V1.4.1a
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: dcu-container-toolkit >= 1.3.0
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -25,27 +27,36 @@ Explicitly installed; the version is the one baked into this image:
 - `gcc`
 - `pciutils`
 
-## SDK components
+### SDK components
 
 - Hygon DTK 26.04
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`dcu-container-toolkit >= 1.3.0`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it -e DCU_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g361735c bash
+docker run --rm -it \
+  -e DCU_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/kfd \
+  --device /dev/mkfd \
+  --device /dev/dri \
+  --group-add video \
+  -v /opt/hyhal:/opt/hyhal \
+  --security-opt seccomp=unconfined \
+  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 source /opt/hyhal/env.sh && hy-smi

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -2,10 +2,6 @@
 title: "iluvatar-corex4.4.0"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "iluvatar-corex4.4.0"
 - **Host driver:** 4.4.0
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: ix-container-toolkit >= 1.1.0
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -24,7 +26,7 @@ Explicitly installed; the version is the one baked into this image:
 - `gcc`
 - `unzip`
 
-## SDK components
+### SDK components
 
 - Corex Runtime 4.4.0
 - CUDA Header files 260604
@@ -37,21 +39,27 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`ix-container-toolkit >= 1.1.0`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it --runtime iluvatar --env IX_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --runtime iluvatar \
+  --env IX_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/iluvatar0 -v /usr/local/corex:/usr/local/corex:ro harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/iluvatar0 \
+  -v /usr/local/corex:/usr/local/corex:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 ixsmi

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -2,10 +2,6 @@
 title: "kunlunxin-xre5.29.0"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "kunlunxin-xre5.29.0"
 - **Host driver:** 5.29.0.0
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: xpu_container >= 1.0.13
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -26,7 +28,7 @@ Explicitly installed; the version is the one baked into this image:
 - `kmod`
 - `pciutils`
 
-## SDK components
+### SDK components
 
 - CUDA 12.9.0_575.51.03
 - XRE-CUDA12 5.29.0.0
@@ -39,21 +41,27 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`xpu_container >= 1.0.13`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it --runtime xpu -e CXPU_VISIBLE_DEVICES=0 harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --runtime xpu \
+  -e CXPU_VISIBLE_DEVICES=0 \
+  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/xpu0 --device /dev/xpuctrl harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/xpu0 \
+  --device /dev/xpuctrl \
+  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 xpu-smi

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -2,10 +2,6 @@
 title: "metax-maca3.7.2.1"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "metax-maca3.7.2.1"
 - **Host driver:** 3.8.30
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: metax-docker >= 0.15.3
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -28,7 +30,7 @@ Explicitly installed; the version is the one baked into this image:
 - `libpython3-dev`
 - `make`
 
-## SDK components
+### SDK components
 
 - MetaX Driver 3.7.2.30
 - MACA SDK 3.7.2.0
@@ -41,21 +43,27 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`metax-docker >= 0.15.3`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-metax-docker --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g361735c bash
+metax-docker \
+  --gpus all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mxcd --device /dev/dri --group-add video harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/mxcd \
+  --device /dev/dri \
+  --group-add video \
+  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 mx-smi

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -2,10 +2,6 @@
 title: "mthreads-musa4.3.6"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "mthreads-musa4.3.6"
 - **Host driver:** 5.2.0-server
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -30,7 +32,7 @@ Explicitly installed; the version is the one baked into this image:
 - `libpython3-dev`
 - `openmpi-bin`
 
-## SDK components
+### SDK components
 
 - MUSA Toolkits RC4.3.6
 - MCCL RC2.1.6
@@ -44,21 +46,28 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --runtime mthreads \
+  --env MTHREADS_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/mtgpu.0 \
+  --device /dev/dri \
+  -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 mthreads-gmi

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -2,10 +2,6 @@
 title: "mthreads-musa5.2.0"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "mthreads-musa5.2.0"
 - **Host driver:** 5.2.0-server
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -30,7 +32,7 @@ Explicitly installed; the version is the one baked into this image:
 - `libpython3-dev`
 - `openmpi-bin`
 
-## SDK components
+### SDK components
 
 - MUSA Toolkits 5.2.0
 - MCCL 2.4.0
@@ -44,21 +46,28 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it --runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --runtime mthreads \
+  --env MTHREADS_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/mtgpu.0 --device /dev/dri -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/mtgpu.0 \
+  --device /dev/dri \
+  -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 mthreads-gmi

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -2,10 +2,6 @@
 title: "nvidia-cuda12.8"
 ---
 
-## Base image
-
-`nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "nvidia-cuda12.8"
 - **Host driver:** 610.43.02
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: nvidia-container-toolkit
 
-## System packages
+## Image contents
+
+### Base image
+
+`nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -28,7 +30,7 @@ Explicitly installed; the version is the one baked into this image:
 - `libpython3-dev`
 - `make`
 
-## SDK components
+### SDK components
 
 - CUDA 12.8 (x86_64)
 
@@ -39,21 +41,30 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --gpus all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/nvidia0 \
+  --device /dev/nvidiactl \
+  --device /dev/nvidia-uvm \
+  -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
+  -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
+  -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 nvidia-smi

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -2,10 +2,6 @@
 title: "nvidia-cuda13.3"
 ---
 
-## Base image
-
-`nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "nvidia-cuda13.3"
 - **Host driver:** 610.43.02
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: nvidia-container-toolkit
 
-## System packages
+## Image contents
+
+### Base image
+
+`nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -28,7 +30,7 @@ Explicitly installed; the version is the one baked into this image:
 - `libpython3-dev`
 - `make`
 
-## SDK components
+### SDK components
 
 - CUDA 13.3 (x86_64)
 
@@ -39,21 +41,30 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`nvidia-container-toolkit`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it --gpus all harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --gpus all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/nvidia0 \
+  --device /dev/nvidiactl \
+  --device /dev/nvidia-uvm \
+  -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
+  -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
+  -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 nvidia-smi

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -2,17 +2,19 @@
 title: "sunrise-tangrt1.2.0"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
 - **Chip models:** Sunrise SR-SUN-S2-X1
 - **Host driver:** 0.24.0
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -24,7 +26,7 @@ Explicitly installed; the version is the one baked into this image:
 - `gcc`
 - `pciutils`
 
-## SDK components
+### SDK components
 
 - Tang Toolkit 1.2.0
 - PCCL 1.2.0
@@ -42,12 +44,13 @@ Explicitly installed; the version is the one baked into this image:
 Start an interactive shell in the container:
 
 ```bash
-docker run --rm -it harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-17-g361735c bash
+docker run --rm -it \
+  harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 pt_smi

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -2,10 +2,6 @@
 title: "tsingmicro-tsm260604"
 ---
 
-## Base image
-
-`ubuntu:24.04`
-
 ## Prerequisites
 
 - **Architecture:** x86_64
@@ -13,7 +9,13 @@ title: "tsingmicro-tsm260604"
 - **Host driver:** 260604163331.01
 - **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: tx-container-toolkit >= 2.5.0
 
-## System packages
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
 
 Explicitly installed; the version is the one baked into this image:
 
@@ -30,7 +32,7 @@ Explicitly installed; the version is the one baked into this image:
 - `libunwind8`
 - `sudo`
 
-## SDK components
+### SDK components
 
 - TSM Runtime 260604163331
 - TSM Validation Suite 260604163331
@@ -53,21 +55,27 @@ Explicitly installed; the version is the one baked into this image:
 
 ## Launch
 
-**With the container toolkit** *(optional)* (`tx-container-toolkit >= 2.5.0`):
+**With the container toolkit** *(optional)*:
 
 ```bash
-docker run --rm -it --runtime=tsingmicro -e TSINGMICRO_VISIBLE_DEVICES=all harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --runtime=tsingmicro \
+  -e TSINGMICRO_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-17-g361735c bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
-docker run --rm -it --device /dev/accel --device /dev/accel_drv_mgr harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-17-g361735c bash
+docker run --rm -it \
+  --device /dev/accel \
+  --device /dev/accel_drv_mgr \
+  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-17-g361735c bash
 ```
 
 ## Verify
 
-Inside the container, confirm the accelerator is visible (the first run may take a moment):
+Inside the container, confirm the accelerator is visible:
 
 ```bash
 tsm_smi

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -62,6 +62,30 @@ def load_versions(versions_dir: Path | None, name: str) -> dict:
     return out
 
 
+def wrap_cmd(cmd: str, width: int = 84) -> str:
+    """Wrap a long `docker run …` / wrapper-launcher command onto multiple lines
+    (one flag per continuation line) so the code block doesn't scroll sideways.
+    Short commands are left as-is."""
+    if len(cmd) <= width:
+        return cmd
+    head = "docker run --rm -it"
+    if cmd.startswith(head + " "):
+        rest = cmd[len(head) + 1:]
+    else:  # wrapper launcher, e.g. `metax-docker …`
+        head, _, rest = cmd.partition(" ")
+    toks = rest.split(" ")
+    tail = f"{toks[-2]} {toks[-1]}"  # "<image> bash"
+    toks = toks[:-2]
+    groups, i = [], 0
+    while i < len(toks):
+        if toks[i].startswith("-") and i + 1 < len(toks) and not toks[i + 1].startswith("-"):
+            groups.append(f"{toks[i]} {toks[i + 1]}"); i += 2
+        else:
+            groups.append(toks[i]); i += 1
+    out = [f"{head} \\"] + [f"  {g} \\" for g in groups] + [f"  {tail}"]
+    return "\n".join(out)
+
+
 def render(entry: dict, versions: dict) -> str:
     """Compose the description markdown for one backend."""
     base = entry["base"]
@@ -70,11 +94,6 @@ def render(entry: dict, versions: dict) -> str:
 
     # Hugo front matter (docs title/ordering). Stripped before Harbor upload.
     lines += ["---", f'title: "{name}"', "---", ""]
-
-    # Base OS of the container, as its own section (a fact about the image, not
-    # a host prerequisite — and not a floating line above the first heading).
-    if base.get("os"):
-        lines += ["## Base image", "", f"`{base['os']}`", ""]
 
     # ── Prerequisites ────────────────────────────────────────────
     lines += ["## Prerequisites", ""]
@@ -87,9 +106,9 @@ def render(entry: dict, versions: dict) -> str:
         lines.append(f"- **Host driver:** {drv}")
     toolkit = entry.get("run_prereq") or ""
     if toolkit:
-        # The container toolkit is only needed for the recommended (toolkit) launch.
-        # Where a raw/generic tier also exists it's optional — the raw command needs
-        # no toolkit; it's only truly required for toolkit-only backends.
+        # The container toolkit is only needed for the toolkit launch. Where a
+        # raw/generic tier also exists it's optional; only truly required for
+        # toolkit-only backends.
         has_raw = any(t["kind"] in ("raw", "generic") for t in (entry.get("launch") or []))
         if has_raw:
             lines.append(f"- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: {toolkit}")
@@ -97,23 +116,25 @@ def render(entry: dict, versions: dict) -> str:
             lines.append(f"- **Container toolkit:** {toolkit}")
     lines.append("")
 
-    # ── System packages (explicit apt, with baked-in versions) ──
+    # ── Image contents (base OS + system packages + SDK components) ──
     pkgs = base.get("system_packages") or []
-    if pkgs:
-        lines += ["## System packages", ""]
-        lines += ["Explicitly installed; the version is the one baked into this image:", ""]
-        for p in sorted(pkgs):
-            ver = versions.get(p)
-            lines.append(f"- `{p}` — {ver}" if ver else f"- `{p}`")
-        lines.append("")
-
-    # ── SDK components (already versioned in configs) ───────────
     sdk = base.get("sdk") or []
-    if sdk:
-        lines += ["## SDK components", ""]
-        for s in sdk:
-            lines.append(f"- {s}")
-        lines.append("")
+    if base.get("os") or pkgs or sdk:
+        lines += ["## Image contents", ""]
+        if base.get("os"):
+            lines += ["### Base image", "", f"`{base['os']}`", ""]
+        if pkgs:
+            lines += ["### System packages", ""]
+            lines += ["Explicitly installed; the version is the one baked into this image:", ""]
+            for p in sorted(pkgs):
+                ver = versions.get(p)
+                lines.append(f"- `{p}` — {ver}" if ver else f"- `{p}`")
+            lines.append("")
+        if sdk:
+            lines += ["### SDK components", ""]
+            for s in sdk:
+                lines.append(f"- {s}")
+            lines.append("")
 
     # ── Environment ─────────────────────────────────────────────
     env = base.get("env") or {}
@@ -124,21 +145,20 @@ def render(entry: dict, versions: dict) -> str:
         lines.append("")
 
     # ── Launch ──────────────────────────────────────────────────
-    # One block per launch tier (see gen_data.launch_tiers). When a vendor has both
-    # a toolkit and a raw tier, the toolkit one is labelled "Recommended" and the raw
-    # one is the no-toolkit/podman fallback; a lone tier gets a plain header.
+    # One block per launch tier (see gen_data.launch_tiers). When both a toolkit
+    # and a raw tier exist, the toolkit is labelled optional and the raw one is the
+    # no-toolkit/podman path; a lone tier gets a plain header. The toolkit version
+    # is not repeated here — it's in Prerequisites.
     image = base["image"]
     tiers = entry.get("launch") or []
-    prereq = entry.get("run_prereq") or ""
     both = any(t["kind"] == "toolkit" for t in tiers) and any(t["kind"] == "raw" for t in tiers)
     if tiers:
         lines += ["## Launch", ""]
         for t in tiers:
-            cmd = t["template"].replace("{image}", image)
+            cmd = wrap_cmd(t["template"].replace("{image}", image))
             if t["kind"] == "toolkit":
-                tk = f" (`{prereq}`)" if prereq else ""
                 opt = " *(optional)*" if both else ""
-                hdr = f"**With the container toolkit**{opt}{tk}:"
+                hdr = f"**With the container toolkit**{opt}:"
             elif t["kind"] == "raw":
                 hdr = ("**Without a toolkit** — plain docker / podman:" if both
                        else "Start an interactive shell (works with docker or podman):")
@@ -147,18 +167,13 @@ def render(entry: dict, versions: dict) -> str:
             lines += [hdr, "", "```bash", cmd, "```", ""]
 
     # ── Verify ──────────────────────────────────────────────────
-    # Shown as a SEPARATE command to run INSIDE the launched container (not
-    # folded into the `docker run` line): some vendor runtimes take a moment or
-    # hang on the first container start, so users run the device check on its
-    # own and can retry it independently.
+    # A SEPARATE command to run INSIDE the launched container (not folded into the
+    # docker run line): some vendor runtimes hang on first touch, so users run the
+    # device check on its own and can retry it independently.
     verify = entry.get("verify")
     if verify:
         lines += ["## Verify", ""]
-        lines += [
-            "Inside the container, confirm the accelerator is visible "
-            "(the first run may take a moment):",
-            "",
-        ]
+        lines += ["Inside the container, confirm the accelerator is visible:", ""]
         lines += ["```bash", verify, "```", ""]
 
     return "\n".join(lines).rstrip() + "\n"


### PR DESCRIPTION
Restructures the per-image base description (English `.md`, the single source that also feeds Harbor):

- **`## Image contents`** — merges the former *System packages* and *SDK components* sections under one H2, with **Base image** (base OS) as its first subsection. **Prerequisites** now leads the page.
- **Launch** — drops the redundant toolkit version from the toolkit label (it's already in Prerequisites).
- **Command wrapping** — `docker run` / wrapper-launcher commands now wrap one-flag-per-line (new `wrap_cmd` helper) so the code block doesn't scroll sideways.
- **Verify** — removes "(the first run may take a moment)".

Generator-only change (+ the 14 regenerated `.md`); no `build-config.yml`. Toolkit tiers already landed separately on main.

Note: zh-cn base + runtime pages still render via the old shortcodes and keep the previous layout — they'll be unified via the single-source migration (tracked separately), not hand-ported here.