### PR TITLE
refactor: per-backend image versioning + code/data separation

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -14,7 +14,7 @@
 
 # Global build configuration, shared across image layers (base / runtime / app).
 #
-# Read by base/generate_matrix.py (runners) and base/build.py (registry).
+# Read by scripts/generate_matrix.py (runners) and scripts/build_base.py (registry).
 # Keep globally-shared build settings here instead of threading them through
 # workflow inputs.
 

--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -23,11 +23,6 @@ name: Base image descriptions
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Released image tag to describe (e.g. 2.1.1). Blank = latest git tag.'
-        type: string
-        default: ''
   workflow_run:
     workflows: ["Base Image Build (manual)"]
     types: [completed]
@@ -45,7 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.m.outputs.matrix }}
-      version: ${{ steps.v.outputs.version }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -53,15 +47,8 @@ jobs:
       - run: python3 -m pip install --user pyyaml
       - id: m
         run: |
-          python3 base/generate_matrix.py > matrix.json
+          python3 scripts/generate_matrix.py > matrix.json
           echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
-      - id: v
-        # Describe the released images: explicit input, else the latest tag.
-        run: |
-          ver="${{ inputs.version }}"
-          [ -n "$ver" ] || ver=$(git describe --tags --abbrev=0 | sed 's/^v//')
-          echo "version=$ver" >> "$GITHUB_OUTPUT"
-          echo "describing image version: $ver"
 
   extract:
     needs: set-matrix
@@ -69,8 +56,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     runs-on: ${{ fromJSON(matrix.runson) }}
-    env:
-      IMAGE_VERSION: ${{ needs.set-matrix.outputs.version }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -102,7 +87,6 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      IMAGE_VERSION: ${{ needs.set-matrix.outputs.version }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
@@ -143,14 +127,15 @@ jobs:
           if git diff --cached --quiet; then
             echo "no description changes — nothing to PR"; exit 0
           fi
-          branch="auto/base-descriptions-${IMAGE_VERSION}"
+          label="$(git describe --tags --abbrev=0 | sed 's/^v//')"
+          branch="auto/base-descriptions-${label}"
           git checkout -b "$branch"
-          git commit -m "docs(base): refresh image descriptions for ${IMAGE_VERSION}"
+          git commit -m "docs(base): refresh image descriptions for ${label}"
           git push -f origin "$branch"
           if ! gh pr view "$branch" >/dev/null 2>&1; then
             gh pr create --base "${GITHUB_REF_NAME}" --head "$branch" \
-              --title "docs(base): refresh image descriptions for ${IMAGE_VERSION}" \
-              --body "Automated refresh of per-image descriptions (baked-in system-package versions) for ${IMAGE_VERSION}. On merge, the descriptions publish to the docs site and Harbor."
+              --title "docs(base): refresh image descriptions for ${label}" \
+              --body "Automated refresh of per-image descriptions (baked-in system-package versions) for ${label}. On merge, the descriptions publish to the docs site and Harbor."
           fi
           gh pr merge "$branch" --auto --squash || \
             echo "auto-merge queued/unavailable — PR left for review"

--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0  # tags needed for base/build.py version (git describe)
+          fetch-depth: 0  # tags needed for version computation (git rev-list)
 
       - name: Install PyYAML
         # Self-hosted runners (h20) have an externally-managed system Python
@@ -64,4 +64,4 @@ jobs:
 
       - name: Build base image
         run: |
-          python3 base/build.py "${{ inputs.name }}" ${{ inputs.push && '--push' || '' }}
+          python3 scripts/build_base.py "${{ inputs.name }}" ${{ inputs.push && '--push' || '' }}

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -50,9 +50,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.backend }}" == "all" ]]; then
-            python3 base/generate_matrix.py > matrix.json
+            python3 scripts/generate_matrix.py > matrix.json
           else
-            python3 base/generate_matrix.py "${{ inputs.backend }}" > matrix.json
+            python3 scripts/generate_matrix.py "${{ inputs.backend }}" > matrix.json
           fi
           cat matrix.json
           echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
@@ -88,6 +88,6 @@ jobs:
           if [[ "${{ inputs.push }}" == "true" ]]; then
             push_flag="--push"
           fi
-          python3 runtime/build.py "${{ matrix.name }}" \
+          python3 scripts/build_runtime.py "${{ matrix.name }}" \
             --flaggems-dir FlagGems \
             ${push_flag}

--- a/.github/workflows/scheduled.yml.disabled
+++ b/.github/workflows/scheduled.yml.disabled
@@ -41,7 +41,7 @@ jobs:
       - id: set-matrix
         shell: bash
         run: |
-          python3 base/generate_matrix.py > matrix.json
+          python3 scripts/generate_matrix.py > matrix.json
           cat matrix.json
           echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -47,9 +47,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.backend }}" == "all" ]]; then
