### PR TITLE
feat: dual-compiler runtime images (FlagTree + Triton)

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -29,9 +29,13 @@ ARG PYTHON_VERSION=3.12
 ARG FLAGOS_PYPI=""
 ARG DAILY_PYPI=""
 ARG EXTRAS_GROUP=""
-ARG COMPILER=""
-ARG COMPILER_PKG=""
-ARG TRITON_POST_INSTALL=""
+# Compiler packages — each may be empty (no-op). When both are set, FlagTree
+# is the default (installed to /flagos) and Triton is installed to /opt/triton
+# (side dir, switched via PYTHONPATH). When only Triton is set, it goes to
+# /flagos (backward compat).
+ARG FLAGTREE_PKG=""
+ARG TRITON_PKG=""
+ARG TRITON_EXTRA_PKGS=""
 # FlagGems wheel version to pin (== exact). build.py derives it from the
 # FlagGems git describe; buildkit excludes .git from the context so the wheel
 # can't self-detect it.
@@ -48,8 +52,9 @@ ARG FLAGOS_PYPI
 ARG DAILY_PYPI
 ARG EXTRA_PYPI
 ARG EXTRAS_GROUP
-ARG COMPILER_PKG
-ARG TRITON_POST_INSTALL
+ARG FLAGTREE_PKG
+ARG TRITON_PKG
+ARG TRITON_EXTRA_PKGS
 ARG INCLUDE_TESTS
 ARG FLAGGEMS_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
@@ -63,7 +68,7 @@ RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
 ENV VIRTUAL_ENV=/flagos \
     PATH="/flagos/bin:${PATH}"
 
-# ── Install FlagGems (prebuilt wheels) + compiler ─────────────
+# ── Install FlagGems (prebuilt wheels) ─────────────────────────
 # Wheel-based: no source tree, no inline C++ compile. Hermetic — only
 # resource.flagos.net. Two FlagOS indexes with uv's unsafe-first-match so a
 # dependency can resolve from EITHER index; uv's default first-index strategy
@@ -71,16 +76,36 @@ ENV VIRTUAL_ENV=/flagos \
 # cross-index deps like a pinned PyYAML).
 #   flag_gems + flag-gems-cpp-<backend>      -> flagos-pypi-daily  (DAILY_PYPI)
 #   torch / triton / flagtree / pinned deps  -> flagos-pypi-<vendor> (FLAGOS_PYPI)
+# Install FlagGems first (no compiler yet), then layer compilers on top.
 RUN uv pip install --no-cache-dir --prerelease=allow \
       --index-strategy unsafe-first-match \
       --index ${FLAGOS_PYPI} \
       --index ${DAILY_PYPI} \
       --trusted-host resource.flagos.net \
-      "flag_gems[${EXTRAS_GROUP}]==${FLAGGEMS_VERSION}" ${COMPILER_PKG}
+      "flag_gems[${EXTRAS_GROUP}]==${FLAGGEMS_VERSION}"
 
-# ── Triton post-install (e.g. triton_ascend) ─────────────────
-RUN if [ -n "${TRITON_POST_INSTALL}" ]; then \
-      sh -c "${TRITON_POST_INSTALL}"; \
+# ── Install FlagTree (default compiler, if configured) ──────────
+# FlagTree installs to site-packages/triton/ — it's the default import.
+RUN if [ -n "${FLAGTREE_PKG}" ]; then \
+      uv pip install --no-cache-dir ${FLAGTREE_PKG} \
+        --index ${FLAGOS_PYPI} --index ${DAILY_PYPI}; \
+    fi
+
+# ── Install Triton (if configured) ──────────────────────────────
+# When both compilers are present: install Triton to /opt/triton (side dir).
+# The compiler() shell function toggles it by prepending /opt/triton to
+# PYTHONPATH. When FlagTree is absent: install Triton to /flagos normally.
+# Always create /opt/triton so the runtime COPY doesn't fail on missing source.
+RUN mkdir -p /opt/triton
+RUN if [ -n "${TRITON_PKG}" ]; then \
+      if [ -n "${FLAGTREE_PKG}" ]; then \
+        uv pip install --no-cache-dir --target /opt/triton \
+          --index ${FLAGOS_PYPI} --index ${DAILY_PYPI} \
+          ${TRITON_PKG} ${TRITON_EXTRA_PKGS}; \
+      else \
+        uv pip install --no-cache-dir ${TRITON_PKG} ${TRITON_EXTRA_PKGS} \
+          --index ${FLAGOS_PYPI} --index ${DAILY_PYPI}; \
+      fi; \
     fi
 
 # ── Tests — deferred (image not finalized) ────────────────────
