### PR TITLE
fix(ci): use isolated venv for python on self-hosted runners

### DIFF
--- a/.github/workflows/flaggems-release.yml
+++ b/.github/workflows/flaggems-release.yml
@@ -53,18 +53,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Install PyYAML
+      - name: Setup Python (isolated venv)
         run: |
-          python3 -c "import yaml" 2>/dev/null \
-            || python3 -m pip install --user --break-system-packages pyyaml
+          python3 -m venv /tmp/ci-venv
+          /tmp/ci-venv/bin/pip install --quiet pyyaml twine
       - name: Build wheel
-        run: python3 scripts/release_flaggems.py build-python --ref "$FLAGGEMS_REF"
+        run: /tmp/ci-venv/bin/python scripts/release_flaggems.py build-python --ref "$FLAGGEMS_REF"
       - name: Upload to all vendor PyPIs
         run: |
-          python3 -m pip install --user --break-system-packages --quiet twine 2>/dev/null || \
-            python3 -m pip install --user --quiet twine
           wheel=$(ls -t wheels/flag_gems-*.whl 2>/dev/null | head -1)
-          python3 scripts/release_flaggems.py upload-python "$wheel"
+          /tmp/ci-venv/bin/python scripts/release_flaggems.py upload-python "$wheel"
       - uses: actions/upload-artifact@v7
         with:
           name: flag_gems-wheel
@@ -101,26 +99,23 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Install PyYAML
+      - name: Setup Python (isolated venv)
         run: |
-          python3 -c "import yaml" 2>/dev/null \
-            || python3 -m pip install --user --break-system-packages pyyaml
+          python3 -m venv /tmp/ci-venv
+          /tmp/ci-venv/bin/pip install --quiet pyyaml twine
 
       - name: Build cpp wheel inside runtime:v1
         run: |
           vendor=$(echo "$BACKEND" | cut -d- -f1)
           bk=$(echo "$BACKEND" | cut -d- -f2-)
           image="flagos-runtime-${vendor}-${bk}:latest"
-          python3 scripts/release_flaggems.py build-cpp "$BACKEND" \
+          /tmp/ci-venv/bin/python scripts/release_flaggems.py build-cpp "$BACKEND" \
             --ref "$FLAGGEMS_REF" --runtime-image "$image" --outdir wheels-cpp
 
       - name: Upload cpp wheel to vendor PyPI
         run: |
-          python3 -m pip install --break-system-packages --quiet twine 2>/dev/null || \
-            python3 -m pip install --break-system-packages --user --quiet twine 2>/dev/null || \
-            python3 -m pip install --user --quiet twine
           wheel=$(ls -t wheels-cpp/flag_gems_cpp_*.whl 2>/dev/null | head -1)
-          python3 scripts/release_flaggems.py upload-cpp "$BACKEND" "$wheel"
+          /tmp/ci-venv/bin/python scripts/release_flaggems.py upload-cpp "$BACKEND" "$wheel"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -75,8 +75,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install PyYAML
-        run: python3 -m pip install --user pyyaml
+      - name: Setup Python (isolated venv)
+        run: |
+          python3 -m venv /tmp/ci-venv
+          /tmp/ci-venv/bin/pip install --quiet yaml twine
 
       - name: Harbor login (pull base image + push runtime)
         if: ${{ inputs.push }}
@@ -86,7 +88,7 @@ jobs:
           HTTPS_PROXY: ""
           no_proxy: "harbor.baai.ac.cn,.baai.ac.cn"
         run: |
-          host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
+          host=$(/tmp/ci-venv/bin/python -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
           for i in 1 2 3; do
             if printf '%s' "$HARBOR_PW" | docker login "$host" -u tengqm --password-stdin; then
               exit 0
@@ -101,9 +103,6 @@ jobs:
         env:
           NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
         run: |
-          # twine is needed for cpp wheel upload (cmake_backend backends).
-          python3 -m pip install --user --break-system-packages --quiet twine 2>/dev/null || \
-            python3 -m pip install --user --quiet twine
           push_flag=""
           if [[ "${{ inputs.push }}" == "true" ]]; then
             push_flag="--push"
@@ -112,6 +111,6 @@ jobs:
           if [[ "${{ inputs.no_flaggems }}" == "true" ]]; then
             no_flag="--no-flaggems"
           fi
-          python3 scripts/build_runtime.py "${{ matrix.name }}" \
+          /tmp/ci-venv/bin/python scripts/build_runtime.py "${{ matrix.name }}" \
             --flaggems "${{ inputs.flaggems }}" \
             ${push_flag} ${no_flag}


### PR DESCRIPTION
Self-hosted runners have PEP 668 (externally-managed Python) and no guarantee of pre-installed yaml/twine. Replace all ad-hoc pip install --break-system-packages with a clean /tmp/ci-venv created once per job.

Affected:
- runtime.yml: all 3 steps (Install PyYAML → Harbor login → Build runtime image)
- flaggems-release.yml: python-wheel + cpp-wheels jobs

Each job now creates /tmp/ci-venv once, installs pyyaml + twine, then uses /tmp/ci-venv/bin/python for all script invocations. No host-side pip pollution.

This PR was written in part with the assistance of generative AI.