### PR TITLE
docs: split base descriptions into web (tooltip) and plain flavors

### DIFF
--- a/.github/workflows/base-descriptions-publish.yml
+++ b/.github/workflows/base-descriptions-publish.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'docs/content/en/base/**'
+      - 'base/*.md'
 
 defaults:
   run:

--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -108,17 +108,12 @@ jobs:
           find versions-dl -name '*.tsv' -exec cp {} versions/ \;
           ls -1 versions/ || true
       - name: Generate descriptions (with resolved versions)
-        # Writes both docs/content/en/base/*.md and docs/content/zh-cn/base/*.md
-        # from the same data — see docs/gen_descriptions.py.
+        # One generator, three outputs from the same data: web-flavored pages at
+        # docs/content/{en,zh-cn}/base/*.md (Hugo site) and plain-flavored
+        # base/*.md (in-repo readme + Harbor description). See gen_descriptions.py.
         run: |
           python3 docs/gen_data.py
           VERSIONS_DIR="$PWD/versions" python3 docs/gen_descriptions.py
-      - name: Refresh base/<name>.md symlinks
-        run: |
-          for md in docs/content/en/base/*.md; do
-            n=$(basename "$md" .md); [ "$n" = "_index" ] && continue
-            ln -sf "../docs/content/en/base/$n.md" "base/$n.md"
-          done
 
       # Open a PR with the version-enriched descriptions and enable auto-merge.
       # Publication (docs + Harbor) is gated on this PR merging — see
@@ -127,9 +122,9 @@ jobs:
         run: |
           git config user.name "flagos-ci"
           git config user.email "noreply@flagos.net"
-          # Both language trees are generated from the same data and must land in
-          # the same commit so en/ and zh-cn/ never drift. base/*.md are the
-          # EN-only Harbor/in-repo description symlinks (Harbor is English).
+          # All outputs are generated from the same data and must land in one
+          # commit so the web pages (en + zh-cn) and the plain base/*.md readmes
+          # never drift. base/*.md are English plain-flavor (Harbor is English).
           git add docs/content/en/base/*.md docs/content/zh-cn/base/*.md base/*.md
           if git diff --cached --quiet; then
             echo "no description changes — nothing to PR"; exit 0

--- a/base/ascend-cann8.5.0.md
+++ b/base/ascend-cann8.5.0.md
@@ -1,1 +1,56 @@
-../docs/content/en/base/ascend-cann8.5.0.md
+## Prerequisites
+
+- **Architecture:** aarch64
+- **Chip models:** Ascend 910B
+- **Host driver:** 25.5.0
+- **Container toolkit** *(optional)*: Ascend-docker-runtime >= 6.0.RC3
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `ca-certificates`
+- `software-properties-common`
+
+### SDK components
+
+- CANN Toolkit 8.5.0 (aarch64)
+- CANN 910B Ops 8.5.0 (aarch64)
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  -e ASCEND_VISIBLE_DEVICES=0 \
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/davinci0 \
+  --device /dev/davinci_manager \
+  --device /dev/devmm_svm \
+  --device /dev/hisi_hdc \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
+```

--- a/base/ascend-cann9.0.0.md
+++ b/base/ascend-cann9.0.0.md
@@ -1,1 +1,57 @@
-../docs/content/en/base/ascend-cann9.0.0.md
+## Prerequisites
+
+- **Architecture:** aarch64
+- **Chip models:** Ascend 910B
+- **Host driver:** 26.0.rc1
+- **Container toolkit** *(optional)*: Ascend-docker-runtime >= 6.0.RC3
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `ca-certificates`
+- `software-properties-common`
+
+### SDK components
+
+- CANN Toolkit 9.0.0 (aarch64)
+- CANN 910B Ops 9.0.0 (aarch64)
+- CANN NNAL 9.0.0 (aarch64)
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  -e ASCEND_VISIBLE_DEVICES=0 \
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/davinci0 \
+  --device /dev/davinci_manager \
+  --device /dev/devmm_svm \
+  --device /dev/hisi_hdc \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
+```

--- a/base/cambricon-neuware4.4.3.md
+++ b/base/cambricon-neuware4.4.3.md
@@ -1,1 +1,77 @@
-../docs/content/en/base/cambricon-neuware4.4.3.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Cambricon MLU590
+- **Host driver:** 6.2.15
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `gdb`
+- `libc6-dev-i386`
+- `libncurses6`
+- `libtinfo6`
+- `make`
+- `pciutils`
+- `unzip`
+
+### SDK components
+
+- cndev 6.5.25 (amd64)
+- cnmon 6.2.15
+- cnbin 2.4.2
+- cndrv 3.4.3
+- cnrt 7.4.0
+- cnrtc 0.7.4
+- cncc/cnas 5.4.3
+- cngdb 4.4.2
+- cnpapi 4.4.2
+- cnpx 1.6.0
+- cnperf 6.4.3
+- cnjpeg 0.5.1
+- cncodec3 2.4.1
+- cnsanitizer 0.12.3
+- cnnl+extra 2.1.829
+- mluops 1.8.1
+- cncl 1.29.4
+- cnstudio 1.2.1
+- cntoolkit 4.4.3
+- cntoolkit-cloud 4.4.3
+- cnclep 1.1.1.
+
+## Environment
+
+- `PATH=/usr/local/neuware/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/neuware/lib64`
+
+## Launch
+
+Start an interactive shell (works with docker or podman):
+
+```bash
+docker run --rm -it \
+  --device /dev/cambricon_dev0 \
+  --device /dev/cambricon_ctl \
+  harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+cnmon
+```

--- a/base/enflame-tops1.9.10.md
+++ b/base/enflame-tops1.9.10.md
@@ -1,1 +1,63 @@
-../docs/content/en/base/enflame-tops1.9.10.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Enflame Zixiao C200 (S60)
+- **Host driver:** 1.9.10
+- **Container toolkit** *(optional)*: tencent-container-toolkit >= 2.0.52
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+
+### SDK components
+
+- Enflame driver 1.9.10
+- TOPS Runtime 1.9.10
+- TOPS CC 1.9.10
+- TOPS PTI 1.9.10
+- TOPSTX 1.9.10
+- TOPS ATen 3.7.20260514
+- EFML 1.9.10
+- ECCL 3.6.3.11
+- Triton GCU 3.6.0+1.0.20260521.cc.1.9.10
+- Gculare-perftest 1.9.10
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  --network host \
+  -e TENCENT_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/gcu \
+  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+efsmi
+```

--- a/base/hygon-dtk26.04.md
+++ b/base/hygon-dtk26.04.md
@@ -1,1 +1,59 @@
-../docs/content/en/base/hygon-dtk26.04.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Hygon BW1000
+- **Host driver:** 6.3.30-V1.4.1a
+- **Container toolkit** *(optional)*: dcu-container-toolkit >= 1.3.0
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `pciutils`
+
+### SDK components
+
+- Hygon DTK 26.04
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  -e DCU_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/kfd \
+  --device /dev/mkfd \
+  --device /dev/dri \
+  --group-add video \
+  -v /opt/hyhal:/opt/hyhal \
+  --security-opt seccomp=unconfined \
+  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+source /opt/hyhal/env.sh && hy-smi
+```

--- a/base/iluvatar-corex4.4.0.md
+++ b/base/iluvatar-corex4.4.0.md
@@ -1,1 +1,62 @@
-../docs/content/en/base/iluvatar-corex4.4.0.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Iluvatar BI-V150
+- **Host driver:** 4.4.0
+- **Container toolkit** *(optional)*: ix-container-toolkit >= 1.1.0
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `curl`
+- `g++`
+- `gcc`
+- `unzip`
+
+### SDK components
+
+- Corex Runtime 4.4.0
+- CUDA Header files 260604
+
+## Environment
+
+- `COREX_ROOT=/usr/local/corex`
+- `PATH=/usr/local/corex/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/corex/lib`
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  --runtime iluvatar \
+  --env IX_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/iluvatar0 \
+  -v /usr/local/corex:/usr/local/corex:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+ixsmi
+```

--- a/base/kunlunxin-xre5.29.0.md
+++ b/base/kunlunxin-xre5.29.0.md
@@ -1,1 +1,64 @@
-../docs/content/en/base/kunlunxin-xre5.29.0.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Kunlunxin P800
+- **Host driver:** 5.29.0.0
+- **Container toolkit** *(optional)*: xpu_container >= 1.0.13
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `kmod`
+- `pciutils`
+
+### SDK components
+
+- CUDA 12.9.0_575.51.03
+- XRE-CUDA12 5.29.0.0
+- XCUDART 5.13.0
+
+## Environment
+
+- `PATH=/usr/local/xpu/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/xpu/lib:/usr/local/xcudart/lib`
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  --runtime xpu \
+  -e CXPU_VISIBLE_DEVICES=0 \
+  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/xpu0 \
+  --device /dev/xpuctrl \
+  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+xpu-smi
+```

--- a/base/metax-maca3.7.2.1.md
+++ b/base/metax-maca3.7.2.1.md
@@ -1,1 +1,66 @@
-../docs/content/en/base/metax-maca3.7.2.1.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** MetaX C550
+- **Host driver:** 3.8.30
+- **Container toolkit** *(optional)*: metax-docker >= 0.15.3
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libnuma1`
+- `libpython3-dev`
+- `make`
+
+### SDK components
+
+- MetaX Driver 3.7.2.30
+- MACA SDK 3.7.2.0
+
+## Environment
+
+- `PATH=/opt/maca/mxgpu_llvm/bin:/opt/maca/bin:${PATH}`
+- `MACA_PATH=/opt/maca`
+- `LD_LIBRARY_PATH=/opt/maca/lib:/opt/maca/mxgpu_llvm/lib`
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+metax-docker \
+  --gpus all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/mxcd \
+  --device /dev/dri \
+  --group-add video \
+  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+mx-smi
+```

--- a/base/mthreads-musa4.3.6.md
+++ b/base/mthreads-musa4.3.6.md
@@ -1,1 +1,70 @@
-../docs/content/en/base/mthreads-musa4.3.6.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** MThreads MTT S5000
+- **Host driver:** 5.2.0-server
+- **Container toolkit** *(optional)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libgfortran5`
+- `libnuma-dev`
+- `libopenmpi-dev`
+- `libpython3-dev`
+- `openmpi-bin`
+
+### SDK components
+
+- MUSA Toolkits RC4.3.6
+- MCCL RC2.1.6
+- muDNN RC3.1.6
+
+## Environment
+
+- `MUSA_HOME=/usr/local/musa`
+- `PATH=/usr/local/musa/bin:${PATH}`
+- `LD_LIBRARY_PATH=/usr/local/musa/lib`
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  --runtime mthreads \
+  --env MTHREADS_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/mtgpu.0 \
+  --device /dev/dri \
+  -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+mthreads-gmi
+```

--- a/base/mthreads-musa5.2.0.md
+++ b/base/mthreads-musa5.2.0.md
@@ -1,1 +1,70 @@
-../docs/content/en/base/mthreads-musa5.2.0.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** MThreads MTT S5000
+- **Host driver:** 5.2.0-server
+- **Container toolkit** *(optional)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libgfortran5`
+- `libnuma-dev`
+- `libopenmpi-dev`
+- `libpython3-dev`
+- `openmpi-bin`
+
+### SDK components
+
+- MUSA Toolkits 5.2.0
+- MCCL 2.4.0
+- muDNN 3.4.0
+
+## Environment
+
+- `MUSA_HOME=/usr/local/musa`
+- `PATH=/usr/local/musa/bin:${PATH}`
+- `LD_LIBRARY_PATH=/usr/local/musa/lib`
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  --runtime mthreads \
+  --env MTHREADS_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/mtgpu.0 \
+  --device /dev/dri \
+  -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+mthreads-gmi
+```

--- a/base/nvidia-cuda12.8.md
+++ b/base/nvidia-cuda12.8.md
@@ -1,1 +1,67 @@
-../docs/content/en/base/nvidia-cuda12.8.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** NVIDIA H20
+- **Host driver:** 610.43.02
+- **Container toolkit** *(optional)*: nvidia-container-toolkit
+
+## Image contents
+
+### Base image
+
+`nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libnuma1`
+- `libpython3-dev`
+- `make`
+
+### SDK components
+
+- CUDA 12.8 (x86_64)
+
+## Environment
+
+- `PATH=/usr/local/cuda/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH`
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  --gpus all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/nvidia0 \
+  --device /dev/nvidiactl \
+  --device /dev/nvidia-uvm \
+  -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
+  -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
+  -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+nvidia-smi
+```

--- a/base/nvidia-cuda13.3.md
+++ b/base/nvidia-cuda13.3.md
@@ -1,1 +1,67 @@
-../docs/content/en/base/nvidia-cuda13.3.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** NVIDIA H20
+- **Host driver:** 610.43.02
+- **Container toolkit** *(optional)*: nvidia-container-toolkit
+
+## Image contents
+
+### Base image
+
+`nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libelf1`
+- `libnuma1`
+- `libpython3-dev`
+- `make`
+
+### SDK components
+
+- CUDA 13.3 (x86_64)
+
+## Environment
+
+- `PATH=/usr/local/cuda/bin:$PATH`
+- `LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH`
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  --gpus all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/nvidia0 \
+  --device /dev/nvidiactl \
+  --device /dev/nvidia-uvm \
+  -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
+  -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
+  -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+nvidia-smi
+```

--- a/base/sunrise-tangrt1.2.0.md
+++ b/base/sunrise-tangrt1.2.0.md
@@ -1,1 +1,53 @@
-../docs/content/en/base/sunrise-tangrt1.2.0.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Sunrise SR-SUN-S2-X1
+- **Host driver:** 0.24.0
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `pciutils`
+
+### SDK components
+
+- Tang Toolkit 1.2.0
+- PCCL 1.2.0
+- taDNN 1.2.0
+- taBLAS 1.2.0
+
+## Environment
+
+- `TANGRT_ROOT=/usr/local/tangrt`
+- `LIBRARY_PATH=/usr/local/tangrt/targets/linux-x86_64/lib:/usr/local/tangrt/lib/linux-x86_64`
+- `LD_LIBRARY_PATH=/usr/local/tangrt/targets/linux-x86_64/lib:/usr/local/tangrt/lib/linux-x86_64`
+
+## Launch
+
+Start an interactive shell in the container:
+
+```bash
+docker run --rm -it \
+  harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+pt_smi
+```

--- a/base/tsingmicro-tsm260604.md
+++ b/base/tsingmicro-tsm260604.md
@@ -1,1 +1,78 @@
-../docs/content/en/base/tsingmicro-tsm260604.md
+## Prerequisites
+
+- **Architecture:** x86_64
+- **Chip models:** Tsingmicro TX8110
+- **Host driver:** 260604163331.01
+- **Container toolkit** *(optional)*: tx-container-toolkit >= 2.5.0
+
+## Image contents
+
+### Base image
+
+`ubuntu:24.04`
+
+### System packages
+
+Explicitly installed; the version is the one baked into this image:
+
+- `build-essential`
+- `ca-certificates`
+- `clang`
+- `cmake`
+- `curl`
+- `g++`
+- `gcc`
+- `libfmt-dev`
+- `libopenmpi3`
+- `libpython3-dev`
+- `libunwind8`
+- `sudo`
+
+### SDK components
+
+- TSM Runtime 260604163331
+- TSM Validation Suite 260604163331
+- TSM CCL 260604163331
+- TSM Profiler 260604163331
+- TX8 Compiler Dependencies 20260507
+- LLVM a66376b0
+
+## Environment
+
+- `KUIPER_PATH=/usr/local/kuiper`
+- `TX8_DEPS_ROOT=/usr/local/tx8_deps`
+- `LLVM_SYSPATH=/usr/local/llvm`
+- `PATH=/usr/local/kuiper/bin:${PATH}`
+- `LLVM_BINARY_DIR=/usr/local/llvm/bin`
+- `PYTHONPATH=/usr/local/llvm/python_packages/mlir_core`
+- `LD_LIBRARY_PATH=/usr/local/tx8_deps/lib:/usr/local/kuiper/lib:/usr/local/kuiper/tsm8-profiler/lib`
+- `USE_TORCH_XLA=0`
+- `TORCH_COMPILE_DISABLE=1`
+
+## Launch
+
+**With the container toolkit** *(optional)*:
+
+```bash
+docker run --rm -it \
+  --runtime=tsingmicro \
+  -e TSINGMICRO_VISIBLE_DEVICES=all \
+  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g9ab46c9 bash
+```
+
+**Without a toolkit** — plain docker / podman:
+
+```bash
+docker run --rm -it \
+  --device /dev/accel \
+  --device /dev/accel_drv_mgr \
+  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g9ab46c9 bash
+```
+
+## Verify
+
+Inside the container, confirm the accelerator is visible:
+
+```bash
+tsm_smi
+```

--- a/docs/assets/_custom.scss
+++ b/docs/assets/_custom.scss
@@ -18,3 +18,13 @@ code.plain {
 .muted code.plain {
   opacity: 0.5;
 }
+
+// Tooltip affordance: base-image pages render the container-toolkit caveat as an
+// <abbr title="…"> hover tooltip (see docs/gen_descriptions.py, web flavor).
+// Give it a discoverable hint — a dotted underline and the help cursor — since
+// the theme's reset otherwise leaves it looking like plain text.
+abbr[title] {
+  text-decoration: underline dotted;
+  text-underline-offset: 0.15em;
+  cursor: help;
+}

--- a/docs/content/en/base/ascend-cann8.5.0.md
+++ b/docs/content/en/base/ascend-cann8.5.0.md
@@ -7,7 +7,7 @@ title: "ascend-cann8.5.0"
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
 - **Host driver:** 25.5.0
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: Ascend-docker-runtime >= 6.0.RC3
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: Ascend-docker-runtime >= 6.0.RC3
 
 ## Image contents
 
@@ -34,7 +34,7 @@ Explicitly installed; the version is the one baked into this image:
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -48,7 +48,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/ascend-cann9.0.0.md
+++ b/docs/content/en/base/ascend-cann9.0.0.md
@@ -7,7 +7,7 @@ title: "ascend-cann9.0.0"
 - **Architecture:** aarch64
 - **Chip models:** Ascend 910B
 - **Host driver:** 26.0.rc1
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: Ascend-docker-runtime >= 6.0.RC3
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: Ascend-docker-runtime >= 6.0.RC3
 
 ## Image contents
 
@@ -35,7 +35,7 @@ Explicitly installed; the version is the one baked into this image:
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -49,7 +49,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -69,7 +69,7 @@ Start an interactive shell (works with docker or podman):
 docker run --rm -it \
   --device /dev/cambricon_dev0 \
   --device /dev/cambricon_ctl \
-  harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -7,7 +7,7 @@ title: "enflame-tops1.9.10"
 - **Architecture:** x86_64
 - **Chip models:** Enflame Zixiao C200 (S60)
 - **Host driver:** 1.9.10
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: tencent-container-toolkit >= 2.0.52
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: tencent-container-toolkit >= 2.0.52
 
 ## Image contents
 
@@ -47,7 +47,7 @@ Explicitly installed; the version is the one baked into this image:
 docker run --rm -it \
   --network host \
   -e TENCENT_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -55,7 +55,7 @@ docker run --rm -it \
 ```bash
 docker run --rm -it \
   --device /dev/gcu \
-  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/hygon-dtk26.04.md
+++ b/docs/content/en/base/hygon-dtk26.04.md
@@ -7,7 +7,7 @@ title: "hygon-dtk26.04"
 - **Architecture:** x86_64
 - **Chip models:** Hygon BW1000
 - **Host driver:** 6.3.30-V1.4.1a
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: dcu-container-toolkit >= 1.3.0
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: dcu-container-toolkit >= 1.3.0
 
 ## Image contents
 
@@ -38,7 +38,7 @@ Explicitly installed; the version is the one baked into this image:
 ```bash
 docker run --rm -it \
   -e DCU_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -51,7 +51,7 @@ docker run --rm -it \
   --group-add video \
   -v /opt/hyhal:/opt/hyhal \
   --security-opt seccomp=unconfined \
-  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/iluvatar-corex4.4.0.md
+++ b/docs/content/en/base/iluvatar-corex4.4.0.md
@@ -7,7 +7,7 @@ title: "iluvatar-corex4.4.0"
 - **Architecture:** x86_64
 - **Chip models:** Iluvatar BI-V150
 - **Host driver:** 4.4.0
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: ix-container-toolkit >= 1.1.0
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: ix-container-toolkit >= 1.1.0
 
 ## Image contents
 
@@ -45,7 +45,7 @@ Explicitly installed; the version is the one baked into this image:
 docker run --rm -it \
   --runtime iluvatar \
   --env IX_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -54,7 +54,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/iluvatar0 \
   -v /usr/local/corex:/usr/local/corex:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -7,7 +7,7 @@ title: "kunlunxin-xre5.29.0"
 - **Architecture:** x86_64
 - **Chip models:** Kunlunxin P800
 - **Host driver:** 5.29.0.0
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: xpu_container >= 1.0.13
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: xpu_container >= 1.0.13
 
 ## Image contents
 
@@ -47,7 +47,7 @@ Explicitly installed; the version is the one baked into this image:
 docker run --rm -it \
   --runtime xpu \
   -e CXPU_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -56,7 +56,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/xpu0 \
   --device /dev/xpuctrl \
-  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/metax-maca3.7.2.1.md
+++ b/docs/content/en/base/metax-maca3.7.2.1.md
@@ -7,7 +7,7 @@ title: "metax-maca3.7.2.1"
 - **Architecture:** x86_64
 - **Chip models:** MetaX C550
 - **Host driver:** 3.8.30
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: metax-docker >= 0.15.3
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: metax-docker >= 0.15.3
 
 ## Image contents
 
@@ -48,7 +48,7 @@ Explicitly installed; the version is the one baked into this image:
 ```bash
 metax-docker \
   --gpus all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -58,7 +58,7 @@ docker run --rm -it \
   --device /dev/mxcd \
   --device /dev/dri \
   --group-add video \
-  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa4.3.6.md
+++ b/docs/content/en/base/mthreads-musa4.3.6.md
@@ -7,7 +7,7 @@ title: "mthreads-musa4.3.6"
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
 - **Host driver:** 5.2.0-server
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
 ## Image contents
 
@@ -52,7 +52,7 @@ Explicitly installed; the version is the one baked into this image:
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -62,7 +62,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/mthreads-musa5.2.0.md
+++ b/docs/content/en/base/mthreads-musa5.2.0.md
@@ -7,7 +7,7 @@ title: "mthreads-musa5.2.0"
 - **Architecture:** x86_64
 - **Chip models:** MThreads MTT S5000
 - **Host driver:** 5.2.0-server
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
 ## Image contents
 
@@ -52,7 +52,7 @@ Explicitly installed; the version is the one baked into this image:
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -62,7 +62,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda12.8.md
+++ b/docs/content/en/base/nvidia-cuda12.8.md
@@ -7,7 +7,7 @@ title: "nvidia-cuda12.8"
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
 - **Host driver:** 610.43.02
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: nvidia-container-toolkit
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: nvidia-container-toolkit
 
 ## Image contents
 
@@ -46,7 +46,7 @@ Explicitly installed; the version is the one baked into this image:
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -59,7 +59,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/nvidia-cuda13.3.md
+++ b/docs/content/en/base/nvidia-cuda13.3.md
@@ -7,7 +7,7 @@ title: "nvidia-cuda13.3"
 - **Architecture:** x86_64
 - **Chip models:** NVIDIA H20
 - **Host driver:** 610.43.02
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: nvidia-container-toolkit
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: nvidia-container-toolkit
 
 ## Image contents
 
@@ -46,7 +46,7 @@ Explicitly installed; the version is the one baked into this image:
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -59,7 +59,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/base/sunrise-tangrt1.2.0.md
@@ -45,7 +45,7 @@ Start an interactive shell in the container:
 
 ```bash
 docker run --rm -it \
-  harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -7,7 +7,7 @@ title: "tsingmicro-tsm260604"
 - **Architecture:** x86_64
 - **Chip models:** Tsingmicro TX8110
 - **Host driver:** 260604163331.01
-- **Container toolkit** *(optional — only for the toolkit launch below; the plain docker/podman command needs none)*: tx-container-toolkit >= 2.5.0
+- **Container toolkit** <abbr title="only for the toolkit launch below; the plain docker/podman command needs none">*(optional)*</abbr>: tx-container-toolkit >= 2.5.0
 
 ## Image contents
 
@@ -61,7 +61,7 @@ Explicitly installed; the version is the one baked into this image:
 docker run --rm -it \
   --runtime=tsingmicro \
   -e TSINGMICRO_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g9ab46c9 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -70,7 +70,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/accel \
   --device /dev/accel_drv_mgr \
-  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g9ab46c9 bash
 ```
 
 ## Verify

--- a/docs/content/zh-cn/base/ascend-cann8.5.0.md
+++ b/docs/content/zh-cn/base/ascend-cann8.5.0.md
@@ -7,7 +7,7 @@ title: "ascend-cann8.5.0"
 - **架构:** aarch64
 - **芯片型号:** Ascend 910B
 - **宿主机驱动:** 25.5.0
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: Ascend-docker-runtime >= 6.0.RC3
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: Ascend-docker-runtime >= 6.0.RC3
 
 ## 镜像内容
 
@@ -34,7 +34,7 @@ title: "ascend-cann8.5.0"
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -48,7 +48,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann8.5.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/ascend-cann9.0.0.md
+++ b/docs/content/zh-cn/base/ascend-cann9.0.0.md
@@ -7,7 +7,7 @@ title: "ascend-cann9.0.0"
 - **架构:** aarch64
 - **芯片型号:** Ascend 910B
 - **宿主机驱动:** 26.0.rc1
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: Ascend-docker-runtime >= 6.0.RC3
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: Ascend-docker-runtime >= 6.0.RC3
 
 ## 镜像内容
 
@@ -35,7 +35,7 @@ title: "ascend-cann9.0.0"
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -49,7 +49,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-ascend-cann9.0.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/cambricon-neuware4.4.3.md
+++ b/docs/content/zh-cn/base/cambricon-neuware4.4.3.md
@@ -69,7 +69,7 @@ title: "cambricon-neuware4.4.3"
 docker run --rm -it \
   --device /dev/cambricon_dev0 \
   --device /dev/cambricon_ctl \
-  harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-cambricon-neuware4.4.3:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/enflame-tops1.9.10.md
+++ b/docs/content/zh-cn/base/enflame-tops1.9.10.md
@@ -7,7 +7,7 @@ title: "enflame-tops1.9.10"
 - **架构:** x86_64
 - **芯片型号:** Enflame Zixiao C200 (S60)
 - **宿主机驱动:** 1.9.10
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: tencent-container-toolkit >= 2.0.52
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: tencent-container-toolkit >= 2.0.52
 
 ## 镜像内容
 
@@ -47,7 +47,7 @@ title: "enflame-tops1.9.10"
 docker run --rm -it \
   --network host \
   -e TENCENT_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -55,7 +55,7 @@ docker run --rm -it \
 ```bash
 docker run --rm -it \
   --device /dev/gcu \
-  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-enflame-tops1.9.10:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/hygon-dtk26.04.md
+++ b/docs/content/zh-cn/base/hygon-dtk26.04.md
@@ -7,7 +7,7 @@ title: "hygon-dtk26.04"
 - **架构:** x86_64
 - **芯片型号:** Hygon BW1000
 - **宿主机驱动:** 6.3.30-V1.4.1a
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: dcu-container-toolkit >= 1.3.0
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: dcu-container-toolkit >= 1.3.0
 
 ## 镜像内容
 
@@ -38,7 +38,7 @@ title: "hygon-dtk26.04"
 ```bash
 docker run --rm -it \
   -e DCU_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -51,7 +51,7 @@ docker run --rm -it \
   --group-add video \
   -v /opt/hyhal:/opt/hyhal \
   --security-opt seccomp=unconfined \
-  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-hygon-dtk26.04:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/iluvatar-corex4.4.0.md
+++ b/docs/content/zh-cn/base/iluvatar-corex4.4.0.md
@@ -7,7 +7,7 @@ title: "iluvatar-corex4.4.0"
 - **架构:** x86_64
 - **芯片型号:** Iluvatar BI-V150
 - **宿主机驱动:** 4.4.0
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: ix-container-toolkit >= 1.1.0
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: ix-container-toolkit >= 1.1.0
 
 ## 镜像内容
 
@@ -45,7 +45,7 @@ title: "iluvatar-corex4.4.0"
 docker run --rm -it \
   --runtime iluvatar \
   --env IX_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -54,7 +54,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/iluvatar0 \
   -v /usr/local/corex:/usr/local/corex:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-iluvatar-corex4.4.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/zh-cn/base/kunlunxin-xre5.29.0.md
@@ -7,7 +7,7 @@ title: "kunlunxin-xre5.29.0"
 - **架构:** x86_64
 - **芯片型号:** Kunlunxin P800
 - **宿主机驱动:** 5.29.0.0
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: xpu_container >= 1.0.13
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: xpu_container >= 1.0.13
 
 ## 镜像内容
 
@@ -47,7 +47,7 @@ title: "kunlunxin-xre5.29.0"
 docker run --rm -it \
   --runtime xpu \
   -e CXPU_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -56,7 +56,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/xpu0 \
   --device /dev/xpuctrl \
-  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-kunlunxin-xre5.29.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/metax-maca3.7.2.1.md
+++ b/docs/content/zh-cn/base/metax-maca3.7.2.1.md
@@ -7,7 +7,7 @@ title: "metax-maca3.7.2.1"
 - **架构:** x86_64
 - **芯片型号:** MetaX C550
 - **宿主机驱动:** 3.8.30
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: metax-docker >= 0.15.3
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: metax-docker >= 0.15.3
 
 ## 镜像内容
 
@@ -48,7 +48,7 @@ title: "metax-maca3.7.2.1"
 ```bash
 metax-docker \
   --gpus all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -58,7 +58,7 @@ docker run --rm -it \
   --device /dev/mxcd \
   --device /dev/dri \
   --group-add video \
-  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-metax-maca3.7.2.1:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/mthreads-musa4.3.6.md
+++ b/docs/content/zh-cn/base/mthreads-musa4.3.6.md
@@ -7,7 +7,7 @@ title: "mthreads-musa4.3.6"
 - **架构:** x86_64
 - **芯片型号:** MThreads MTT S5000
 - **宿主机驱动:** 5.2.0-server
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
 ## 镜像内容
 
@@ -52,7 +52,7 @@ title: "mthreads-musa4.3.6"
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -62,7 +62,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa4.3.6:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/mthreads-musa5.2.0.md
+++ b/docs/content/zh-cn/base/mthreads-musa5.2.0.md
@@ -7,7 +7,7 @@ title: "mthreads-musa5.2.0"
 - **架构:** x86_64
 - **芯片型号:** MThreads MTT S5000
 - **宿主机驱动:** 5.2.0-server
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: KUAE Cloud Native Toolkits (MT Container Toolkit) >= 2.1.0
 
 ## 镜像内容
 
@@ -52,7 +52,7 @@ title: "mthreads-musa5.2.0"
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -62,7 +62,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-mthreads-musa5.2.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/nvidia-cuda12.8.md
+++ b/docs/content/zh-cn/base/nvidia-cuda12.8.md
@@ -7,7 +7,7 @@ title: "nvidia-cuda12.8"
 - **架构:** x86_64
 - **芯片型号:** NVIDIA H20
 - **宿主机驱动:** 610.43.02
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: nvidia-container-toolkit
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: nvidia-container-toolkit
 
 ## 镜像内容
 
@@ -46,7 +46,7 @@ title: "nvidia-cuda12.8"
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -59,7 +59,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda12.8:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/nvidia-cuda13.3.md
+++ b/docs/content/zh-cn/base/nvidia-cuda13.3.md
@@ -7,7 +7,7 @@ title: "nvidia-cuda13.3"
 - **架构:** x86_64
 - **芯片型号:** NVIDIA H20
 - **宿主机驱动:** 610.43.02
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: nvidia-container-toolkit
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: nvidia-container-toolkit
 
 ## 镜像内容
 
@@ -46,7 +46,7 @@ title: "nvidia-cuda13.3"
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -59,7 +59,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-nvidia-cuda13.3:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/sunrise-tangrt1.2.0.md
+++ b/docs/content/zh-cn/base/sunrise-tangrt1.2.0.md
@@ -45,7 +45,7 @@ title: "sunrise-tangrt1.2.0"
 
 ```bash
 docker run --rm -it \
-  harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-sunrise-tangrt1.2.0:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/base/tsingmicro-tsm260604.md
+++ b/docs/content/zh-cn/base/tsingmicro-tsm260604.md
@@ -7,7 +7,7 @@ title: "tsingmicro-tsm260604"
 - **架构:** x86_64
 - **芯片型号:** Tsingmicro TX8110
 - **宿主机驱动:** 260604163331.01
-- **容器工具包** *(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*: tx-container-toolkit >= 2.5.0
+- **容器工具包** <abbr title="仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装">*(可选)*</abbr>: tx-container-toolkit >= 2.5.0
 
 ## 镜像内容
 
@@ -61,7 +61,7 @@ title: "tsingmicro-tsm260604"
 docker run --rm -it \
   --runtime=tsingmicro \
   -e TSINGMICRO_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g9ab46c9 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -70,7 +70,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/accel \
   --device /dev/accel_drv_mgr \
-  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g18451ed bash
+  harbor.baai.ac.cn/flagos-base/flagos-base-tsingmicro-tsm260604:2.1.1-20-g9ab46c9 bash
 ```
 
 ## 验证

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -12,17 +12,25 @@ from a per-backend TSV (`<name>.tsv`, lines "package\tversion") produced in CI b
 Both languages are generated from the same language-neutral data: only the prose
 and section headers differ (the STRINGS table below), while the technical values
 (chip models, SDK strings, package names, env, launch/verify commands) are
-verbatim in both. English pages double as the Harbor repository descriptions;
-the Chinese pages are docs-only. This keeps en/ and zh-cn/ in lockstep — the
-reason both are emitted from one generator rather than a per-language shortcode.
+verbatim in both. This keeps en/ and zh-cn/ in lockstep — the reason both are
+emitted from one generator rather than a per-language shortcode.
+
+Two output flavors feed three consumers:
+  - "web"   -> docs/content/{en,zh-cn}/base/*.md — the Hugo site. Keeps front
+               matter and renders the container-toolkit caveat as an <abbr>
+               hover tooltip (styled in docs/assets/_custom.scss).
+  - "plain" -> base/*.md (English) — the in-repo image readme and the source for
+               the Harbor repository description. No front matter, no tooltip.
+These are separate files, so the web pages can be polished (HTML/CSS) without
+touching the plain readmes.
 
 The body starts at H2 (no H1): Hugo supplies the page title from the front
 matter, and Harbor shows the repository name as the top heading — so the same
-body reads correctly in both once the front matter is stripped for Harbor.
+body reads correctly in both.
 
 Usage:
-  python docs/gen_descriptions.py                    # all langs -> docs/content/<lang>/base/<name>.md
-  python docs/gen_descriptions.py nvidia-cuda13.3    # one backend, all langs -> stdout
+  python docs/gen_descriptions.py                    # all langs + plain -> files
+  python docs/gen_descriptions.py nvidia-cuda13.3    # one backend, all langs + plain -> stdout
   VERSIONS_DIR=/path python docs/gen_descriptions.py # resolve versions from <dir>/<name>.tsv
 """
 
@@ -47,7 +55,8 @@ STRINGS = {
         "chip_models": "Chip models",
         "host_driver": "Host driver",
         "toolkit": "Container toolkit",
-        "toolkit_optional_note": "*(optional — only for the toolkit launch below; the plain docker/podman command needs none)*",
+        "toolkit_optional": "*(optional)*",
+        "toolkit_tooltip": "only for the toolkit launch below; the plain docker/podman command needs none",
         "image_contents": "Image contents",
         "base_image": "Base image",
         "system_packages": "System packages",
@@ -69,7 +78,8 @@ STRINGS = {
         "chip_models": "芯片型号",
         "host_driver": "宿主机驱动",
         "toolkit": "容器工具包",
-        "toolkit_optional_note": "*(可选 —— 仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装)*",
+        "toolkit_optional": "*(可选)*",
+        "toolkit_tooltip": "仅用于下方的工具包启动方式；直接使用 docker/podman 的命令无需安装",
         "image_contents": "镜像内容",
         "base_image": "基础镜像",
         "system_packages": "系统软件包",
@@ -148,20 +158,33 @@ def wrap_cmd(cmd: str, width: int = 84) -> str:
     return "\n".join(out)
 
 
-def render(entry: dict, versions: dict, lang: str = "en") -> str:
+def render(entry: dict, versions: dict, lang: str = "en", flavor: str = "web") -> str:
     """Compose the description markdown for one backend in `lang`.
 
     Only prose/headers are localized (from STRINGS); every technical value —
     chip models, SDK strings, package names, env, launch/verify commands —
     renders verbatim, so the two languages stay structurally identical.
+
+    Two flavors, because the same content feeds three consumers with different
+    needs:
+      - "web"   — the Hugo site. Keeps the Hugo front matter and renders the
+                  container-toolkit caveat as an <abbr> hover tooltip, so the
+                  page stays uncluttered but the explanation is one hover away.
+      - "plain" — the in-repo base/<name>.md readme and the Harbor repository
+                  description. No front matter, no tooltip: the toolkit line is
+                  just "*(optional)*" with the caveat dropped (these surfaces
+                  render plain markdown and have no hover affordance).
     """
     s = STRINGS[lang]
+    web = flavor == "web"
     base = entry["base"]
     name = entry["name"]
     lines: list[str] = []
 
-    # Hugo front matter (docs title/ordering). Stripped before Harbor upload.
-    lines += ["---", f'title: "{name}"', "---", ""]
+    # Hugo front matter (docs title/ordering) — web flavor only. The plain flavor
+    # feeds a repo readme / Harbor description, where the front matter is noise.
+    if web:
+        lines += ["---", f'title: "{name}"', "---", ""]
 
     # ── Prerequisites ────────────────────────────────────────────
     lines += [f"## {s['prerequisites']}", ""]
@@ -176,10 +199,15 @@ def render(entry: dict, versions: dict, lang: str = "en") -> str:
     if toolkit:
         # The container toolkit is only needed for the toolkit launch. Where a
         # raw/generic tier also exists it's optional; only truly required for
-        # toolkit-only backends.
+        # toolkit-only backends. On the web that "why" is a hover tooltip; in the
+        # plain flavor it's dropped (no hover), leaving a bare "*(optional)*".
         has_raw = any(t["kind"] in ("raw", "generic") for t in (entry.get("launch") or []))
         if has_raw:
-            lines.append(f"- **{s['toolkit']}** {s['toolkit_optional_note']}: {toolkit}")
+            if web:
+                opt = f'<abbr title="{s["toolkit_tooltip"]}">{s["toolkit_optional"]}</abbr>'
+            else:
+                opt = s["toolkit_optional"]
+            lines.append(f"- **{s['toolkit']}** {opt}: {toolkit}")
         else:
             lines.append(f"- **{s['toolkit']}:** {toolkit}")
     lines.append("")
@@ -255,27 +283,38 @@ def main():
 
     requested = sys.argv[1:]
     if requested:
-        # Spot-check to stdout: every requested backend in every language, so a
-        # single-backend check never silently covers just one language.
+        # Spot-check to stdout: every requested backend, every language, both
+        # flavors — so a single-backend check never silently covers just one.
         for name in requested:
             if name not in backends:
                 sys.exit(f"Error: '{name}' not in images.yaml")
+            versions = load_versions(versions_dir, name)
             for lang in LANGS:
-                print(render(backends[name], load_versions(versions_dir, name), lang))
+                print(render(backends[name], versions, lang, "web"))
+            print(render(backends[name], versions, "en", "plain"))
         return
 
-    # Emit every backend for every language. English pages double as the Harbor
-    # descriptions; the Chinese pages keep the zh-cn docs in lockstep.
+    # Web flavor: every backend, every language, into the Hugo content tree. The
+    # zh-cn pages stay in lockstep with en; both may use tooltips/HTML.
     total = 0
     for lang in LANGS:
         out_dir = root / "docs" / "content" / lang / "base"
         out_dir.mkdir(parents=True, exist_ok=True)
         for name, entry in backends.items():
-            md = render(entry, load_versions(versions_dir, name), lang)
+            md = render(entry, load_versions(versions_dir, name), lang, "web")
             (out_dir / f"{name}.md").write_text(md)
             total += 1
-        print(f"Wrote {len(backends)} {lang} descriptions to {out_dir}")
-    print(f"Total: {total} descriptions")
+        print(f"Wrote {len(backends)} {lang} web pages to {out_dir}")
+
+    # Plain flavor: English only, into base/<name>.md — the in-repo image readme
+    # and the source for the Harbor repository description. Real files (no longer
+    # symlinks into docs/), so the web pages can be polished independently.
+    base_dir = root / "base"
+    for name, entry in backends.items():
+        md = render(entry, load_versions(versions_dir, name), "en", "plain")
+        (base_dir / f"{name}.md").write_text(md)
+    print(f"Wrote {len(backends)} plain readmes to {base_dir}")
+    print(f"Total: {total + len(backends)} descriptions")
 
 
 if __name__ == "__main__":

--- a/docs/upload_descriptions.py
+++ b/docs/upload_descriptions.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 """Push each generated base-image description to Harbor as the repository
-description. Strips the Hugo front matter — Harbor renders the description as
-markdown and shows the repository name as the top heading, so the H2-based body
-reads correctly on its own.
+description. Harbor renders the description as markdown and shows the repository
+name as the top heading, so the H2-based body reads correctly on its own.
 
-Reads the generated markdown from docs/content/en/base/<name>.md for every
-backend in docs/data/images.yaml. The repository is flagos-base-<name> under the
-project taken from the image ref.
+Reads the plain-flavor markdown from base/<name>.md (the same file that serves
+as the in-repo image readme) for every backend in docs/data/images.yaml. The
+repository is flagos-base-<name> under the project taken from the image ref.
 
 Env: HARBOR_HOST, HARBOR_USER, HARBOR_PW (basic auth).
 Usage: python docs/upload_descriptions.py [--dry-run]
@@ -45,7 +44,7 @@ def main():
 
     root = Path(__file__).resolve().parent.parent
     images = yaml.safe_load((root / "docs" / "data" / "images.yaml").read_text())
-    base_dir = root / "docs" / "content" / "en" / "base"
+    base_dir = root / "base"
 
     failures = 0
     for entry in images.get("backends", []):


### PR DESCRIPTION
## What

The single base-image description fed three consumers with conflicting needs — the **Hugo site** (wants an elegant, uncluttered page), the **in-repo `base/<name>.md` readme**, and the **Harbor repository description** (both plain markdown). They all read the same `content/en/base/*.md` via symlink, so the container-toolkit caveat *"— only for the toolkit launch below; the plain docker/podman command needs none"* had to sit inline on every surface.

This splits the generator into **two flavors** from the same data:

| Flavor | Output | Toolkit caveat | Front matter |
|---|---|---|---|
| **web** | `docs/content/{en,zh-cn}/base/*.md` | `<abbr>` hover tooltip on a bare `*(optional)*` | yes |
| **plain** | `base/*.md` (English) | dropped — just `*(optional)*` | no |

The web tooltip gets a discoverable affordance (dotted underline + help cursor) via a small `abbr[title]` rule in `_custom.scss`.

## Decoupling

`base/<name>.md` become **real generated files, not symlinks** into `docs/`. The two outputs are now independent, so the web pages can be polished with HTML/CSS without touching the plain readmes.

- `upload_descriptions.py` reads `base/` now (was `docs/content/en/base/`).
- `base-descriptions-publish.yml` triggers on `base/*.md`.
- The CI symlink-refresh step is removed; the generator writes `base/*.md` directly.

Every run still emits **every backend, both languages, both flavors** — no single-language or single-flavor path.

## Verification

- Web page renders `<abbr title="…">*(optional)*</abbr>`; the `abbr[title]` CSS compiles into the site bundle.
- All 14 plain readmes are clean — no front matter, no `<abbr>`.
- `hugo --gc --minify` builds clean (EN 52 / ZH 51); scripts `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)