### PR TITLE
feat: fix flaggems-builder default ref to master, add runtime image CI workflow

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -24,7 +24,7 @@ registry:
   host: harbor.baai.ac.cn
   prefixes:
     base: flagos-base
-    # runtime: <prefix>   # TODO: fill in when runtime image CI lands
+    runtime: flagos-runtime
     # app: <prefix>       # TODO: fill in when app image CI lands
 
 # Which runner builds each image (base containerfile name -> runs-on).

--- a/.github/workflows/flaggems-wheel.yml
+++ b/.github/workflows/flaggems-wheel.yml
@@ -17,10 +17,6 @@ name: FlagGems daily wheel
 # Build the pure-Python flag_gems wheel from FlagGems source and (optionally)
 # upload it to the internal PyPI. The wheel is versioned by FlagGems'
 # setuptools_scm (git tags): a dev build looks like 5.4.0.dev580+gb89e0aeb8.
-#
-# NOTE: FLAGGEMS_REF defaults to the under-review wheel-packaging-split branch,
-# which carries the pure-Python setuptools packaging. Change the default to the
-# FlagGems default branch once that branch merges.
 
 on:
   workflow_dispatch:
@@ -28,7 +24,7 @@ on:
       flaggems_ref:
         description: 'FlagGems git ref to build'
         type: string
-        default: wheel-packaging-split
+        default: master
       upload:
         description: 'upload the wheel to the internal PyPI'
         type: boolean