-            python3 base/generate_matrix.py > matrix.json
+            python3 scripts/generate_matrix.py > matrix.json
           else
-            python3 base/generate_matrix.py "${{ inputs.backend }}" > matrix.json
+            python3 scripts/generate_matrix.py "${{ inputs.backend }}" > matrix.json
           fi
           cat matrix.json
           echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+FlagOS container image build infrastructure — **configs.yaml is the single source of truth**.
+It builds three layers for 13+ GPU/NPU vendors:
+
+| Layer | What | Built by |
+|---|---|---|
+| **Base images** | Vendor SDK + toolchain on Ubuntu 24.04 | `base/<vendor>-<backend>` Containerfiles |
+| **Runtime images** | Base + Python venv + FlagGems + compilers (FlagTree/Triton) | `runtime/Containerfile` (one for all) |
+| **Wheels** | FlagTree (C++ compiler) + FlagGems (pure Python) | `flagtree-builder/`, `flaggems-builder/` |
+
+## Key commands
+
+```bash
+# Build a base image locally
+python scripts/build_base.py nvidia-cuda12.8 --dry-run    # preview
+python scripts/build_base.py nvidia-cuda12.8 --push        # build + push
+
+# Build a runtime image (needs FlagGems source for version derivation)
+python scripts/build_runtime.py nvidia-cuda12.8 --flaggems-dir ../FlagGems --dry-run
+python scripts/build_runtime.py metax --flaggems-dir ../FlagGems --push   # vendor shorthand (single backend)
+
+# Generate CI matrix from configs.yaml
+python scripts/generate_matrix.py                          # all buildable backends
+python scripts/generate_matrix.py nvidia-cuda12.8 metax    # subset
+
+# Regenerate the intermediate data file from configs.yaml + Containerfiles
+python docs/gen_data.py                                 # → docs/data/images.yaml
+
+# Generate docs pages + in-repo readmes (base/<name>.md, runtime/<name>.md)
+python docs/gen_descriptions.py                         # all backends → files
+python docs/gen_descriptions.py nvidia-cuda13.3          # one backend → stdout
+```
+
+## Architecture
+
+### Data flow (config-driven, no duplication)
+
+```
+configs.yaml + base/ Containerfiles + build-config.yml
+        │
+        ▼
+  docs/gen_data.py  ──→  docs/data/images.yaml  ──→  docs/gen_descriptions.py  ──→  Hugo pages + Harbor descriptions
+        │
+        ├──→  scripts/generate_matrix.py  ──→  CI matrix JSON  ──→  trigger.yml / runtime.yml
+        └──→  scripts/build_runtime.py    ──→  --build-arg       ──→  runtime/Containerfile
+```
+
+`configs.yaml` owns: vendors, backends, deps, env vars, SDK components, Python version, compiler packages, cmake backend.
+`build-config.yml` owns: registry host+prefixes, runner labels per backend, `docker run` flags per vendor, verify commands.
+`docs/gen_data.py` parses `configs.yaml` + `base/` Containerfiles (FROM, apt packages, env) + `build-config.yml` to produce `docs/data/images.yaml` — the intermediate data file that feeds doc generation.
+`docs/gen_descriptions.py` renders `images.yaml` into per-image markdown (web flavor for Hugo, plain flavor for in-repo + Harbor).
+
+### Image naming
+
+- **Base:** `flagos-base-{vendor}-{backend}:{version}-{n}` — version from Containerfile `LABEL org.opencontainers.image.version` (repo tag), n = per-backend git revision count since that tag. Only Containerfile changes bump n.
+- **Runtime:** `flagos-runtime-{vendor}-{backend}:latest`
+- Registry: `harbor.baai.ac.cn/{prefix}/` (prefix from `build-config.yml` registry.prefixes)
+- `base/<name>` Containerfile names match the `{vendor}-{backend}` key (e.g. `base/nvidia-cuda12.8`)
+
+### Base image version (per-backend, not global)
+
+Each Containerfile declares `LABEL org.opencontainers.image.version="X.Y.Z"`. `scripts/version.py` computes the full version: reads the LABEL + counts commits to that file since tag `vX.Y.Z`. The repo tag anchors all backends at the same X.Y.Z baseline; n diverges per-backend as Containerfiles evolve independently. See `scripts/version.py` for the implementation.
+
+### Runtime Containerfile (multi-stage, dual-compiler)
+
+`runtime/Containerfile` is a single file for all backends. `scripts/build_runtime.py` resolves build args from `configs.yaml`:
+- `BASE_IMAGE` — the base image ref (built from same git tag)
+- `DEPS` — space-separated vendor packages from `configs.yaml deps:` (explicit, no extras — extras are unreliable across vendor indexes)
+- `CPP_EXTRA` — e.g. `cpp-cuda`, derived from `cmake_backend`
+- `FLAGTREE_PKG` / `TRITON_PKG` — compiler packages
+
+Two stages: **builder** (installs uv, venv, deps, compilers, FlagGems wheel) → **runtime** (copies venv + uv). When both compilers are configured, FlagTree is default (`/flagos`) and Triton is a side install (`/opt/triton`), switchable via the `compiler` shell function.
+
+### CI workflows (manual trigger, not push-driven)
+
+- **`trigger.yml`** — Base Image Build (manual). `workflow_dispatch` with backend + push inputs. Generates matrix via `generate_matrix.py`, calls reusable `imagebuild.yml` per backend.
+- **`runtime.yml`** — Runtime Image Build (manual). Same pattern, additionally checks out FlagGems repo for version derivation.
+- **`flaggems-wheel.yml`** — Daily (01:17 UTC) + manual FlagGems wheel build + upload to `flagos-pypi-daily` via twine.
+- **`base-descriptions.yml`** — Triggered on base image build completion. Extracts system package versions from built images (`dpkg-query`), runs `gen_data.py` + `gen_descriptions.py`, opens a **review-gated PR** with the version diff. Publication to Harbor (`base-descriptions-publish.yml`) only happens when that PR lands on `main`.
+- **`hugo-site.yaml`** — Builds + deploys docs site to GitHub Pages (triggered on push to `main` when `docs/**`, `configs.yaml`, or `base/**` changes).
+
+### Runners
+
+All self-hosted: default is `[self-hosted, h20]` (x86_64). Ascend backends override to aarch64 CANN nodes (`cann850` / `cann9`). Defined in `build-config.yml` runners.overrides.
+
+### Adding a new backend
+
+1. Add the vendor SDK to a `base/<vendor>-<backend>` Containerfile
+2. Add the backend spec to `configs.yaml` under `vendors.<vendor>.<backend>`
+3. Add to `docs/data/images.yaml` (display metadata, launch commands)
+4. Add runner override in `build-config.yml` if needed (arch or GPU-specific)
+
+## Conventions
+
+- **Version = Containerfile LABEL + git count.** Each `base/<name>` has `LABEL org.opencontainers.image.version="X.Y.Z"`. `scripts/version.py` computes the per-backend version as `X.Y.Z-n` where n = commits to that file since tag vX.Y.Z. CI needs `fetch-depth: 0`.
+- **Reset at release.** Moving the repo tag (`vX.Y.Z`) and updating all LABELs resets n to 0 across all backends. A `sed` across all Containerfiles is the release procedure.
+- **Per-vendor PyPI indexes.** Each vendor has a separate index: `flagos-pypi-{vendor}`. This isolates vendor-specific packages so there is no cross-vendor package confusion.
+- **No extras for runtime deps.** `configs.yaml deps:` lists explicit packages passed to `uv pip install` — extras (`.[nvidia-cuda128]`) can't resolve correctly across vendor indexes.
+- **FlagTree is the default compiler.** Triton is the fallback (installed to `/opt/triton` when both present). The `compiler` bash function toggles.
+- **Wheel-based install for runtime.** FlagGems is installed from PyPI wheels, not from a source checkout. `--flaggems-dir` in `scripts/build_runtime.py` is only for version derivation.
+- **`base_source` env = TODO.** Some vendors (ascend, hygon, thead) need a `source set_env.sh` step; the goal is to expand these into base image ENV so users don't need to source.
+- **Docs are generated, not hand-written.** `base/<name>.md` and `runtime/<name>.md` are outputs of `docs/gen_descriptions.py`. Edit the generator or data files, not the markdown.
+- **Review-gated descriptions.** System package versions are extracted from built images and injected into description PRs. Human review of version bumps happens before descriptions go live on the docs site or Harbor.
+- **Apache 2.0 license.** All source files carry the license header. `license-tool/` provides header scanning + auto-adding.

