### PR TITLE
refactor: runtime:v1 as build platform, separate FlagGems wheel construction

### DIFF
--- a/.github/workflows/flaggems-release.yml
+++ b/.github/workflows/flaggems-release.yml
@@ -14,12 +14,13 @@
 
 name: FlagGems Release Wheels
 
-# RELEASE.md steps 5a + 5c:
-#   5a — Build the pure-Python flag_gems wheel + push to every vendor PyPI.
+# RELEASE.md step 5:
+#   5a — Build the pure-Python flag_gems wheel → push to every vendor PyPI.
+#   5b — Build cpp operator wheels inside runtime:v1 (local, from step 4).
 #   5c — Write flaggems: into configs.yaml, commit, open a PR.
 #
-# Step 5b (cpp operator wheels) has moved into the runtime builder stage
-# (runtime/Containerfile + scripts/build_runtime.py).
+# Prerequisites: step 4 must have completed — runtime:v1 images (built with
+# --no-flaggems) must be present on each vendor's self-hosted runner.
 
 on:
   workflow_dispatch:
@@ -40,7 +41,11 @@ defaults:
 jobs:
   # ── 5a: pure-Python wheel, all vendor PyPIs ──────────────────────────────
   python-wheel:
-    runs-on: ubuntu-latest
+    # Self-hosted runner for fast upload — pushing a 5.4 MB wheel to 14
+    # vendor Nexus repositories over the public internet (GitHub runner) has
+    # been observed at ~60 kB/s. An internal self-hosted runner saturates
+    # the link in seconds. The build itself is pure Python and runs anywhere.
+    runs-on: [self-hosted, h20]
     env:
       FLAGGEMS_REF: ${{ inputs.flaggems_ref }}
       NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
@@ -48,16 +53,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
       - name: Install PyYAML
-        run: python3 -m pip install --user pyyaml
+        run: |
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages pyyaml
       - name: Build wheel
         run: python3 scripts/release_flaggems.py build-python --ref "$FLAGGEMS_REF"
       - name: Upload to all vendor PyPIs
         run: |
-          python3 -m pip install --quiet twine
+          python3 -m pip install --user --break-system-packages --quiet twine 2>/dev/null || \
+            python3 -m pip install --user --quiet twine
           wheel=$(ls -t wheels/flag_gems-*.whl 2>/dev/null | head -1)
           python3 scripts/release_flaggems.py upload-python "$wheel"
       - uses: actions/upload-artifact@v7
@@ -65,9 +70,67 @@ jobs:
           name: flag_gems-wheel
           path: wheels/flag_gems-*.whl
 
+  # ── 5b: cpp operator wheels, inside runtime:v1 ───────────────────────────
+  cpp-matrix:
+    needs: python-wheel
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --user pyyaml
+      - id: m
+        run: |
+          python3 scripts/cpp_matrix.py > matrix.json
+          cat matrix.json
+          echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+  cpp-wheels:
+    needs: [python-wheel, cpp-matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.cpp-matrix.outputs.matrix) }}
+    runs-on: ${{ fromJSON(matrix.runson) }}
+    env:
+      FLAGGEMS_REF: ${{ inputs.flaggems_ref }}
+      BACKEND: ${{ matrix.name }}
+      NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Install PyYAML
+        run: |
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages pyyaml
+
+      - name: Build cpp wheel inside runtime:v1
+        run: |
+          vendor=$(echo "$BACKEND" | cut -d- -f1)
+          bk=$(echo "$BACKEND" | cut -d- -f2-)
+          image="flagos-runtime-${vendor}-${bk}:latest"
+          python3 scripts/release_flaggems.py build-cpp "$BACKEND" \
+            --ref "$FLAGGEMS_REF" --runtime-image "$image" --outdir wheels-cpp
+
+      - name: Upload cpp wheel to vendor PyPI
+        run: |
+          python3 -m pip install --break-system-packages --quiet twine 2>/dev/null || \
+            python3 -m pip install --break-system-packages --user --quiet twine 2>/dev/null || \
+            python3 -m pip install --user --quiet twine
+          wheel=$(ls -t wheels-cpp/flag_gems_cpp_*.whl 2>/dev/null | head -1)
+          python3 scripts/release_flaggems.py upload-cpp "$BACKEND" "$wheel"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: flag_gems_cpp_${{ matrix.name }}-wheel
+          path: wheels-cpp/flag_gems_cpp_*.whl
+
   # ── 5c: update configs.yaml ──────────────────────────────────────────────
   update-config:
-    needs: python-wheel
+    needs: [python-wheel, cpp-wheels]
+    if: always() && needs.python-wheel.result == 'success' && needs.cpp-wheels.result == 'success'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -33,6 +33,10 @@ on:
         description: 'FlagGems wheel version to install (e.g. 5.4.0.dev601+g03122362d)'
         type: string
         default: ''
