### PR TITLE
refactor: stack version + flaggems from configs.yaml

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -29,10 +29,10 @@ on:
         description: 'push image(s) to the registry'
         type: boolean
         default: false
-      flaggems_ref:
-        description: 'FlagGems git ref for version derivation'
+      flaggems:
+        description: 'FlagGems wheel version to install (e.g. 5.4.0.dev601+g03122362d)'
         type: string
-        default: master
+        default: ''
 
 jobs:
   set-matrix:
@@ -71,14 +71,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Checkout FlagGems
-        uses: actions/checkout@v7
-        with:
-          repository: flagos-ai/FlagGems
-          ref: ${{ inputs.flaggems_ref }}
-          fetch-depth: 0
-          path: FlagGems
-
       - name: Install PyYAML
         run: python3 -m pip install --user pyyaml
 
@@ -89,5 +81,5 @@ jobs:
             push_flag="--push"
           fi
           python3 scripts/build_runtime.py "${{ matrix.name }}" \
-            --flaggems-dir FlagGems \
+            --flaggems "${{ inputs.flaggems }}" \
             ${push_flag}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,10 @@ It builds three layers for 13+ GPU/NPU vendors:
 python scripts/build_base.py nvidia-cuda12.8 --dry-run    # preview
 python scripts/build_base.py nvidia-cuda12.8 --push        # build + push
 
-# Build a runtime image (needs FlagGems source for version derivation)
-python scripts/build_runtime.py nvidia-cuda12.8 --flaggems-dir ../FlagGems --dry-run
-python scripts/build_runtime.py metax --flaggems-dir ../FlagGems --push   # vendor shorthand (single backend)
+# Build a runtime image (FlagGems version from configs.yaml, or override)
+python scripts/build_runtime.py nvidia-cuda12.8 --dry-run
+python scripts/build_runtime.py metax --push                     # vendor shorthand
+python scripts/build_runtime.py nvidia-cuda12.8 --flaggems 5.4.0.dev601+g03122362d
 
 # Generate CI matrix from configs.yaml
 python scripts/generate_matrix.py                          # all buildable backends
@@ -64,7 +65,7 @@ configs.yaml + base/ Containerfiles + build-config.yml
 
 ### Base image version (per-backend, not global)
 
-Each Containerfile declares `LABEL org.opencontainers.image.version="X.Y.Z"`. `scripts/version.py` computes the full version: reads the LABEL + counts commits to that file since tag `vX.Y.Z`. The repo tag anchors all backends at the same X.Y.Z baseline; n diverges per-backend as Containerfiles evolve independently. See `scripts/version.py` for the implementation.
+`configs.yaml` declares `version: "X.Y.Z"` — the single stack-wide release version. `scripts/version.py` counts git commits to each `base/<name>` since tag `vX.Y.Z`, producing `X.Y.Z-n` per backend. The repo tag anchors all backends at the same baseline; n diverges as Containerfiles evolve independently. The version is stamped onto the image at build time as an OCI label — Containerfiles do not hardcode it.
 
 ### Runtime Containerfile (multi-stage, dual-compiler)
 