--- a/README.md
+++ b/README.md
@@ -31,20 +31,21 @@ from `configs.yaml` + `base/`, so they can't drift from the source.
 |-----------------------------|-------------------------------------------------------------|
 | `configs.yaml`              | Source of truth: per-backend deps, versions, image env      |
 | `base/<vendor>-<backend>`   | Base image containerfiles                                   |
-| `base/build.py`             | Build a base image (reads OCI labels + registry)            |
-| `base/generate_matrix.py`   | Emit the CI build matrix from `configs.yaml`                |
+| `scripts/build_base.py`     | Build a base image (reads OCI labels + registry)            |
+| `scripts/generate_matrix.py`| Emit the CI build matrix from `configs.yaml`                |
+| `scripts/build_runtime.py`  | Build a runtime image                                       |
 | `.github/build-config.yml`  | Global build config: registry + per-backend runners         |
-| `runtime/`                  | FlagGems runtime image build system                         |
+| `runtime/`                  | Runtime Containerfile + per-image readmes                   |
 | `flagtree-builder/`         | Low-glibc FlagTree wheel builders                           |
-| `docs/`                     | Hugo docs site (data-driven from the files above)           |
+| `docs/`                     | Hugo docs site + data-generation scripts                    |
 
 ## Quick start
 
 Build a base image locally:
 
 ```bash
-python base/build.py nvidia-cuda12.8 --dry-run   # preview
-python base/build.py nvidia-cuda12.8 --push      # build + push
+python scripts/build_base.py nvidia-cuda12.8 --dry-run   # preview
+python scripts/build_base.py nvidia-cuda12.8 --push      # build + push
 ```
 
 In CI, base images are built on demand via the **Base Image Build (manual)**