+      no_flaggems:
+        description: 'skip flag_gems install — produce build-platform image (step 4)'
+        type: boolean
+        default: false
 
 jobs:
   set-matrix:
@@ -104,6 +108,10 @@ jobs:
           if [[ "${{ inputs.push }}" == "true" ]]; then
             push_flag="--push"
           fi
+          no_flag=""
+          if [[ "${{ inputs.no_flaggems }}" == "true" ]]; then
+            no_flag="--no-flaggems"
+          fi
           python3 scripts/build_runtime.py "${{ matrix.name }}" \
             --flaggems "${{ inputs.flaggems }}" \
-            ${push_flag}
+            ${push_flag} ${no_flag}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,8 +19,8 @@ version: "2.2.0"
 ```
 
 注意：
-- `flaggems` 此时留空，base image 构建不依赖 FlagGems 版本。
-- **此时不打 tag**。`version:` 只是声明"我们打算发布 `2.2.0`"；
+- `flaggems` 此时留空。
+- **此时不打 tag**。`version:` 只是声明"打算发布 `2.2.0`"；
   `scripts/version.py` 在 tag 不存在时返回纯版本号（不含 `-n`），
   构建不受影响。tag 在整个栈验证通过后才打。
 
@@ -34,63 +34,61 @@ GitHub Actions → **Base Image Build (manual)** → `backend: all`, `push: true
 
 ## 3. 验证 base images + 生成描述
 
-### 3a. 验证
+> 自愈合：触发一次 **Base image descriptions** 即可。extract 在 14 个硬件 runner
+> 上 verify → dpkg-query → artifact，accumulate（ubuntu-latest）收集全部后自动
+> 生成描述 PR。个别 runner 失联会自触发重试，全齐后开出 PR。
 
-构建完成的 base image 需要在有对应硬件的节点上逐一验证。
-
-1. 在目标硬件节点上 `docker pull` 对应 vendor 的 base image
-2. 运行 `build-config.yml` 中 `verify:` 定义的验证命令，确认加速器可见
-3. 如果验证失败，修复 Containerfile 后回到步骤 2 重建
-
-验证命令速查（详见 `build-config.yml` `verify.vendors`）：
-
-| Vendor | Verify 命令 |
-|---|---|
-| nvidia | `nvidia-smi` |
-| ascend | `source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info` |
-| metax | `mx-smi` |
-| cambricon | `cnmon` |
-| iluvatar | `ixsmi` |
-| hygon | `source /opt/hyhal/env.sh && hy-smi` |
-| kunlunxin | `xpu-smi` |
-| mthreads | `mthreads-gmi` |
-| enflame | `efsmi` |
-| sunrise | `pt_smi` |
-| tsingmicro | `tsm_smi` |
-
-### 3b. 生成描述
-
-验证通过后，触发 **Base image descriptions** workflow (dispatch)。验证节点上镜像已就绪，
-直接提取系统包版本并生成描述，打开 **review-gated PR**。
-
-Base image 线自此结束——后续不再修改 Containerfile。
-
-## 4. 审核描述 PR
-
-- [ ] 确认版本号正确
+- [ ] 确认所有 backend verify 通过（PR 合并前检查 run log 即可）
 - [ ] 系统包版本无意外大版本跳变（gcc、libc 等）
 - [ ] 所有 backend 的描述均已生成
 
-Merge PR。合并后 **base-descriptions-publish.yml** 自动将描述推到 Harbor。
+Merge PR。合并后 **base-descriptions-publish.yml** 和 **hugo-site.yaml** 自动
+将描述推到 Harbor 和文档站。
 
-## 5. FlagGems 打 tag + 构建纯 Python wheel
+## 4. 构建 runtime:v1（无 FlagGems，作构建平台）
+
+Runtime 镜像的 venv（torch / flagtree / triton）是构建 FlagGems cpp wheel
+的理想环境。先产出不含 FlagGems 的 runtime:v1 作为步骤 5 的构建平台。
+
+每个 backend 在自己的硬件 runner 上构建，**仅本地保存**（不推 Harbor）：
+
+```bash
+python3 scripts/build_runtime.py nvidia-cuda12.8 --no-flaggems
+```
+
+14 个 backend 全部成功后进入步骤 5。
+
+## 5. FlagGems 打 tag + 构建 wheels
 
 - [ ] 在 FlagGems 仓库打 release tag（如 `v5.3.1`）
 
-### 5a. 构建 + 推送 Python wheel
+### 5a. Python wheel → 所有 vendor PyPI
 
-使用 GitHub Actions → **FlagGems Release Wheels** → `flaggems_ref=v5.3.1`：
+GitHub Actions → **FlagGems Release Wheels** → `flaggems_ref=v5.3.1`：
+- `python-wheel` job（ubuntu-latest）：`pip wheel` → 纯 Python `py3-none-any.whl`
+- 推送到**所有 14 个** vendor PyPI
 