@@ -73,6 +74,7 @@ Each Containerfile declares `LABEL org.opencontainers.image.version="X.Y.Z"`. `s
 - `DEPS` — space-separated vendor packages from `configs.yaml deps:` (explicit, no extras — extras are unreliable across vendor indexes)
 - `CPP_EXTRA` — e.g. `cpp-cuda`, derived from `cmake_backend`
 - `FLAGTREE_PKG` / `TRITON_PKG` — compiler packages
+- `FLAGGEMS_VERSION` — from `configs.yaml` `flaggems:`, override with `--flaggems`
 
 Two stages: **builder** (installs uv, venv, deps, compilers, FlagGems wheel) → **runtime** (copies venv + uv). When both compilers are configured, FlagTree is default (`/flagos`) and Triton is a side install (`/opt/triton`), switchable via the `compiler` shell function.
 
@@ -97,12 +99,12 @@ All self-hosted: default is `[self-hosted, h20]` (x86_64). Ascend backends overr
 
 ## Conventions
 
-- **Version = Containerfile LABEL + git count.** Each `base/<name>` has `LABEL org.opencontainers.image.version="X.Y.Z"`. `scripts/version.py` computes the per-backend version as `X.Y.Z-n` where n = commits to that file since tag vX.Y.Z. CI needs `fetch-depth: 0`.
-- **Reset at release.** Moving the repo tag (`vX.Y.Z`) and updating all LABELs resets n to 0 across all backends. A `sed` across all Containerfiles is the release procedure.
+- **Version from configs.yaml.** `configs.yaml` `version:` is the single stack-wide release version. `scripts/version.py` computes per-backend versions as `X.Y.Z-n` where n = commits to `base/<name>` since tag vX.Y.Z. At release: bump `version:` and `flaggems:` in one place → `git tag vX.Y.Z`.
+- **FlagGems version from configs.yaml.** `configs.yaml` `flaggems:` sets the wheel version for runtime builds. Override with `--flaggems` CLI flag when needed.
 - **Per-vendor PyPI indexes.** Each vendor has a separate index: `flagos-pypi-{vendor}`. This isolates vendor-specific packages so there is no cross-vendor package confusion.
 - **No extras for runtime deps.** `configs.yaml deps:` lists explicit packages passed to `uv pip install` — extras (`.[nvidia-cuda128]`) can't resolve correctly across vendor indexes.
 - **FlagTree is the default compiler.** Triton is the fallback (installed to `/opt/triton` when both present). The `compiler` bash function toggles.
-- **Wheel-based install for runtime.** FlagGems is installed from PyPI wheels, not from a source checkout. `--flaggems-dir` in `scripts/build_runtime.py` is only for version derivation.
+- **Wheel-based install for runtime.** FlagGems is installed from PyPI wheels. `--flaggems` pins the exact wheel version.
 - **`base_source` env = TODO.** Some vendors (ascend, hygon, thead) need a `source set_env.sh` step; the goal is to expand these into base image ENV so users don't need to source.
 - **Docs are generated, not hand-written.** `base/<name>.md` and `runtime/<name>.md` are outputs of `docs/gen_descriptions.py`. Edit the generator or data files, not the markdown.
 - **Review-gated descriptions.** System package versions are extracted from built images and injected into description PRs. Human review of version bumps happens before descriptions go live on the docs site or Harbor.

--- a/base/ascend-cann8.5.0
+++ b/base/ascend-cann8.5.0
@@ -22,7 +22,6 @@
 FROM ubuntu:24.04 AS Builder
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG PYTHON_VERSION=3.11

--- a/base/ascend-cann9.0.0
+++ b/base/ascend-cann9.0.0
@@ -22,7 +22,6 @@
 FROM ubuntu:24.04 AS Builder
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG PYTHON_VERSION=3.11

--- a/base/cambricon-neuware4.4.3
+++ b/base/cambricon-neuware4.4.3
@@ -26,7 +26,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/cambricon

--- a/base/enflame-tops1.9.10
+++ b/base/enflame-tops1.9.10
@@ -21,7 +21,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/enflame

--- a/base/hygon-dtk26.04
+++ b/base/hygon-dtk26.04
@@ -25,7 +25,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG FILE_STORE=https://resource.flagos.net/repository/flagos-filestore

--- a/base/iluvatar-corex4.4.0
+++ b/base/iluvatar-corex4.4.0
@@ -20,7 +20,6 @@
 FROM ubuntu:24.04 AS builder
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore

--- a/base/kunlunxin-xre5.29.0
+++ b/base/kunlunxin-xre5.29.0
@@ -25,7 +25,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ARG FILE_STORE=https://resource.flagos.net/repository/flagos-filestore

--- a/base/metax-maca3.7.2.1
+++ b/base/metax-maca3.7.2.1
@@ -21,7 +21,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 ARG SDK_VERSION=3.7.2.0
 ARG DRIVER_VERSION=3.7.2.30

--- a/base/mthreads-musa4.3.6
+++ b/base/mthreads-musa4.3.6
@@ -23,7 +23,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/mthreads

--- a/base/mthreads-musa5.2.0
+++ b/base/mthreads-musa5.2.0
@@ -23,7 +23,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/mthreads

--- a/base/nvidia-cuda12.8
+++ b/base/nvidia-cuda12.8
@@ -23,7 +23,6 @@
 FROM nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV DEBIAN_FRONTEND=noninteractive

--- a/base/nvidia-cuda13.3
+++ b/base/nvidia-cuda13.3
@@ -23,7 +23,6 @@
 FROM nvcr.io/nvidia/cuda:13.3.0-runtime-ubuntu24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV DEBIAN_FRONTEND=noninteractive

--- a/base/sunrise-tangrt1.2.0
+++ b/base/sunrise-tangrt1.2.0
@@ -21,7 +21,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 ARG TANGRT_VERSION=v1.2.0
 

--- a/base/tsingmicro-tsm260604
+++ b/base/tsingmicro-tsm260604
@@ -22,7 +22,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
-LABEL org.opencontainers.image.version="2.1.1"
 
 ARG PYTHON_VERSION=3.10
 ARG SDK_RELEASE=260604163331

--- a/configs.yaml
+++ b/configs.yaml
@@ -15,12 +15,16 @@
 # FlagOS build configuration.
 #
 # Single source of truth for all vendor/backend dependencies and build
-# settings. Used by base/build.py and runtime/build.py.
+# settings. Used by scripts/build_base.py and scripts/build_runtime.py.
+#
+# Stack-level fields:
+#   version:  release version (e.g. "2.1.1") — seeds all base image tags.
+#   flaggems: FlagGems wheel version for runtime builds — override with --flaggems.
 #
 # Base image naming convention:
-#   {base_image_prefix}-{vendor}-{backend}:{version}-{revision}
-#   e.g. flagos-base-nvidia-cuda12.8:2.1.0-0
-#   Version and revision are read from OCI LABELs in base/{vendor}-{backend}.
+#   {base_image_prefix}-{vendor}-{backend}:{version}-{n}
+#   e.g. flagos-base-nvidia-cuda12.8:2.1.1-0
+#   {n} = commits to base/{vendor}-{backend} since tag v{version}.
 #
 # Runtime image naming convention:
 #   flagos-runtime-{vendor}-{backend}:latest
@@ -54,6 +58,14 @@
 #   "driver:"          — host driver version installed on the node — a prerequisite,
 #                        distinct from the in-container SDK. Probed from the vendor's
 #                        smi tool (nvidia-smi, npu-smi, ...).
+
+# FlagOS software stack version — the single anchor for the whole release.
+# This version seeds all base image tags and the runtime Containerfile OCI labels.
+# Runtime images also pull the corresponding FlagGems wheel version below.
+#
+# At release: bump both fields → git tag v<VERSION> → done.
+version: "2.1.1"
+flaggems: ""
 
 base_image_prefix: "flagos-base"
 

--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -40,9 +40,8 @@ ARG CPP_EXTRA=""
 ARG FLAGTREE_PKG=""
 ARG TRITON_PKG=""
 ARG TRITON_EXTRA_PKGS=""
-# FlagGems wheel version to pin (== exact). build.py derives it from the
-# FlagGems git describe; buildkit excludes .git from the context so the wheel
-# can't self-detect it.
+# FlagGems wheel version to pin (== exact). Set by build_runtime.py from
+# configs.yaml flaggems: or the --flaggems CLI override.
 ARG FLAGGEMS_VERSION=0.0.0
 
 

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -21,12 +21,13 @@ dependencies) to resolve build arguments, then invokes `docker build`
 with the appropriate --build-arg values.
 
 Usage:
-    python scripts/build_runtime.py <backend-key> --flaggems-dir <path> [options]
+    python scripts/build_runtime.py <backend-key> [options]
 
 Examples:
-    python scripts/build_runtime.py nvidia-cuda12.8 --flaggems-dir ../FlagGems --dry-run
-    python scripts/build_runtime.py ascend-cann9.0.0 --flaggems-dir ../FlagGems --tag latest
-    python scripts/build_runtime.py metax --flaggems-dir ../FlagGems --push
+    python scripts/build_runtime.py nvidia-cuda12.8 --dry-run
+    python scripts/build_runtime.py ascend-cann9.0.0 --tag latest
+    python scripts/build_runtime.py metax --push
+    python scripts/build_runtime.py nvidia-cuda12.8 --flaggems 5.4.0.dev601+g03122362d   # override
 """
 
 import argparse
@@ -42,40 +43,6 @@ import yaml
 def load_yaml(path: Path) -> dict:
     with open(path) as f:
         return yaml.safe_load(f)
-
-
-def get_flaggems_version(flaggems_dir: Path) -> str:
-    """Get FlagGems version from git describe.
-
-    TODO: Remove once we switch to wheel-based install — the wheel
-    will carry the correct version and setuptools-scm won't be needed.
-    """
-    try:
-        result = subprocess.run(
-            ["git", "describe", "--tags"],
-            cwd=flaggems_dir,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            # Convert git describe output to setuptools-scm format:
-            #   "v5.4.0.dev0-528-g0283c119d" → "5.4.0.dev528+g0283c119d"
-            desc = result.stdout.strip().lstrip("v")
-            parts = desc.split("-")
-            if len(parts) >= 3:
-                tag = parts[0]  # "5.4.0.dev0"
-                distance = parts[-2]  # "528"
-                commit = parts[-1]  # "g0283c119d"
-                # Replace ".dev0" with ".dev{distance}"
-                if ".dev" in tag:
-                    tag = tag[: tag.index(".dev")]
-                return f"{tag}.dev{distance}+{commit}"
-            else:
-                # Exact tag, no commits after
-                return parts[0]
-    except FileNotFoundError:
-        pass
-    return "0.0.0"
 
 
 def resolve_backend(backend_arg: str, configs: dict):
@@ -256,10 +223,9 @@ def main():
         help="Backend key (e.g. nvidia-cuda12.8, ascend-cann9.0.0, metax)",
     )
     parser.add_argument(
-        "--flaggems-dir",
-        required=True,
-        help="Path to FlagGems source tree — used ONLY to derive the wheel "
-        "version (git describe); no longer the docker build context.",
+        "--flaggems",
+        default="",
+        help="FlagGems wheel version override (default: from configs.yaml)",
     )
     parser.add_argument("--base-image", help="Override base image")
     parser.add_argument("--extra-pypi", help="Override extra PyPI mirror URL")
@@ -282,7 +248,6 @@ def main():
 
     script_dir = Path(__file__).resolve().parent
     repo_root = script_dir.parent
-    flaggems_dir = Path(args.flaggems_dir).resolve()
     runtime_dir = repo_root / "runtime"
 
     configs_path = repo_root / "configs.yaml"
@@ -294,9 +259,6 @@ def main():
         sys.exit(f"Error: {containerfile} not found")
 
     configs = load_yaml(configs_path)
-
-    # TODO: Remove FLAGGEMS_VERSION once we switch to wheel-based install.
-    flaggems_version = get_flaggems_version(flaggems_dir)
 
     backend_info, vendor, backend = resolve_backend(args.backend, configs)
 
@@ -310,7 +272,7 @@ def main():
         extra_pypi_override=args.extra_pypi,
         include_tests_override=args.include_tests,
     )
-    build_args["FLAGGEMS_VERSION"] = flaggems_version
+    build_args["FLAGGEMS_VERSION"] = args.flaggems or configs.get("flaggems", "")
 
     image_name = f"flagos-runtime-{vendor}-{backend}"
 

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -12,40 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Base image version computation.
+"""Per-backend image version from configs.yaml + git.
 
-Each base/<vendor>-<backend> Containerfile declares a base repo version label::
+configs.yaml declares the stack version::
 
-    LABEL org.opencontainers.image.version="2.1.1"
+    version: "2.1.1"
 
-image_version() reads that label and counts git commits to the Containerfile
-since the corresponding tag (v2.1.1), producing::
+image_version() counts git commits to ``base/<name>`` since tag
+``v2.1.1``, producing::
 
     2.1.1        (n=0, no changes since the tag)
     2.1.1-3      (3 commits to this Containerfile since v2.1.1)
 """
 
-import re
 import subprocess
 from pathlib import Path
 
 
-_VERSION_LABEL_RE = re.compile(
-    r'LABEL\s+org\.opencontainers\.image\.version\s*=\s*"([^"]+)"'
-)
+def _load_version(repo_root: Path) -> str | None:
+    """Read ``version:`` from configs.yaml."""
+    import yaml
 
-
-def read_version_label(repo_root: Path, name: str) -> str | None:
-    """Read the base version label from ``base/<name>`` Containerfile.
-
-    Returns the version string (e.g. ``"2.1.1"``) or None when the
-    file is missing or has no version label.
-    """
-    cf = repo_root / "base" / name
-    if not cf.is_file():
+    cfg = repo_root / "configs.yaml"
+    if not cfg.is_file():
         return None
-    m = _VERSION_LABEL_RE.search(cf.read_text())
-    return m.group(1) if m else None
+    with open(cfg) as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("version") or None
 
 
 def image_version(repo_root: Path, name: str) -> str | None:
@@ -55,10 +48,9 @@ def image_version(repo_root: Path, name: str) -> str | None:
 
     Returns ``"X.Y.Z-n"`` when there are *n* commits to ``base/<name>``
     since tag ``vX.Y.Z``, or just ``"X.Y.Z"`` when n=0.  Returns None
-    when the Containerfile has no version label — callers should fall
-    back to the old ``git describe`` scheme.
+    when configs.yaml has no version field.
     """
-    label_ver = read_version_label(repo_root, name)
+    label_ver = _load_version(repo_root)
     if not label_ver:
         return None
 
@@ -73,9 +65,6 @@ def image_version(repo_root: Path, name: str) -> str | None:
     except FileNotFoundError:
         return label_ver
 
-    # Tag not reachable (e.g. it still points to an old commit, or doesn't
-    # exist yet) — treat as n=0, which is the right answer once the tag is
-    # moved to HEAD.
     if r.returncode != 0:
         return label_ver
 


### PR DESCRIPTION
## Summary

Moves both the release version and FlagGems wheel version into `configs.yaml` — the single source of truth — so the release procedure is a two-line edit instead of plumbing 14 Containerfiles and passing external CLI args.

Builds on #147.

## Changes

**configs.yaml** — two new top-level fields:
```yaml
version: "2.1.1"
flaggems: ""
```

**scripts/version.py** — reads `version:` from `configs.yaml` instead of parsing `LABEL org.opencontainers.image.version` from each Containerfile.

**All 14 base Containerfiles** — version LABEL removed. The version is now stamped at build time from `configs.yaml`.

**scripts/build_runtime.py** — `--flaggems` is now optional; defaults to `configs.yaml` `flaggems:` value. `get_flaggems_version()` removed.

**runtime.yml** — FlagGems source checkout step removed; `flaggems_ref` input replaced with `flaggems` (string).

## Release procedure

```
# 1. Edit configs.yaml:
version: "2.2.0"
flaggems: "5.4.0.dev601+g03122362d"

# 2. Tag:
git tag -f v2.2.0 HEAD && git push -f origin v2.2.0
```

That is it. No `sed`, no manual LABEL bumps.

This PR was written in part with the assistance of generative AI.