--- a/base/ascend-cann8.5.0
+++ b/base/ascend-cann8.5.0
@@ -22,6 +22,7 @@
 FROM ubuntu:24.04 AS Builder
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG PYTHON_VERSION=3.11

--- a/base/ascend-cann9.0.0
+++ b/base/ascend-cann9.0.0
@@ -22,6 +22,7 @@
 FROM ubuntu:24.04 AS Builder
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG PYTHON_VERSION=3.11

--- a/base/cambricon-neuware4.4.3
+++ b/base/cambricon-neuware4.4.3
@@ -26,6 +26,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/cambricon

--- a/base/enflame-tops1.9.10
+++ b/base/enflame-tops1.9.10
@@ -21,6 +21,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/enflame

--- a/base/hygon-dtk26.04
+++ b/base/hygon-dtk26.04
@@ -25,6 +25,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG FILE_STORE=https://resource.flagos.net/repository/flagos-filestore

--- a/base/iluvatar-corex4.4.0
+++ b/base/iluvatar-corex4.4.0
@@ -20,6 +20,7 @@
 FROM ubuntu:24.04 AS builder
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore

--- a/base/kunlunxin-xre5.29.0
+++ b/base/kunlunxin-xre5.29.0
@@ -25,6 +25,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG FILE_STORE=https://resource.flagos.net/repository/flagos-filestore

