### PR TITLE
docs: highlight and wrap runtime-image run commands

### DIFF
--- a/docs/layouts/partials/wrap-cmd.html
+++ b/docs/layouts/partials/wrap-cmd.html
@@ -1,0 +1,51 @@
+{{- /*
+  wrap-cmd — wrap a long `docker run …` / wrapper-launcher command onto multiple
+  lines (one flag or flag+value per continuation line, ending "<image> bash"), so
+  the rendered code block does not scroll sideways. Mirrors the base-page
+  generator docs/gen_descriptions.py::wrap_cmd so runtime pages wrap identically.
+
+  Call: {{ partial "wrap-cmd" $cmd }}  ->  returns the wrapped string.
+  Short commands (<= 84 chars) are returned unchanged.
+*/ -}}
+{{- $cmd := . -}}
+{{- $width := 84 -}}
+{{- if le (len $cmd) $width -}}
+{{- $cmd -}}
+{{- else -}}
+  {{- $head := "docker run --rm -it" -}}
+  {{- $rest := "" -}}
+  {{- if hasPrefix $cmd (printf "%s " $head) -}}
+    {{- $rest = substr $cmd (add (len $head) 1) -}}
+  {{- else -}}
+    {{- /* wrapper launcher, e.g. `metax-docker …`: head is the first token */ -}}
+    {{- $parts := split $cmd " " -}}
+    {{- $head = index $parts 0 -}}
+    {{- $rest = substr $cmd (add (len $head) 1) -}}
+  {{- end -}}
+  {{- $toks := split $rest " " -}}
+  {{- $n := len $toks -}}
+  {{- $tail := printf "%s %s" (index $toks (sub $n 2)) (index $toks (sub $n 1)) -}}
+  {{- $body := first (sub $n 2) $toks -}}
+  {{- $groups := slice -}}
+  {{- $skip := false -}}
+  {{- range $i, $t := $body -}}
+    {{- if $skip -}}
+      {{- $skip = false -}}
+    {{- else -}}
+      {{- $next := "" -}}
+      {{- if lt (add $i 1) (len $body) -}}{{- $next = index $body (add $i 1) -}}{{- end -}}
+      {{- if and (hasPrefix $t "-") $next (not (hasPrefix $next "-")) -}}
+        {{- $groups = $groups | append (printf "%s %s" $t $next) -}}
+        {{- $skip = true -}}
+      {{- else -}}
+        {{- $groups = $groups | append $t -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $lines := slice (printf "%s \\" $head) -}}
+  {{- range $groups -}}
+    {{- $lines = $lines | append (printf "  %s \\" .) -}}
+  {{- end -}}
+  {{- $lines = $lines | append (printf "  %s" $tail) -}}
+  {{- delimit $lines "\n" -}}
+{{- end -}}

--- a/docs/layouts/shortcodes/runtime-image.html
+++ b/docs/layouts/shortcodes/runtime-image.html
@@ -43,7 +43,7 @@
   {{- else }}
 <p>{{ T "run_generic" }}:</p>
   {{- end }}
-<pre><code>{{ replace .template "{image}" $img }}</code></pre>
+<pre class="language-bash"><code class="language-bash">{{ partial "wrap-cmd" (replace .template "{image}" $img) }}</code></pre>
 {{- end }}
 {{- if not .launch }}
 <p><em>{{ T "run_todo" }}</em></p>


### PR DESCRIPTION
## Problem

On the runtime per-image pages (e.g. `/runtime/nvidia-cuda13.3/`), the `docker run` commands:

1. **weren't syntax-highlighted** — the block had no `language-*` class, so Prism.js skipped it, and
2. **weren't wrapped** — the full command sat on one line, so long `raw` commands (up to ~357 chars) forced horizontal scrolling.

Base pages don't have this: they render fenced ` ```bash ` blocks that get `language-bash`, and the generator pre-wraps long commands with `\` continuations.

The difference is that runtime pages are generated by the `runtime-image` shortcode, which emitted a bare `<pre><code>{{ .template }}</code></pre>`.

## Fix

- **`docs/layouts/partials/wrap-cmd.html`** (new) — a Go-template port of `docs/gen_descriptions.py::wrap_cmd`. Wraps a long command onto multiple lines (one flag or `-flag value` pair per continuation line, `<image> bash` last); leaves commands ≤84 chars untouched. Handles both `docker run …` and wrapper-launchers (e.g. `metax-docker`).
- **`docs/layouts/shortcodes/runtime-image.html`** — the run block now emits `<pre class="language-bash"><code class="language-bash">…</code></pre>` and pipes the command through the `wrap-cmd` partial.

## Result

Runtime pages now match the base pages: Coldark syntax highlighting applies, and long commands wrap with `\` continuations instead of scrolling sideways. Short toolkit commands stay on one line.

## Verification

Clean `hugo --minify` build (exit 0). Spot-checked rendered HTML:

- `nvidia-cuda13.3` — toolkit command one line; raw command wrapped across 8 lines, both `language-bash`.
- `metax-maca3.7.2.1` (wrapper-launcher) — wraps correctly with `metax-docker` as the head.
- No runtime page emits a bare `<pre><code>` anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