@@ -100,12 +125,13 @@ RUN mkdir -p /app \
 FROM ${BASE_IMAGE} AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG COMPILER
 
 # ── Copy uv and venv from builder ─────────────────────────────
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /root/.local/share/uv /root/.local/share/uv
 COPY --from=builder /flagos /flagos
+# Triton side dir — only exists for dual-compiler backends.
+COPY --from=builder /opt/triton /opt/triton
 
 # ── Copy tests and benchmarks ─────────────────────────────────
 COPY --from=builder /app /app
@@ -113,11 +139,78 @@ COPY --from=builder /app /app
 ENV VIRTUAL_ENV=/flagos \
     PATH="/flagos/bin:${PATH}"
 
-# Compiler backend FlagGems uses (flagtree, or triton fallback), and enable the
-# C++ operator extensions (the flag-gems-cpp-<backend> .so files won't load
-# without this).
-ENV COMPILER=${COMPILER} \
-    USE_C_EXTENSION=1
+# Enable C++ operator extensions (the flag-gems-cpp-<backend> .so files
+# won't load without this). The default compiler is FlagTree (installed to
+# /flagos); use 'compiler triton' or 'compiler flagtree' to switch.
+ENV USE_C_EXTENSION=1
+
+# ── Compiler switching function ────────────────────────────────
+# Defined in /etc/bash.bashrc so it's available in interactive shells.
+#   compiler            — show active compiler and what's available
+#   compiler flagtree   — switch to FlagTree (default)
+#   compiler triton     — switch to Triton (prepends /opt/triton to PYTHONPATH)
+RUN printf '\n\
+compiler() {\n\
+  _strip_opt_triton() {\n\
+    local cleaned=""\n\
+    IFS=":"\n\
+    for p in $PYTHONPATH; do\n\
+      [ "$p" != "/opt/triton" ] && [ -n "$cleaned" ] && cleaned="${cleaned}:${p}"\n\
+      [ "$p" != "/opt/triton" ] && [ -z "$cleaned" ] && cleaned="$p"\n\
+    done\n\
+    printf "%%s" "$cleaned"\n\
+  }\n\
+\n\
+  case "${1:-}" in\n\
+    flagtree)\n\
+      cleaned=$(_strip_opt_triton)\n\
+      if [ -n "$cleaned" ]; then\n\
+        export PYTHONPATH="$cleaned"\n\
+      else\n\
+        unset PYTHONPATH\n\
+      fi\n\
+      python3 -c "import triton; print(\"flagtree (active) -\", triton.__version__)"\n\
+      ;;\n\
+    triton)\n\
+      if [ ! -d /opt/triton/triton ]; then\n\
+        echo "triton: not available on this backend" >&2\n\
+        return 1\n\
+      fi\n\
+      cleaned=$(_strip_opt_triton)\n\
+      if [ -n "$cleaned" ]; then\n\
+        export PYTHONPATH="/opt/triton:${cleaned}"\n\
+      else\n\
+        export PYTHONPATH="/opt/triton"\n\
+      fi\n\
+      python3 -c "import triton; print(\"triton (active) -\", triton.__version__)"\n\
+      ;;\n\
+    ""|status|help)\n\
+      echo "available compilers:"\n\
+      if python3 -c "import importlib.metadata; importlib.metadata.version(\"flagtree\")" 2>/dev/null; then\n\
+        ft_ver=$(python3 -c "import importlib.metadata; print(importlib.metadata.version(\"flagtree\"))")\n\
+        echo "  flagtree  ${ft_ver}  (default)"\n\
+      fi\n\
+      if [ -d /opt/triton/triton ]; then\n\
+        tr_ver=$(PYTHONPATH="/opt/triton${PYTHONPATH:+:}${PYTHONPATH:-}" python3 -c "import triton; print(triton.__version__)")\n\
+        echo "  triton    ${tr_ver}"\n\
+      elif python3 -c "import triton" 2>/dev/null; then\n\
+        tr_ver=$(python3 -c "import triton; print(triton.__version__)")\n\
+        echo "  triton    ${tr_ver}  (default)"\n\
+      fi\n\
+      echo\n\
+      echo "active compiler:"\n\
+      python3 -c "import os, triton; print(\" \", \"flagtree\" if \"/opt/triton\" not in os.path.dirname(triton.__file__) else \"triton\", \"-\", triton.__version__)"\n\
+      ;;\n\
+    *)\n\
+      echo "Usage: compiler [flagtree|triton]" >&2\n\
+      echo "  compiler           show status" >&2\n\
+      echo "  compiler flagtree  switch to FlagTree (default)" >&2\n\
+      echo "  compiler triton    switch to Triton" >&2\n\
+      return 1\n\
+      ;;\n\
+  esac\n\
+}\n\
+' >> /etc/bash.bashrc
 
 WORKDIR /app
 ENTRYPOINT ["bash"]