--- a/base/metax-maca3.7.2.1
+++ b/base/metax-maca3.7.2.1
@@ -21,6 +21,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 ARG SDK_VERSION=3.7.2.0
 ARG DRIVER_VERSION=3.7.2.30

--- a/base/mthreads-musa4.3.6
+++ b/base/mthreads-musa4.3.6
@@ -23,6 +23,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/mthreads

--- a/base/mthreads-musa5.2.0
+++ b/base/mthreads-musa5.2.0
@@ -23,6 +23,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/mthreads

--- a/base/nvidia-cuda12.8
+++ b/base/nvidia-cuda12.8
@@ -23,6 +23,7 @@
 FROM nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV DEBIAN_FRONTEND=noninteractive

--- a/base/nvidia-cuda13.3
+++ b/base/nvidia-cuda13.3
@@ -23,6 +23,7 @@
 FROM nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV DEBIAN_FRONTEND=noninteractive

--- a/base/sunrise-tangrt1.2.0
+++ b/base/sunrise-tangrt1.2.0
@@ -21,6 +21,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 ARG TANGRT_VERSION=v1.2.0
 

--- a/base/tsingmicro-tsm260604
+++ b/base/tsingmicro-tsm260604
@@ -22,6 +22,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
+LABEL org.opencontainers.image.version="2.1.1"
 
 ARG PYTHON_VERSION=3.10
 ARG SDK_RELEASE=260604163331

--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -30,11 +30,15 @@ Each entry has a `base` section (from the containerfile) and a `runtime`
 section (the software stack from configs.yaml).
 """
 
-import os
 import re
 import subprocess
 import sys
 from pathlib import Path
+
+# load version.py from sibling scripts/ directory
+_scripts_dir = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(_scripts_dir))
+from version import image_version
 
 import yaml
 
@@ -46,17 +50,8 @@ def find_repo_root() -> Path:
     sys.exit("Error: cannot locate repository root (base/ + configs.yaml)")
 
 
-def git_version(repo_root: Path) -> str:
-    """Release version for the image tags.
-
-    An explicit IMAGE_VERSION env wins (the descriptions workflow feeds the
-    released tag so refs match the pushed images even when main has advanced
-    past the tag). Otherwise `git describe --tags`, matching base/build.py:
-    "v2.1.0" -> "2.1.0", commits after -> "2.1.0-3-gsha". Falls back to "latest".
-    """
-    override = os.environ.get("IMAGE_VERSION")
-    if override:
-        return override.lstrip("v")
+def _git_describe(repo_root: Path) -> str:
+    """Fallback version when a Containerfile has no version LABEL."""
     try:
         r = subprocess.run(
             ["git", "describe", "--tags", "--always"],
@@ -202,7 +197,6 @@ def main():
     configs = load_yaml(repo_root / "configs.yaml")
     build_config = load_yaml(repo_root / ".github" / "build-config.yml")
 
-    version = git_version(repo_root)  # release version, all base images share it
     base_prefix = prefix_for(build_config, "base")
     runtime_prefix = prefix_for(build_config, "runtime")
     run_cfg = build_config.get("run") or {}
@@ -264,6 +258,8 @@ def main():
             sdk_blob = " ".join(sdk).lower()
             arch = "aarch64" if ("aarch64" in sdk_blob or "arm64" in sdk_blob) else "x86_64"
 
+            ver = image_version(repo_root, name) or _git_describe(repo_root)
+
             backends.append(
                 {
                     "name": name,
@@ -273,7 +269,7 @@ def main():
                     "run_prereq": run_prereq.get(vendor, ""),
                     "verify": verify_vendors.get(vendor, ""),
                     "base": {
-                        "image": image(base_prefix, "base", name, version),
+                        "image": image(base_prefix, "base", name, ver),
                         "os": meta["base_os"] or "",
                         "arch": arch,
                         "hardware": spec.get("hardware") or [],

--- a/scripts/build_base.py
+++ b/scripts/build_base.py
@@ -16,28 +16,28 @@
 
 """Build FlagOS base container images.
 
