### PR TITLE
fix(ci): verify with toolkit flags, reset versions/ on fresh runs

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -108,7 +108,7 @@ run:
     enflame:
       # gotcha: toolkit uses --network host + env var, no --runtime flag.
       toolkit: "--network host -e TENCENT_VISIBLE_DEVICES=all"
-      raw: "--device /dev/gcu"
+      raw: "--privileged -v /dev:/dev"
     sunrise:
       # generic launch only — no device flags / toolkit known.
       raw: ""

--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -190,6 +190,12 @@ jobs:
           retry="${RETRY_COUNT:-0}"
           done="false"
 
+          # Fresh run: wipe versions/ so stale TSV files from a previous cycle
+          # don't mask a missing backend.  Retries restore from the state branch
+          # instead (below).
+          if [ "$retry" = "0" ]; then
+            rm -rf versions/
+          fi
           mkdir -p versions
           set +e   # GHA injects -e; undo it so we always reach the output lines
 

--- a/scripts/verify_base.py
+++ b/scripts/verify_base.py
@@ -63,13 +63,14 @@ def main() -> None:
         print(f"::notice::{vendor}: no verify command in build-config.yml → SKIP")
         return
 
-    # Per-vendor `docker run` flags (raw device-passthrough — no toolkit needed).
-    raw_cfg = ((build_cfg.get("run") or {}).get("vendors") or {}).get(vendor) or {}
-    raw_flags_str = raw_cfg.get("raw", "")
-    raw_flags = shlex.split(raw_flags_str) if raw_flags_str else []
+    # Per-vendor `docker run` flags: toolkit first (container runtime installed
+    # on every self-hosted runner), raw device-passthrough as fallback.
+    run_cfg = ((build_cfg.get("run") or {}).get("vendors") or {}).get(vendor) or {}
+    flags_str = run_cfg.get("toolkit", "") or run_cfg.get("raw", "")
+    flags = shlex.split(flags_str) if flags_str else []
 
     # docker run <run-flags> --rm <image> verify
-    cmd = ["docker", "run"] + raw_flags + ["--rm", image, "bash", "-c", verify_cmd]
+    cmd = ["docker", "run"] + flags + ["--rm", image, "bash", "-c", verify_cmd]
     print(f"::group::{' '.join(cmd)}")
     r = subprocess.run(cmd, capture_output=True, text=True)
     if r.stdout:


### PR DESCRIPTION
verify_base.py: try toolkit flags first (all self-hosted runners have container runtimes), fallback to raw.

build-config.yml: enflame raw `/dev/gcu` → `--privileged -v /dev:/dev`.

base-descriptions.yml: clear `versions/` on retry=0 so stale TSV files don't hide missing backends. Retries still restore from state branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR was written in part with the assistance of generative AI.