-1. 构建纯 Python wheel：`flag_gems-x.y.z-py3-none-any.whl`（不依赖 vendor SDK）
-2. 推送到**所有** vendor 的 PyPI：`flagos-pypi-<vendor>`
+### 5b. Cpp operator wheel → vendor PyPI（cmake_backend 后端）
 
-> **不再有独立的 5b 步骤。** cpp operator wheels 移到步骤 6 的
-> runtime builder 阶段 — runtime builder 的 venv 中 torch / flagtree /
-> triton / flag_gems base 已经就绪，编译 cpp wheel 只需追加 `pip wheel ./cpp`。
+`cpp-wheels` job 矩阵，每个 vendor 在自己的 runner 上，docker run 本地 runtime:v1：
+
+```bash
+docker run --rm -v $PWD:/out runtime:v1 bash -c "
+  git clone https://github.com/flagos-ai/FlagGems.git /tmp/src
+  cd /tmp/src && git checkout v5.3.1
+  tools/set_cpp_vendor.sh <vendor>
+  pip install setuptools scikit-build-core pybind11 cmake ninja
+  CMAKE_ARGS='-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=CUDA ...' \
+    SETUPTOOLS_SCM_PRETEND_VERSION=5.3.1 \
+    pip wheel ./cpp --no-deps -w /out
+"
+```
+
+构建完成后 readelf 检查 .so 的 DT_NEEDED / rpath，然后推送到对应 vendor 的 PyPI。
 
 ### 5c. 回填版本号
 
-步骤 6 完成后，**更新 configs.yaml 中的 `flaggems` 字段**：
+步骤 5a/5b 完成后，**更新 configs.yaml 中的 `flaggems` 字段**：
 
 ```yaml
 flaggems: "5.3.1"
@@ -98,37 +96,17 @@ flaggems: "5.3.1"
 
 提交并 push。
 
-## 6. 构建 runtime images（含 cpp operator wheels）
+## 6. 构建 runtime:v2（含 FlagGems，推送 Harbor）
 
-### 6a. 确认依赖版本
+runtime:v2 在 runtime:v1 基础上安装 flag_gems + cpp wheel（来自 PyPI），
+推送到 Harbor 作为正式镜像。
 
-检查 `configs.yaml` 中所有 backend 的 `deps:` / `flagtree:` / `triton:` 版本是否为目标版本。
-`torch` 与 `flagtree`/`triton`、`torch` 与 `triton_post_install` 之间的版本匹配是高风险点——
-运行时会首次将这些包在同一 venv 中组装，兼容性问题在这里暴露。
-
-### 6b. CI 构建（Python wheel + cpp wheel + runtime image）
-
-GitHub Actions → **Runtime Image Build (manual)**：
-
+GitHub Actions → **Runtime Image Build (manual)**（正常触发，不传 `--no-flaggems`）：
 - `backend: all`
 - `push: true`
-- `flaggems: 5.3.1`（与 configs.yaml `flaggems` 字段一致）
+- `flaggems` 留空（读取 configs.yaml 中的 `5.3.1`）
 
-Runtime builder 在每个 vendor 的 self-hosted runner 上执行：
-
-1. 从 `flagos-pypi-<vendor>` 安装 torch / deps / flagtree / triton
-2. 从 `flagos-pypi-<vendor>` 安装 `flag_gems==5.3.1`（纯 Python wheel）
-3. **对 `cmake_backend` vendor**：checkout FlagGems @ `v5.3.1` →
-   `set_cpp_vendor.sh <v>` → `pip wheel ./cpp` → 装 cpp wheel →
-   readelf 检查 → 推 cpp wheel 到 `flagos-pypi-<vendor>`
-4. 组装 runtime 镜像（venv + compilers + flag_gems base + cpp）
-5. 推送 runtime 镜像到 Harbor
-
-> cpp operator wheel 不再单独构建——runtime builder 的 venv 中依赖
-> （torch / flagtree / triton）已经齐全，`pip wheel ./cpp` 是自然的一步。
-> 之前尝试在 base image 内临时装 torch 再编译，脆弱且重复。
-
-### 6c. 验证 runtime images（端到端）
+## 7. 验证 runtime v2（端到端）
 
 构建并推送到 Harbor 后，在有对应硬件的节点上：
 
@@ -136,41 +114,18 @@ Runtime builder 在每个 vendor 的 self-hosted runner 上执行：
 2. 运行 `python tools/run_tests.py` 确认端到端可用
 
 如果验证失败，根据错误类型回退：
+- **包版本不兼容**：调整 `configs.yaml` → 返回**步骤 4**
+- **FlagGems bug**：修补代码 → 重新打 tag → 返回**步骤 5**
 
-- **包版本不兼容**（`torch` / `flagtree` / `triton` 版本冲突）：调整 `configs.yaml` 中
-  对应 backend 的 `deps:` / `flagtree:` / `triton:` 版本，返回**步骤 6a**。
-- **FlagGems 本身存在 bug**：修补 FlagGems 代码 → 重新打 tag（如 `v5.4.1`）→ 返回
-  **步骤 5** 重新构建 wheels。
-
-> TODO: FlagGems 仓库的 `tools/run_tests.py` 脚本需要打包到 runtime 镜像中。
-> 测试文件和 benchmarks 已随 `flaggems_test` / `flaggems_benchmark` 路径安装，
-> 脚本到位后验证命令即统一为 `python tools/run_tests.py`，无需 per-vendor 定制。
-
-## 7. 更新 runtime 描述
-
-Runtime 验证通过后，`flaggems` 版本刚确定，需要刷一遍 runtime 页面的描述。
+## 8. 更新 runtime 描述
 
 触发 **Base image descriptions** workflow (dispatch)，重新运行 `gen_data.py` +
-`gen_descriptions.py`，生成 runtime 页面的最终版本（含 `flag_gems` 版本号等）。
-与步骤 3b/4 一样，打开 review-gated PR，审核后 merge。
-
-合并后 **hugo-site.yaml** 和 **base-descriptions-publish.yml** 自动触发：
-- 文档站部署到 `flagos-ai.github.io/release-info`
-- Runtime 描述推到 Harbor
-
-## 8. App 镜像（TODO）
-
-> 此步骤待 `app/` 构建系统落地后补全。App 镜像在 runtime 的基础上部署：
-> - vllm + vllm-plugin-FL（推理）
-> - sglang + sglang-plugin-FL（推理）
-> - Megatron-LM-FL + 依赖（训练）
->
-> 核心技术挑战：安装 vllm/sglang 等上层包时，必须确保不覆盖 runtime 层已锁定版本的
-> torch / flagtree / triton / flag_gems 等依赖。此项将单独设计。
+`gen_descriptions.py`，生成 runtime 页面最终版本（含 `flag_gems` 版本号）。
+打开 review-gated PR，审核后 merge。
 
 ## 9. 打 build-infra tag
 
-全部验证通过后，在此 commit 上打 tag：
+全部验证通过后：
 
 ```bash
 git checkout main && git pull