-The image version comes from the build-infra Git tag (`git describe --tags`) —
-there is no version stored in the containerfiles. A tagged release commit builds
-a clean version (`2.1.0`); commits after a tag build `2.1.0-<n>-g<sha>`, which
-is self-evidently a dev build. The version, source commit, and build time are
-stamped onto the image as OCI labels.
+The image version comes from the Containerfile's ``LABEL org.opencontainers.image.version``
+plus a per-backend git revision count since that version's tag — so only
+Containerfile changes bump the version, not unrelated repo edits.
 
 Image tag convention:
-    flagos-base-{name}:{version}       (version = git describe, "v" stripped)
+    flagos-base-{name}:{version}-{n}   (n = commits to base/{name} since v{version})
 
 Usage:
-    python base/build.py <name> [options]
+    python scripts/build_base.py <name> [options]
 
 Examples:
-    python base/build.py nvidia-cuda12.8 --dry-run
-    python base/build.py ascend-cann9.0.0 --push
-    python base/build.py metax-maca3.7.2.1 --tag my-registry/flagos-base-metax:custom
+    python scripts/build_base.py nvidia-cuda12.8 --dry-run
+    python scripts/build_base.py ascend-cann9.0.0 --push
+    python scripts/build_base.py metax-maca3.7.2.1 --tag my-registry/flagos-base-metax:custom
 """
 
 import argparse
 import subprocess
 import sys
 from pathlib import Path
+
+from version import image_version
 
 IMAGE_PREFIX = "flagos-base"
 
@@ -136,7 +136,7 @@ def main():
             f"Available: {', '.join(available)}"
         )
 
-    version = git_version(repo_root)
+    version = image_version(repo_root, args.name) or git_version(repo_root)
     commit = git(repo_root, "rev-parse", "HEAD") or ""
     created = git(repo_root, "show", "-s", "--format=%cI", "HEAD") or ""
 

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -21,18 +21,20 @@ dependencies) to resolve build arguments, then invokes `docker build`
 with the appropriate --build-arg values.
 
 Usage:
-    python runtime/build.py <backend-key> --flaggems-dir <path> [options]
+    python scripts/build_runtime.py <backend-key> --flaggems-dir <path> [options]
 
 Examples:
-    python runtime/build.py nvidia-cuda12.8 --flaggems-dir ../FlagGems --dry-run
-    python runtime/build.py ascend-cann9.0.0 --flaggems-dir ../FlagGems --tag latest
-    python runtime/build.py metax --flaggems-dir ../FlagGems --push
+    python scripts/build_runtime.py nvidia-cuda12.8 --flaggems-dir ../FlagGems --dry-run
+    python scripts/build_runtime.py ascend-cann9.0.0 --flaggems-dir ../FlagGems --tag latest
+    python scripts/build_runtime.py metax --flaggems-dir ../FlagGems --push
 """
 
 import argparse
 import subprocess
 import sys
 from pathlib import Path
