### PR TITLE
feat: explicit deps from configs.yaml, no extras for runtime builds

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -28,7 +28,11 @@ ARG INCLUDE_TESTS=true
 ARG PYTHON_VERSION=3.12
 ARG FLAGOS_PYPI=""
 ARG DAILY_PYPI=""
-ARG EXTRAS_GROUP=""
+# Dependencies passed explicitly (no extras) — each may be empty.
+# DEPS: space-separated vendor packages from configs.yaml deps: (torch, etc.)
+# CPP_EXTRA: cpp-cuda / cpp-musa / cpp-npu / cpp-gcu / cpp-ix, or empty
+ARG DEPS=""
+ARG CPP_EXTRA=""
 # Compiler packages — each may be empty (no-op). When both are set, FlagTree
 # is the default (installed to /flagos) and Triton is installed to /opt/triton
 # (side dir, switched via PYTHONPATH). When only Triton is set, it goes to
@@ -51,7 +55,8 @@ ARG PYTHON_VERSION
 ARG FLAGOS_PYPI
 ARG DAILY_PYPI
 ARG EXTRA_PYPI
-ARG EXTRAS_GROUP
+ARG DEPS
+ARG CPP_EXTRA
 ARG FLAGTREE_PKG
 ARG TRITON_PKG
 ARG TRITON_EXTRA_PKGS
@@ -68,21 +73,14 @@ RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
 ENV VIRTUAL_ENV=/flagos \
     PATH="/flagos/bin:${PATH}"
 
-# ── Install FlagGems (prebuilt wheels) ─────────────────────────
-# Wheel-based: no source tree, no inline C++ compile. Hermetic — only
-# resource.flagos.net. Two FlagOS indexes with uv's unsafe-first-match so a
-# dependency can resolve from EITHER index; uv's default first-index strategy
-# pins each package to a single index and won't fall through (which broke
-# cross-index deps like a pinned PyYAML).
-#   flag_gems + flag-gems-cpp-<backend>      -> flagos-pypi-daily  (DAILY_PYPI)
-#   torch / triton / flagtree / pinned deps  -> flagos-pypi-<vendor> (FLAGOS_PYPI)
-# Install FlagGems first (no compiler yet), then layer compilers on top.
-RUN uv pip install --no-cache-dir --prerelease=allow \
-      --index-strategy unsafe-first-match \
-      --index ${FLAGOS_PYPI} \
-      --index ${DAILY_PYPI} \
-      --trusted-host resource.flagos.net \
-      "flag_gems[${EXTRAS_GROUP}]==${FLAGGEMS_VERSION}"
+# ── Install vendor dependencies (explicit, no extras) ──────────
+# Dependencies come from configs.yaml deps: — explicit, no resolver ambiguity.
+# Each vendor has exactly one index (FLAGOS_PYPI), so there is no cross-vendor
+# conflict risk. torch / torchvision / vendor-specific packages go here.
+RUN if [ -n "${DEPS}" ]; then \
+      uv pip install --no-cache-dir ${DEPS} \
+        --index ${FLAGOS_PYPI}; \
+    fi
 
 # ── Install FlagTree (default compiler, if configured) ──────────
 # FlagTree installs to site-packages/triton/ — it's the default import.
@@ -107,6 +105,19 @@ RUN if [ -n "${TRITON_PKG}" ]; then \
           --index ${FLAGOS_PYPI} --index ${DAILY_PYPI}; \
       fi; \
     fi
+
+# ── Install FlagGems LAST (prebuilt wheels) ─────────────────────
+# Installed AFTER all deps and compilers so its ==VERSION pin and dependency
+# constraints are authoritative. Uses two indexes: FlagGems itself lives on
+# DAILY_PYPI, the cpp-* extra (when set) resolves flag-gems-cpp-<vendor> from
+# DAILY_PYPI. All non-FlagGems deps are already installed — uv only verifies,
+# never resolves cross-index. CPP_EXTRA is empty or e.g. cpp-cuda.
+RUN uv pip install --no-cache-dir --prerelease=allow \
+      --index-strategy unsafe-first-match \
+      --index ${FLAGOS_PYPI} \
+      --index ${DAILY_PYPI} \
+      --trusted-host resource.flagos.net \
+      "flag_gems${CPP_EXTRA:+[${CPP_EXTRA}]}==${FLAGGEMS_VERSION}"
 
 # ── Tests — deferred (image not finalized) ────────────────────
 # Tests are NOT shipped yet: FlagGems' [test] extra installs only frameworks,

