### PR TITLE
fix(ci): clean stale TSVs from accumulate step before counting

### DIFF
--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -175,6 +175,8 @@ jobs:
           retry="${RETRY_COUNT:-0}"
           done="false"
 
+          # self-hosted runners have persistent workdirs — need a clean start.
+          rm -rf versions
           mkdir -p versions
           set +e   # GHA injects -e; undo it so we always reach the output lines
 


### PR DESCRIPTION
H20's runner workdir persists across runs. Stale TSVs from a previous accumulate left versions/ with 14 files, causing the collect step to report 'was 14' before any new artifacts arrived. This short-circuits the retry loop — the workflow thinks 14/14 backends are complete when in reality 3 extractors failed.

Fix: rm -rf versions before mkdir -p on each fresh run (retry=0). Only actual state branch restores (retry>=1) repopulate the directory.

This PR was written in part with the assistance of generative AI.