+
+from version import image_version
 
 import yaml
 
@@ -115,7 +117,7 @@ def resolve_backend(backend_arg: str, configs: dict):
 def git_describe(repo_root: Path) -> str | None:
     """build-infra release version via `git describe --tags` ("v" stripped).
 
-    Same scheme base/build.py stamps onto the base image tag.
+    Same scheme build_base.py stamps onto the base image tag.
     """
     try:
         r = subprocess.run(
@@ -165,24 +167,27 @@ def resolve_base_image(
 ) -> str:
     """Full base image ref for the runtime FROM.
 
-    {registry}/{prefix}-{vendor}-{backend}:{git-version}
+    {registry}/{prefix}-{vendor}-{backend}:{version}
 
-    The tag comes from build-infra's `git describe --tags` — the SAME version
-    base/build.py stamps onto the pushed base image. (PR #99 removed the
-    version/revision LABELs, so this no longer reads them.) Falls back to :latest
-    with a warning when no tag is reachable (shallow checkout — use fetch-depth: 0).
+    The version comes from the base image's Containerfile LABEL +
+    per-backend git revision count (see version.image_version).
+    Falls back to git describe when the Containerfile has no version LABEL.
+    Falls back to :latest when no git tag is reachable (shallow checkout).
     """
     prefix = configs.get("base_image_prefix", "flagos-base")
-    version = git_describe(repo_root)
+    name = f"{vendor}-{backend}"
+    version = image_version(repo_root, name)
+    if version is None:
+        version = git_describe(repo_root)
     if not version:
         print(
             "warning: no git tag reachable — base image tag defaults to :latest",
             file=sys.stderr,
         )
         version = "latest"
-    name = f"{prefix}-{vendor}-{backend}:{version}"
+    img = f"{prefix}-{name}:{version}"
     registry = base_registry(repo_root)
-    return f"{registry}/{name}" if registry else name
+    return f"{registry}/{img}" if registry else img
 
 
 def resolve_build_args(
@@ -278,9 +283,10 @@ def main():
     script_dir = Path(__file__).resolve().parent
     repo_root = script_dir.parent
     flaggems_dir = Path(args.flaggems_dir).resolve()
+    runtime_dir = repo_root / "runtime"
 
     configs_path = repo_root / "configs.yaml"
-    containerfile = script_dir / "Containerfile"
+    containerfile = runtime_dir / "Containerfile"
 
     if not configs_path.exists():
         sys.exit(f"Error: {configs_path} not found")
@@ -322,7 +328,7 @@ def main():
     # Wheel-based install: the image installs FlagGems from PyPI, so the build
     # context no longer needs the FlagGems source tree (no COPY). Use runtime/
     # as a trivial context. --flaggems-dir is kept only to derive the version.
-    cmd.extend(["-f", str(containerfile), "-t", tag, str(script_dir)])
+    cmd.extend(["-f", str(containerfile), "-t", tag, str(runtime_dir)])
 
     if args.dry_run:
         print("Would run:")

--- a/scripts/generate_matrix.py
+++ b/scripts/generate_matrix.py
@@ -25,8 +25,8 @@ Output (compact JSON on stdout):
     {"include": [{"name": "nvidia-cuda12.8", "runson": "..."}, ...]}
 
 Usage:
-    python base/generate_matrix.py                       # all buildable backends
-    python base/generate_matrix.py nvidia-cuda12.8 metax-maca3.7.2.1  # subset
+    python scripts/generate_matrix.py                       # all buildable backends
+    python scripts/generate_matrix.py nvidia-cuda12.8 metax-maca3.7.2.1  # subset
 
 Backends without a base/ file (e.g. thead-ppu2.0.0, spacemit-spacemit) are
 skipped with a note on stderr.

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,0 +1,83 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base image version computation.
+
+Each base/<vendor>-<backend> Containerfile declares a base repo version label::
+
+    LABEL org.opencontainers.image.version="2.1.1"
+
+image_version() reads that label and counts git commits to the Containerfile
+since the corresponding tag (v2.1.1), producing::
+
+    2.1.1        (n=0, no changes since the tag)
+    2.1.1-3      (3 commits to this Containerfile since v2.1.1)
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+
+_VERSION_LABEL_RE = re.compile(
+    r'LABEL\s+org\.opencontainers\.image\.version\s*=\s*"([^"]+)"'
+)
+
+
+def read_version_label(repo_root: Path, name: str) -> str | None:
+    """Read the base version label from ``base/<name>`` Containerfile.
+
+    Returns the version string (e.g. ``"2.1.1"``) or None when the
+    file is missing or has no version label.
+    """
+    cf = repo_root / "base" / name
+    if not cf.is_file():
+        return None
+    m = _VERSION_LABEL_RE.search(cf.read_text())
+    return m.group(1) if m else None
+
+
+def image_version(repo_root: Path, name: str) -> str | None:
+    """Compute the per-backend image version tag.
+
+    ``name`` is the containerfile name (e.g. ``"nvidia-cuda12.8"``).
+
+    Returns ``"X.Y.Z-n"`` when there are *n* commits to ``base/<name>``
+    since tag ``vX.Y.Z``, or just ``"X.Y.Z"`` when n=0.  Returns None
+    when the Containerfile has no version label — callers should fall
+    back to the old ``git describe`` scheme.
+    """
+    label_ver = read_version_label(repo_root, name)
+    if not label_ver:
+        return None
+
+    tag = f"v{label_ver}"
+    try:
+        r = subprocess.run(
+            ["git", "rev-list", "--count", f"{tag}..HEAD", "--", f"base/{name}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return label_ver
+
+    # Tag not reachable (e.g. it still points to an old commit, or doesn't
+    # exist yet) — treat as n=0, which is the right answer once the tag is
+    # moved to HEAD.
+    if r.returncode != 0:
+        return label_ver
+
+    n = int(r.stdout.strip())
+    return f"{label_ver}-{n}" if n else label_ver


### PR DESCRIPTION
## Summary

Base image versions now come from `LABEL org.opencontainers.image.version` in each Containerfile, plus a per-backend git revision count since that tag. Only Containerfile changes bump `-n` — editing `docs/`, `runtime/`, or unrelated backends leaves the image tag unchanged.

## Design

```dockerfile
# base/nvidia-cuda12.8
LABEL org.opencontainers.image.version="2.1.1"
```

`scripts/version.py` reads the label + counts commits to that file since `v2.1.1`:

| Backend | Tag |
|---|---|
| nvidia-cuda12.8 (1 change) | `2.1.1-1` |
| ascend-cann9.0.0 (3 changes) | `2.1.1-3` |
| hygon-dtk26.04 (2 changes) | `2.1.1-2` |

When `v2.1.1` tag is moved to HEAD, all `n` reset to 0 → `2.1.1`.

## Code/data separation

Python code moved from `base/` and `runtime/` into `scripts/`:

```
scripts/
  version.py           ← shared module
  build_base.py        ← base/build.py
  build_runtime.py     ← runtime/build.py
  generate_matrix.py   ← base/generate_matrix.py

base/    ← Containerfiles + .md only (pure data)
runtime/ ← Containerfile + .md only (pure data)
```

Also adds `CLAUDE.md` as a project knowledge base for Claude Code.

## Files changed

- **New**: `scripts/version.py`, `CLAUDE.md`
- **Migrated**: `scripts/build_base.py`, `scripts/build_runtime.py`, `scripts/generate_matrix.py`
- **Modified**: 14 Containerfiles (add version LABEL), 6 CI workflows, `docs/gen_data.py`, `README.md`, `build-config.yml`
- **Removed**: `base/build.py`, `base/generate_matrix.py`, `runtime/build.py`

This PR was written in part with the assistance of generative AI.