--- a/runtime/build.py
+++ b/runtime/build.py
@@ -202,16 +202,16 @@ def resolve_build_args(
     pypi_daily = configs.get("pypi_daily", "")
     mirror = configs.get("mirror", "https://mirrors.aliyun.com/pypi/simple")
 
-    # Install spec: fold the per-vendor C++ operators extra into the FlagGems
-    # extras when the backend supports C++ (cmake_backend set). The C++ extra
-    # token is the cmake backend lowercased (CUDA -> cuda -> cpp-cuda), NOT the
-    # vendor name. The extras resolve flag_gems + flag-gems-cpp-<backend> wheels.
-    extras = backend_info.get("extras", "")
+    # Dependencies: explicit vendor packages from configs.yaml deps: (torch,
+    # torchvision, etc.). Passed directly — no extras, no resolver ambiguity.
+    # Extras are unreliable across vendor indexes because uv resolves by package
+    # name and can't distinguish torch==2.8.0+metax from torch==2.9.0+musa.
+    deps = " ".join(backend_info.get("deps", []))
+
+    # C++ extension extra — a single named wheel (flag-gems-cpp-cuda) with no
+    # multi-index resolution ambiguity. Empty when the backend has no C++ support.
     cpp_backend = str(backend_info.get("cmake_backend", "")).lower()
-    if cpp_backend:
-        extras_spec = f"{extras},cpp-{cpp_backend}" if extras else f"cpp-{cpp_backend}"
-    else:
-        extras_spec = extras
+    cpp_extra = f"cpp-{cpp_backend}" if cpp_backend else ""
 
     # Both compilers are installed (when configured). FlagTree is the default
     # (installed to /flagos); Triton is installed to /opt/triton (side dir,
@@ -229,7 +229,8 @@ def resolve_build_args(
         "FLAGOS_PYPI": pypi_base.format(vendor=vendor) if pypi_base else "",
         "DAILY_PYPI": pypi_daily,
         "EXTRA_PYPI": extra_pypi_override or mirror,
-        "EXTRAS_GROUP": extras_spec,
+        "DEPS": deps,
+        "CPP_EXTRA": cpp_extra,
         "FLAGTREE_PKG": flagtree,
         "TRITON_PKG": triton,
         "TRITON_EXTRA_PKGS": triton_extra,


### PR DESCRIPTION
## Problem

Runtime images installed FlagGems with extras (`flag_gems[nvidia-cuda128,cpp-cuda]==V`).
uv resolves extras by package name and can't distinguish
`torch==2.8.0+metax` from `torch==2.9.0+musa` when both indexes are
reachable — it picks unpredictably. This fails in environments where
multiple vendor indexes are configured.

## Solution

Install deps explicitly from `configs.yaml` `deps:`, then FlagGems
LAST with only the `cpp-*` extra (when configured).

**New install order:**
1. `DEPS` — vendor packages (torch, torchvision, etc.) from FLAGOS_PYPI
2. FlagTree — site-packages/triton/ (default compiler)
3. Triton — /opt/triton or /flagos
4. FlagGems LAST — `flag_gems[]==V`

**Why this works:**
- `DEPS` are pinned exact versions, no resolver ambiguity
- The `cpp-*` extra stays because it's a single named wheel
  (`flag-gems-cpp-cuda`), not a multi-package resolution
- FlagGems last = its `==VERSION` pin is authoritative
- Each vendor has exactly one index (FLAGOS_PYPI) — no cross-vendor conflict

**Build-args:** `EXTRAS_GROUP` → `DEPS` + `CPP_EXTRA`
`configs.yaml` `extras:` field is no longer used by runtime builds
(the data stays for documentation purposes).

## Verified

All three backend types produce correct build-args:

| Backend | DEPS | CPP_EXTRA | FlagTree | Triton |
|---------|------|-----------|----------|--------|
| `nvidia-cuda12.8` | torch 2.10.0 + audio + vision | `cpp-cuda` | flagtree==0.6.0 | triton==3.6.0 |
| `cambricon-neuware4.4.3` | dali + torch 2.7.1 + mlu + mlu-ops | _(empty)_ | — | triton==3.2.0 |
| `ascend-cann9.0.0` | torch 2.10.0 + torch-npu | `cpp-npu` | flagtree 0.6.0+ascend3.5 | triton==3.5.0 + triton_ascend |
| `metax-maca3.7.2.1` | torch 2.8.0 + audio + vision + flash_attn | _(empty)_ | flagtree 3.1.0+metax | triton==3.0.0 |

`CPP_EXTRA` empty → `flag_gems==V` (valid pip spec)
`CPP_EXTRA=cpp-cuda` → `flag_gems[cpp-cuda]==V` (valid pip spec)

This PR was written in part with the assistance of generative AI.