@@ -50,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FLAGGEMS_REPO: https://github.com/flagos-ai/FlagGems.git
-      FLAGGEMS_REF: ${{ inputs.flaggems_ref || 'wheel-packaging-split' }}
+      FLAGGEMS_REF: ${{ inputs.flaggems_ref || 'master' }}
       PYPI_REPO: ${{ inputs.pypi_repo || 'flagos-pypi-daily' }}
     steps:
       - name: Checkout build-infra

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,0 +1,93 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Runtime Image Build (manual)
+
+# Runtime images are built on demand, not on every push/PR. They layer
+# FlagGems (pure Python + optional C++ extension) on top of a base image
+# via wheel install. Trigger this manually to build a backend (or all).
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: 'Backend to build (e.g. nvidia-cuda12.8), or "all"'
+        type: string
+        default: all
+      push:
+        description: 'push image(s) to the registry'
+        type: boolean
+        default: false
+      flaggems_ref:
+        description: 'FlagGems git ref for version derivation'
+        type: string
+        default: master
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+
+      - id: set-matrix
+        shell: bash
+        run: |
+          if [[ "${{ inputs.backend }}" == "all" ]]; then
+            python3 base/generate_matrix.py > matrix.json
+          else
+            python3 base/generate_matrix.py "${{ inputs.backend }}" > matrix.json
+          fi
+          cat matrix.json
+          echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+  build-matrix:
+    needs: set-matrix
+    if: ${{ fromJSON(needs.set-matrix.outputs.matrix).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    name: runtime-${{ matrix.name }}
+    runs-on: ${{ fromJSON(matrix.runson) }}
+    steps:
+      - name: Checkout build-infra
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Checkout FlagGems
+        uses: actions/checkout@v7
+        with:
+          repository: flagos-ai/FlagGems
+          ref: ${{ inputs.flaggems_ref }}
+          fetch-depth: 0
+          path: FlagGems
+
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+
+      - name: Build runtime image
+        run: |
+          push_flag=""
+          if [[ "${{ inputs.push }}" == "true" ]]; then
+            push_flag="--push"
+          fi
+          python3 runtime/build.py "${{ matrix.name }}" \
+            --flaggems-dir FlagGems \
+            ${push_flag}

--- a/flaggems-builder/README.md
+++ b/flaggems-builder/README.md
@@ -36,8 +36,8 @@ version; the checkout just has to include tags.
 `build.sh` only builds (uploading is the workflow's job):
 
 ```sh
-# from a ref (default: wheel-packaging-split — see note below)
-FLAGGEMS_REF=wheel-packaging-split ./build.sh
+# from a ref (default: master)
+FLAGGEMS_REF=master ./build.sh
 
 # from a local clone, offline
 FLAGGEMS_REPO=/path/to/FlagGems ./build.sh
@@ -59,13 +59,3 @@ hit the C++ backend — wrong ref or packaging).
   as a GitHub Actions artifact for inspection.
 - Upload target: **`flagos-pypi-daily`** (the daily/dev repo; releases go to
   `flagos-pypi-hosted`). Auth via the org secret `NEXUS_TOKEN` (`user:token`).
-
-## ⚠️ Temporary: FlagGems ref
-
-`FLAGGEMS_REF` defaults to the **under-review `wheel-packaging-split` branch**,
-which carries the pure-Python setuptools packaging (`build-backend =
-setuptools.build_meta`). On the FlagGems default branch today, `pip wheel .`
-still uses scikit-build and tries to compile C++.
-
-**Once `wheel-packaging-split` merges, change the default ref to the FlagGems
-default branch** (in `build.sh` and the workflow) and delete this note.

--- a/flaggems-builder/build.sh
+++ b/flaggems-builder/build.sh
@@ -28,11 +28,7 @@
 set -euo pipefail
 
 FLAGGEMS_REPO="${FLAGGEMS_REPO:-https://github.com/flagos-ai/FlagGems.git}"
-# TODO: default to the FlagGems default branch once wheel-packaging-split merges.
-# The pure-Python setuptools packaging (build-backend = setuptools.build_meta)
-# lives on that under-review branch for now; on master today `pip wheel .` still
-# uses scikit-build (tries to compile C++). Drop this ref once it lands.
-FLAGGEMS_REF="${FLAGGEMS_REF:-wheel-packaging-split}"
+FLAGGEMS_REF="${FLAGGEMS_REF:-master}"
 OUTDIR="${OUTDIR:-$(pwd)/wheels}"
 
 workdir="$(mktemp -d)"

--- a/runtime/build.py
+++ b/runtime/build.py
@@ -147,6 +147,19 @@ def base_registry(repo_root: Path) -> str | None:
     return f"{host}/{prefix}" if host and prefix else None
 
 
+def runtime_registry(repo_root: Path) -> str | None:
+    """Runtime-image registry prefix ({host}/{prefixes.runtime}) from build-config.yml."""
+    cfg_path = repo_root / ".github" / "build-config.yml"
+    if not cfg_path.exists():
+        return None
+    with open(cfg_path) as f:
+        cfg = yaml.safe_load(f) or {}
+    reg = cfg.get("registry") or {}
+    host = reg.get("host")
+    prefix = (reg.get("prefixes") or {}).get("runtime")
+    return f"{host}/{prefix}" if host and prefix else None
+
+
 def resolve_base_image(
     vendor: str, backend: str, configs: dict, repo_root: Path
 ) -> str:
@@ -316,7 +329,8 @@ def main():
     elif args.registry:
         tag = f"{args.registry}/{image_name}:latest"
     else:
-        tag = f"{image_name}:latest"
+        registry = runtime_registry(repo_root)
+        tag = f"{registry}/{image_name}:latest" if registry else f"{image_name}:latest"
 
     cmd = ["docker", "build"]
     for key, value in build_args.items():


### PR DESCRIPTION
## Changes

### flaggems-builder ref fix
The FlagGems [wheel-packaging-split](https://github.com/flagos-ai/FlagGems/pull/4745) has
merged, so the pure-Python packaging is now on the default branch. This PR
updates the stale `wheel-packaging-split` refs across the build-infra codebase:

| File | Change |
|------|--------|
| `flaggems-builder/build.sh` | Default `FLAGGEMS_REF`: `wheel-packaging-split` → `master` |
| `.github/workflows/flaggems-wheel.yml` | Default `flaggems_ref` input and env fallback: `wheel-packaging-split` → `master` |
| `flaggems-builder/README.md` | Remove the "⚠️ Temporary" section; update examples |

### Runtime image CI workflow

`runtime/` has had `Containerfile` + `build.py` for a while, but no CI
workflow to orchestrate building and pushing the `flagos-runtime-{vendor}-{backend}`
images. This PR adds one:

- **`.github/workflows/runtime.yml`** — manual-dispatch workflow patterned
  after `trigger.yml` for base images. Reuses `base/generate_matrix.py` for
  the backend matrix and `build-config.yml` for runner selection.
  Inputs: `backend` (e.g. `nvidia-cuda12.8` or `all`),
  `push` (boolean), `flaggems_ref` (default `master`).

- **`runtime/build.py`** — added `runtime_registry()` function that reads the
  runtime prefix from `build-config.yml`, so the default image tag resolves to
  `harbor.baai.ac.cn/flagos-runtime/flagos-runtime-{vendor}-{backend}:latest`
  (previously it was a bare `flagos-runtime-...:latest`).

- **`.github/build-config.yml`** — added `runtime: flagos-runtime` prefix
  (uncommented the TODO).

### Dry-run verification

```
$ python runtime/build.py nvidia-cuda12.8 --flaggems-dir ../FlagGems --dry-run
...
EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
EXTRAS_GROUP=nvidia-cuda128,cpp-cuda
COMPILER=flagtree
COMPILER_PKG=flagtree==0.6.0
FLAGGEMS_VERSION=5.4.0.dev637+g37a8c501a
-t harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:latest
```

This PR was written in part with the assistance of generative AI.