### PR TITLE
fix(ci): add workflow_dispatch to base-descriptions-publish

### DIFF
--- a/.github/workflows/base-descriptions-publish.yml
+++ b/.github/workflows/base-descriptions-publish.yml
@@ -14,17 +14,22 @@
 
 name: Publish base descriptions to Harbor
 
-# Publication is gated on review+merge (Option B): when reviewed per-image
-# descriptions land on main (a base-descriptions PR merged), push them to the
-# Harbor repository descriptions. Nothing goes live until the version diff — the
-# checkpoint for catching a disruptive change (e.g. a toolchain gcc bump) — has
-# been reviewed and merged.
+# Publication is gated on review+merge: when reviewed per-image descriptions
+# land on main (a base-descriptions PR merged), push them to the Harbor repository.
+# Nothing goes live until the version diff — the checkpoint for catching
+# a disruptive change (e.g. a toolchain gcc bump) — has been reviewed and merged.
 
 on:
+  # This whenever the base image description is changed (usually a followup
+  # to the base image rebuild), the image repository description is supposed
+  # to be automatically updated.
   push:
     branches: [main]
     paths:
       - 'base/*.md'
+
+  # This is for the occasional github failure when the changes on 'base/*.md'
+  # files fail to trigger this workflow.
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/base-descriptions-publish.yml
+++ b/.github/workflows/base-descriptions-publish.yml
@@ -25,6 +25,7 @@ on:
     branches: [main]
     paths:
       - 'base/*.md'
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
GitHub webhook occasionally misses push events — when PR #155 landed both hugo-site and base-descriptions-publish were supposed to fire on the base/*.md diff, but neither triggered. Manual dispatch is the escape hatch.

This PR was written in part with the assistance of generative AI.