--- a/runtime/build.py
+++ b/runtime/build.py
@@ -213,17 +213,14 @@ def resolve_build_args(
     else:
         extras_spec = extras
 
-    # Compiler: prefer flagtree (the blessed default); fall back to triton only
-    # when the backend has no flagtree entry (flagtree unsupported for it).
-    # A single compiler is baked; the flagtree<->triton switch is a later task.
+    # Both compilers are installed (when configured). FlagTree is the default
+    # (installed to /flagos); Triton is installed to /opt/triton (side dir,
+    # switched via PYTHONPATH). When only Triton is configured, it goes to
+    # /flagos as the sole compiler (backward compat).
     flagtree = backend_info.get("flagtree", "")
     triton = backend_info.get("triton", "")
-    if flagtree:
-        compiler, compiler_pkg = "flagtree", flagtree
-    elif triton:
-        compiler, compiler_pkg = "triton", triton
-    else:
-        compiler, compiler_pkg = "", ""
+    triton_post = backend_info.get("triton_post_install", [])
+    triton_extra = " ".join(triton_post) if isinstance(triton_post, list) else ""
 
     args = {
         "BASE_IMAGE": base_image_override
@@ -233,25 +230,11 @@ def resolve_build_args(
         "DAILY_PYPI": pypi_daily,
         "EXTRA_PYPI": extra_pypi_override or mirror,
         "EXTRAS_GROUP": extras_spec,
-        "COMPILER": compiler,
-        "COMPILER_PKG": compiler_pkg,
+        "FLAGTREE_PKG": flagtree,
+        "TRITON_PKG": triton,
+        "TRITON_EXTRA_PKGS": triton_extra,
         "INCLUDE_TESTS": include_tests_override or "false",
     }
-
-    # Optional triton-specific post-install packages from configs.yaml.
-    # Only relevant when the baked compiler is triton — skip under flagtree.
-    triton_post = backend_info.get("triton_post_install", [])
-    if compiler == "triton" and isinstance(triton_post, list) and triton_post:
-        pkgs = " ".join(triton_post)
-        flagos_pypi = args["FLAGOS_PYPI"]
-        extra_pypi = args["EXTRA_PYPI"]
-        cmd = (
-            f"uv pip install --no-cache-dir"
-            f" --default-index {flagos_pypi}"
-            f" --index {extra_pypi}"
-            f" {pkgs}"
-        )
-        args["TRITON_POST_INSTALL"] = cmd
 
     return args
 


### PR DESCRIPTION
## Problem

Runtime images bake a single compiler (FlagTree OR Triton). Users need
both — FlagTree for better performance, Triton as a fallback. But they
collide on `site-packages/triton/`, so they can't coexist in one venv.

## Solution

Install FlagTree to `/flagos` (the default venv) and Triton to
`/opt/triton` via `--target`. A `compiler()` shell function in
`/etc/bash.bashrc` lets users check and switch without `source`/`eval`:

```
$ compiler
available compilers:
  flagtree  0.6.0   (default)
  triton    3.6.0

active compiler:
  flagtree - 0.6.0

$ compiler triton
triton (active) - 3.6.0

$ compiler flagtree
flagtree (active) - 0.6.0
```

**How it works**: `/opt/triton` is prepended to PYTHONPATH. Python searches
PYTHONPATH before site-packages, so `import triton` resolves to the side dir.
Removing it from PYTHONPATH restores FlagTree.

**Image size**: `/opt/triton` adds ~50-100MB — `--target` only installs
triton + its unique deps, not the full torch/FlagGems stack (~2GB).

## Changes

- **Containerfile**: three install steps — FlagGems → FlagTree → Triton
  (side dir or normal depending on whether FlagTree is configured)
- **build.py**: replaced `COMPILER`/`COMPILER_PKG`/`TRITON_POST_INSTALL`
  with `FLAGTREE_PKG`/`TRITON_PKG`/`TRITON_EXTRA_PKGS`

## Behavior per backend type

| | FlagTree | Triton | Image |
|--|---------|--------|-------|
| Both (nvidia, ascend, ...) | /flagos (default) | /opt/triton (side) | Both available |
| Triton only (cambricon, ...) | — | /flagos (default) | Backward compat |

## Verified

Dry-runs all produce correct build-args:
- `nvidia-cuda12.8`: FLAGTREE_PKG + TRITON_PKG set, TRITON_EXTRA_PKGS empty
- `ascend-cann9.0.0`: FLAGTREE_PKG + TRITON_PKG + TRITON_EXTRA_PKGS set
- `cambricon-neuware4.4.3`: FLAGTREE_PKG empty, only TRITON_PKG set

This PR was written in part with the assistance of generative AI.