### PR TITLE
fix(ci): pass raw device flags to docker run in verify step

### DIFF
--- a/scripts/verify_base.py
+++ b/scripts/verify_base.py
@@ -25,6 +25,7 @@ requirement for description extraction.
 Usage: python scripts/verify_base.py <backend-name>
 """
 
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -62,8 +63,13 @@ def main() -> None:
         print(f"::notice::{vendor}: no verify command in build-config.yml → SKIP")
         return
 
-    # docker run <image> verify
-    cmd = ["docker", "run", "--rm", image, "bash", "-c", verify_cmd]
+    # Per-vendor `docker run` flags (raw device-passthrough — no toolkit needed).
+    raw_cfg = ((build_cfg.get("run") or {}).get("vendors") or {}).get(vendor) or {}
+    raw_flags_str = raw_cfg.get("raw", "")
+    raw_flags = shlex.split(raw_flags_str) if raw_flags_str else []
+
+    # docker run <run-flags> --rm <image> verify
+    cmd = ["docker", "run"] + raw_flags + ["--rm", image, "bash", "-c", verify_cmd]
     print(f"::group::{' '.join(cmd)}")
     r = subprocess.run(cmd, capture_output=True, text=True)
     if r.stdout:


### PR DESCRIPTION
verify_base.py ran `docker run --rm <image>` with no hardware exposure, so every SMI command (nvidia-smi, npu-smi, ixsmi, etc.) failed.

Read `run.vendors.<vendor>.raw` from `build-config.yml` — per-vendor device-passthrough flags — and insert them before `--rm`.

`shlex.split` for safe flag parsing.  raw (not toolkit) because it works without a host-side container runtime installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR was written in part with the assistance of generative AI.