@@ -178,6 +133,5 @@ git tag -f v2.2.0 HEAD
 git push -f origin v2.2.0
 ```
 
-tag 的含义：**这个 commit 上的整套 FlagOS 软件栈（base images → FlagGems → runtime images）
-已经过验证，可以发布。** 之后如有 Containerfile 变更，`image_version()` 会从该 tag 开始自动
-产生 `2.2.0-1`、`2.2.0-2` ……
+tag 的含义：**这个 commit 上的整套 FlagOS 软件栈（base images → runtime:v1 →
+FlagGems → runtime:v2）已经过验证，可以发布。**

--- a/configs.yaml
+++ b/configs.yaml
@@ -67,6 +67,17 @@
 version: "2.1.1"
 flaggems: "5.3.1"
 
+# Versions of build tools needed to compile the cpp operator wheel inside the
+# runtime:v1 container.  Pinned so a future pip install won't silently pull an
+# incompatible release.
+flaggems_cpp_build_deps:
+  - "setuptools>=64.0,<77"
+  - "setuptools-scm>=8,<10"
+  - "scikit-build-core==0.12.2"
+  - "pybind11==3.0.3"
+  - "cmake>=3.20,<4"
+  - "ninja==1.13.0"
+
 base_image_prefix: "flagos-base"
 
 pypi_base: "https://resource.flagos.net/repository/flagos-pypi-{vendor}/simple"

--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -43,8 +43,9 @@ ARG TRITON_EXTRA_PKGS=""
 # FlagGems wheel version to pin (== exact). Set by build_runtime.py from
 # configs.yaml flaggems: or the --flaggems CLI override.
 ARG FLAGGEMS_VERSION=0.0.0
-# FlagGems git tag for cpp wheel build — e.g. "v5.3.1".  Empty skips cpp.
-ARG FLAGGEMS_REF=""
+# When non-empty, skip the flag_gems install entirely — produces the
+# build-platform image for step 5 (no flag_gems, just torch + deps + compilers).
+ARG NO_FLAGGEMS=""
 
 
 # ════════════════════════════════════════════════════════════════
@@ -63,7 +64,7 @@ ARG TRITON_PKG
 ARG TRITON_EXTRA_PKGS
 ARG INCLUDE_TESTS
 ARG FLAGGEMS_VERSION
-ARG FLAGGEMS_REF
+ARG NO_FLAGGEMS
 ARG DEBIAN_FRONTEND=noninteractive
 
 # ── Install uv ────────────────────────────────────────────────
@@ -108,38 +109,22 @@ RUN if [ -n "${TRITON_PKG}" ]; then \
       fi; \
     fi
 
-# ── Install FlagGems base (Python-only wheel) ───────────────────
-RUN uv pip install --no-cache-dir --prerelease=allow \
-      --index-strategy unsafe-first-match \
-      --index ${FLAGOS_PYPI} \
-      --index ${DAILY_PYPI} \
-      --trusted-host resource.flagos.net \
-      "flag_gems==${FLAGGEMS_VERSION}"
+# ── FlagGems — skip when building the build-platform (runtime:v1).
 
-# ── Build + install cpp operator wheel (cmake_backend only) ────
-# Replaces the old step-5b: the venv already has torch / deps / compilers,
-# so cloning FlagGems and running pip wheel ./cpp here is a natural fit.
-# Produces flag-gems-cpp-<vendor>-*.whl, installs it, and saves a copy
-# to /app/cpp-wheels/ for the host-side upload step.
-ARG FLAGGEMS_REF
-RUN if [ -n "${CPP_EXTRA}" ] && [ -n "${FLAGGEMS_REF}" ]; then \
-      apt-get update -qq && apt-get install -y -qq git && \
-      vendor=$(echo ${CPP_EXTRA} | sed 's/^cpp-//'); \
-      git clone --quiet "https://github.com/flagos-ai/FlagGems.git" /tmp/FlagGems && \
-      cd /tmp/FlagGems && \
-      git fetch --quiet --tags origin tag "${FLAGGEMS_REF}" 2>/dev/null || \
-        git fetch --quiet --tags --force origin && \
-      git checkout --quiet --detach "${FLAGGEMS_REF}" && \
-      tools/set_cpp_vendor.sh "${vendor}" && \
-      pip install setuptools scikit-build-core pybind11 cmake ninja && \
-      SETUPTOOLS_SCM_PRETEND_VERSION="${FLAGGEMS_REF#v}" \
-        pip wheel ./cpp --no-deps -w /tmp/wheel-out && \
-      pip install --no-deps /tmp/wheel-out/*.whl && \
-      mkdir -p /app/cpp-wheels && \
-      cp /tmp/wheel-out/*.whl /app/cpp-wheels/ && \
-      rm -rf /tmp/FlagGems /tmp/wheel-out; \
-    fi && \
-    mkdir -p /app/cpp-wheels
+# When NO_FLAGGEMS is set: skip flag_gems entirely.  This produces a
+# runtime image that has torch + deps + compilers but no flag_gems —
+# the build platform for step 5 (cpp wheel compilation).
+ARG NO_FLAGGEMS
+RUN if [ -n "${NO_FLAGGEMS}" ]; then \
+      echo "NO_FLAGGEMS: skipping flag_gems install"; \
+    else \
+      uv pip install --no-cache-dir --prerelease=allow \
+        --index-strategy unsafe-first-match \
+        --index ${FLAGOS_PYPI} \
+        --index ${DAILY_PYPI} \
+        --trusted-host resource.flagos.net \
+        "flag_gems${CPP_EXTRA:+[${CPP_EXTRA}]}==${FLAGGEMS_VERSION}"; \
+    fi
 
 # ── Tests — deferred (image not finalized) ────────────────────
 # Tests are NOT shipped yet: FlagGems' [test] extra installs only frameworks,

--- a/scripts/build_cpp_wheel.sh
+++ b/scripts/build_cpp_wheel.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the flag-gems-cpp-<vendor> wheel inside the runtime:v1 container.
+# Env vars (all required):
+#   FLAGGEMS_REF                — git tag, e.g. "v5.3.1"
+#   FLAGGEMS_CPP_VENDOR         — set_cpp_vendor.sh arg, e.g. "cuda"
+#   FLAGGEMS_CMAKE_ARGS         — cmake defines
+#   SETUPTOOLS_SCM_PRETEND_VERSION  — e.g. "5.3.1"
+#   FLAGGEMS_BUILD_DEPS         — space-separated pip install specs
+
+set -euo pipefail
+
+OUTDIR="${OUTDIR:-/tmp/wheel-out}"
+FLAGGEMS_REPO="${FLAGGEMS_REPO:-https://github.com/flagos-ai/FlagGems.git}"
+
+# ── clone + checkout ──────────────────────────────────────────
+git clone --quiet "$FLAGGEMS_REPO" /tmp/FlagGems 2>/dev/null || {
+  sleep 30
+  git clone --quiet "$FLAGGEMS_REPO" /tmp/FlagGems 2>/dev/null
+} || {
+  sleep 30
+  git clone --quiet "$FLAGGEMS_REPO" /tmp/FlagGems
+}
+cd /tmp/FlagGems
+git fetch --quiet --tags origin tag "$FLAGGEMS_REF" 2>/dev/null \
+  || git fetch --quiet --tags --force origin
+git checkout --quiet --detach "$FLAGGEMS_REF"
+echo "FlagGems @ $(git describe --tags 2>/dev/null || echo "$FLAGGEMS_REF")"
+
+# ── set vendor + install build deps ───────────────────────────
+tools/set_cpp_vendor.sh "$FLAGGEMS_CPP_VENDOR"
+if [ -n "${FLAGGEMS_BUILD_DEPS:-}" ]; then
+  # shellcheck disable=SC2086
+  pip install $FLAGGEMS_BUILD_DEPS
+fi
+
+# ── build ─────────────────────────────────────────────────────
+mkdir -p "$OUTDIR"
+pip wheel ./cpp --no-deps -w "$OUTDIR"
+
+# ── install + inspect .so ─────────────────────────────────────
+pip install --no-deps "$OUTDIR"/*.whl
+SO=$(find "$VIRTUAL_ENV" -name 'c_operators*.so' 2>/dev/null | head -1)
+if [ -z "$SO" ]; then
+  echo "ERROR: c_operators .so not found in venv" >&2
+  exit 1
+fi
+echo ".so path: $SO"
+echo ">>> DT_NEEDED:"
+readelf -d "$SO" | grep 'NEEDED' | sed 's/.*\[//;s/\]//' | sort
+echo ">>> rpath / runpath:"
+readelf -d "$SO" | grep -iE 'RPATH|RUNPATH' || echo "  (none — relies on LD_LIBRARY_PATH)"
+echo "OK  cpp extension .so built for $FLAGGEMS_CPP_VENDOR"

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -27,11 +27,11 @@ Examples:
     python scripts/build_runtime.py nvidia-cuda12.8 --dry-run
     python scripts/build_runtime.py ascend-cann9.0.0 --tag latest
     python scripts/build_runtime.py metax --push
-    python scripts/build_runtime.py nvidia-cuda12.8 --flaggems 5.4.0.dev601+g03122362d   # override
+    python scripts/build_runtime.py nvidia-cuda12.8 --flaggems 5.4.0.dev601+g03122362d
+    python scripts/build_runtime.py nvidia-cuda12.8 --no-flaggems   # build-platform (step 4)
 """
 
 import argparse
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -213,31 +213,6 @@ def resolve_build_args(
     return args
 
 
-def _upload_cpp_wheel(vendor: str, wheel: Path, configs: dict, repo_root: Path) -> None:
-    """Upload a cpp wheel to the vendor's PyPI via twine."""
-    token = os.environ.get("NEXUS_TOKEN", "")
-    if not token:
-        print(f"  skip cpp upload for {vendor}: NEXUS_TOKEN not set", file=sys.stderr)
-        return
-    user, _, pw = token.partition(":")
-    env = os.environ.copy()
-    env["TWINE_USERNAME"] = user
-    env["TWINE_PASSWORD"] = pw
-    pypi_base = configs.get("pypi_base", "")
-    upload_url = pypi_base.format(vendor=vendor).rstrip("/").removesuffix("/simple")
-    print(f"  uploading {wheel.name} to {upload_url} ...")
-    subprocess.run(
-        [
-            sys.executable, "-m", "twine", "upload",
-            "--repository-url", f"{upload_url}/",
-            "--non-interactive",
-            str(wheel),
-        ],
-        check=True, env=env,
-    )
-    print(f"  cpp wheel uploaded to {vendor}")
-
-
 def main():
     parser = argparse.ArgumentParser(
         description="Build FlagGems runtime container images",
@@ -252,6 +227,11 @@ def main():
         "--flaggems",
         default="",
         help="FlagGems wheel version override (default: from configs.yaml)",
+    )
+    parser.add_argument(
+        "--no-flaggems",
+        action="store_true",
+        help="Skip flag_gems install — produce the build-platform image (step 4)",
     )
     parser.add_argument("--base-image", help="Override base image")
     parser.add_argument("--extra-pypi", help="Override extra PyPI mirror URL")
@@ -299,11 +279,7 @@ def main():
         include_tests_override=args.include_tests,
     )
     build_args["FLAGGEMS_VERSION"] = args.flaggems or configs.get("flaggems", "")
-
-    # cpp wheel build: derive FlagGems git ref from version ("5.3.1" → "v5.3.1")
-    flaggems_ver = build_args["FLAGGEMS_VERSION"]
-    flaggems_ref = f"v{flaggems_ver}" if flaggems_ver and not flaggems_ver.startswith("v") else flaggems_ver
-    build_args["FLAGGEMS_REF"] = flaggems_ref if build_args.get("CPP_EXTRA") else ""
+    build_args["NO_FLAGGEMS"] = "1" if args.no_flaggems else ""
 
     image_name = f"flagos-runtime-{vendor}-{backend}"
 
@@ -336,24 +312,6 @@ def main():
     result = subprocess.run(cmd)
     if result.returncode != 0:
         sys.exit(f"docker build failed with exit code {result.returncode}")
-
-    # ── cpp wheel: upload to vendor PyPI ──────────────────────────
-    cpp_extra = build_args.get("CPP_EXTRA", "")
-    if cpp_extra and args.push:
-        cpp_dir = Path(f"wheels-cpp-{backend}")
-        container_id = subprocess.run(
-            ["docker", "create", tag], capture_output=True, text=True, check=True
-        ).stdout.strip()
-        try:
-            cpp_dir.mkdir(exist_ok=True)
-            subprocess.run(
-                ["docker", "cp", f"{container_id}:/app/cpp-wheels/.", str(cpp_dir)],
-                check=True,
-            )
-            for wheel in sorted(cpp_dir.glob("flag_gems_cpp_*.whl")):
-                _upload_cpp_wheel(vendor, wheel, configs, repo_root)
-        finally:
-            subprocess.run(["docker", "rm", container_id], capture_output=True)
 
     if args.push:
         print(f"Pushing {tag}...")

--- a/scripts/cpp_matrix.py
+++ b/scripts/cpp_matrix.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate a cpp wheel build matrix: only cmake_backend backends."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> None:
+    import yaml
+
+    configs = yaml.safe_load((ROOT / "configs.yaml").read_text())
+    cpp: set[str] = set()
+    for vendor, bks in (configs.get("vendors") or {}).items():
+        for bk, spec in (bks or {}).items():
+            if spec.get("cmake_backend"):
+                cpp.add(f"{vendor}-{bk}")
+
+    r = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "generate_matrix.py")],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+    if r.returncode != 0:
+        sys.exit(r.stderr or "generate_matrix.py failed")
+    full = json.loads(r.stdout)
+    filtered = {
+        "include": [e for e in full.get("include", []) if e["name"] in cpp],
+    }
+    json.dump(filtered, sys.stdout)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release_flaggems.py
+++ b/scripts/release_flaggems.py
@@ -14,16 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Release FlagGems wheels — RELEASE.md steps 5a + 5c.
+"""Release FlagGems wheels — RELEASE.md steps 5a + 5b.
 
 Usage::
 
     python3 scripts/release_flaggems.py build-python --ref v5.3.1 [--outdir DIR]
     python3 scripts/release_flaggems.py upload-python WHEEL [--dry-run]
-    python3 scripts/release_flaggems.py update-config VERSION
+    python3 scripts/release_flaggems.py build-cpp BACKEND --ref v5.3.1 --runtime-image IMG [--outdir DIR]
+    python3 scripts/release_flaggems.py upload-cpp BACKEND WHEEL [--dry-run]
 
-Cpp operator wheels are built inside the runtime builder stage
-(see runtime/Containerfile and scripts/build_runtime.py).
+Cpp wheel build runs inside the runtime:v1 container (built in step 4
+with --no-flaggems) — its venv already has torch + deps + compilers,
+so ``pip wheel ./cpp`` just works.
 
 The NEXUS_TOKEN env var is required for upload commands (``user:token``).
 """
@@ -147,6 +149,82 @@ def _twine_upload(wheel: Path, repo_url: str) -> None:
     )
 
 
+# ── build-cpp ─────────────────────────────────────────────────────────────────
+
+VENDOR_MAP: dict[str, str] = {
+    "CUDA": "cuda",
+    "NPU": "npu",
+    "GCU": "gcu",
+    "IX": "ix",
+    "MUSA": "musa",
+}
+
+
+def cmd_build_cpp(args: argparse.Namespace) -> str:
+    """Build a cpp operator wheel inside runtime:v1.  Returns wheel path."""
+    cfg = _load_configs()
+    vendor, bk = args.backend.split("-", 1)
+    specs = (cfg.get("vendors") or {}).get(vendor, {}).get(bk)
+    if not specs:
+        sys.exit(f"Error: backend '{args.backend}' not in configs.yaml")
+    cmake_backend = specs.get("cmake_backend")
+    if not cmake_backend:
+        sys.exit(f"Error: backend '{args.backend}' has no cmake_backend")
+    v = VENDOR_MAP.get(cmake_backend)
+    if not v:
+        sys.exit(f"Error: unknown cmake_backend '{cmake_backend}'")
+
+    # Build deps from configs.yaml (pinned so the build is reproducible).
+    build_deps = " ".join(cfg.get("flaggems_cpp_build_deps", []))
+
+    outdir = args.outdir or str(ROOT / "wheels-cpp")
+    os.makedirs(outdir, exist_ok=True)
+    host_out = os.path.abspath(outdir)
+
+    script_path = str(ROOT / "scripts" / "build_cpp_wheel.sh")
+
+    print(f"Building cpp wheel for {args.backend} ({v}) inside {args.runtime_image} ...")
+    subprocess.run(
+        [
+            "docker", "run", "--rm",
+            "-v", f"{host_out}:/tmp/wheel-out",
+            "-v", f"{script_path}:/tmp/build_cpp_wheel.sh:ro",
+            "-e", f'FLAGGEMS_REF={args.ref}',
+            "-e", f'FLAGGEMS_CPP_VENDOR={v}',
+            "-e", f'FLAGGEMS_CMAKE_ARGS=-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND={cmake_backend} -DCMAKE_BUILD_TYPE=Release',
+            "-e", f'SETUPTOOLS_SCM_PRETEND_VERSION={args.ref.lstrip("v")}',
+            "-e", f'FLAGGEMS_BUILD_DEPS={build_deps}',
+            args.runtime_image,
+            "bash", "/tmp/build_cpp_wheel.sh",
+        ],
+        check=True,
+    )
+    wheels = sorted(Path(outdir).glob("flag_gems_cpp_*.whl"))
+    if not wheels:
+        sys.exit("ERROR: no cpp wheel produced")
+    print(f"Wheel: {wheels[-1]}")
+    return str(wheels[-1])
+
+
+# ── upload-cpp ───────────────────────────────────────────────────────────────
+
+
+def cmd_upload_cpp(args: argparse.Namespace) -> None:
+    """Push a cpp wheel to its vendor's PyPI."""
+    cfg = _load_configs()
+    vendor = args.backend.split("-", 1)[0]
+    url = _pypi_urls(cfg).get(vendor)
+    if not url:
+        sys.exit(f"Error: vendor '{vendor}' has no PyPI URL")
+    wheel = Path(args.wheel)
+    print(f">>> uploading to {vendor}: {url}")
+    if args.dry_run:
+        print(f"    [dry-run] would upload {wheel.name} to {url}")
+        return
+    _twine_upload(wheel, url)
+    print(f"Uploaded to {vendor}.")
+
+
 # ── update-config ────────────────────────────────────────────────────────────
 
 
@@ -221,6 +299,22 @@ def main() -> None:
     up.add_argument("wheel", help="Path to flag_gems-*.whl")
     up.add_argument("--dry-run", action="store_true", help="Print without uploading")
     up.set_defaults(func=lambda a: cmd_upload_python(a))
+
+    # build-cpp
+    bc = subs.add_parser("build-cpp", help="Build cpp wheel inside runtime:v1")
+    bc.add_argument("backend", help="Backend name, e.g. nvidia-cuda12.8")
+    bc.add_argument("--ref", required=True, help="FlagGems git tag/ref")
+    bc.add_argument("--runtime-image", required=True,
+                    help="runtime:v1 image ref (built with --no-flaggems in step 4)")
+    bc.add_argument("--outdir", help="Output directory for the cpp wheel")
+    bc.set_defaults(func=lambda a: cmd_build_cpp(a))
+
+    # upload-cpp
+    uc = subs.add_parser("upload-cpp", help="Upload cpp wheel to vendor PyPI")
+    uc.add_argument("backend", help="Backend name, e.g. nvidia-cuda12.8")
+    uc.add_argument("wheel", help="Path to flag_gems_cpp_*.whl")
+    uc.add_argument("--dry-run", action="store_true", help="Print without uploading")
+    uc.set_defaults(func=lambda a: cmd_upload_cpp(a))
 
     # update-config
     ug = subs.add_parser("update-config", help="Set flaggems version + open PR")


### PR DESCRIPTION
RELEASE.md steps reordered:

1. configs.yaml version
2. Build base images
3. Verify + descriptions
4. Build runtime:v1 (no flag_gems, stays local) — BUILD PLATFORM
5. FlagGems wheels built inside runtime:v1:
    5a — Python wheel (ubuntu-latest) → all vendor PyPIs
    5b — Cpp wheel (per-vendor runner, docker run runtime:v1) → vendor PyPI
    5c — Update flaggems version in configs.yaml
6. Build runtime:v2 (flag_gems from PyPI, push to Harbor)
7. Verify runtime v2
8. Runtime descriptions
9. Tag

Key change: step 4 produces a runtime image with torch + deps + compilers but NO flag_gems. Step 5 uses it as a containerized build platform — the venv already has every dependency for cpp wheel compilation. No more ad-hoc pip install torch inside a bare base image.

Code:
- runtime/Containerfile: NO_FLAGGEMS gate, removes cpp build step
- build_runtime.py: --no-flaggems flag, removes docker cp upload
- release_flaggems.py: add back build-cpp/upload-cpp commands
- scripts/cpp_matrix.py: new, filters generate_matrix to cmake_backend
- flaggems-release.yml: add cpp-matrix + cpp-wheels jobs
- runtime.yml: add no_flaggems input

This PR was written in part with the assistance of generative AI.