### PR TITLE
fix(ci): extract scripts from yaml, replace upload-artifact with git push

### DIFF
--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -21,6 +21,12 @@ name: Base image descriptions
 # Separate from the build (per the design): version extraction needs the built
 # image, and keeping this out of the build workflow keeps both simpler.
 #
+# Transport: extract jobs push TSV files via git to per-backend branches
+# (auto/versions-<label>/<backend>) instead of using upload-artifact, which
+# reliably hangs through HTTP_PROXY on some self-hosted runners.
+# Accumulate fetches all per-backend branches, merges them, and saves the
+# cumulative set to a state branch.
+#
 # Self-healing: self-hosted runner connectivity to GitHub is unreliable across
 # vendors. The accumulate job collects whatever extractors succeed, saves partial
 # results to a state branch, then self-triggers with only the missing backends.
@@ -123,30 +129,8 @@ jobs:
           python3 docs/gen_data.py
           python3 docs/extract_versions.py "${{ matrix.name }}" versions
 
-      - name: Upload version artifact (attempt 1)
-        id: upload1
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: versions-${{ matrix.name }}
-          path: versions/${{ matrix.name }}.tsv
-          if-no-files-found: warn
-      - name: Upload version artifact (attempt 2)
-        if: steps.upload1.outcome == 'failure'
-        id: upload2
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: versions-${{ matrix.name }}
-          path: versions/${{ matrix.name }}.tsv
-          if-no-files-found: warn
-      - name: Upload version artifact (attempt 3)
-        if: steps.upload2.outcome == 'failure'
-        uses: actions/upload-artifact@v7
-        with:
-          name: versions-${{ matrix.name }}
-          path: versions/${{ matrix.name }}.tsv
-          if-no-files-found: warn
+      - name: Push version TSV via git
+        run: python3 scripts/upload_version_tsv.py "${{ matrix.name }}" versions
 
   accumulate:
     needs: [set-matrix, extract]
@@ -167,15 +151,10 @@ jobs:
           fetch-depth: 0
       - run: python3 -m pip install --user pyyaml
 
-      - name: Download version artifacts (this run)
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          path: versions-dl
-          pattern: versions-*
-          merge-multiple: false
+      - name: Fetch version TSVs from extract jobs
+        run: python3 scripts/fetch_version_tsvs.py versions-remote
 
-      # collect: restore state → merge artifacts → check gaps → save state.
+      # collect: restore state → merge TSVs → check completeness → save state.
       # Always exits 0 — the next step (Finalize or Retry) acts on the
       # done/missing outputs.
       - id: collect
@@ -185,121 +164,35 @@ jobs:
           GIT_COMMITTER_NAME: flagos-ci
           GIT_COMMITTER_EMAIL: noreply@flagos.net
         run: |
-          label="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 'unknown')"
-          state_branch="auto/versions-${label}"
-          retry="${RETRY_COUNT:-0}"
-          done="false"
+          result=$(python3 scripts/collect_version_tsvs.py \
+            --versions versions --remote versions-remote \
+            --retry "${RETRY_COUNT:-0}")
+          echo "$result"
 
-          # Fresh run: wipe versions/ so stale TSV files from a previous cycle
-          # don't mask a missing backend.  Retries restore from the state branch
-          # instead (below).
-          if [ "$retry" = "0" ]; then
-            rm -rf versions/
-          fi
-          mkdir -p versions
-          set +e   # GHA injects -e; undo it so we always reach the output lines
-
-          # --- restore state branch (skip on retry=0 — fresh run) ---
-          if [ "$retry" != "0" ] && git ls-remote --exit-code origin "refs/heads/${state_branch}" 2>/dev/null; then
-            git fetch origin "${state_branch}" 2>/dev/null
-            git archive "origin/${state_branch}" versions/ 2>/dev/null | tar xf - -C . 2>/dev/null || true
-          fi
-          prev=$(find versions -name '*.tsv' -type f 2>/dev/null | wc -l)
-          echo "Restored from state: ${prev}"
-
-          # --- merge this run's artifacts ---
-          find versions-dl -name '*.tsv' -exec cp {} versions/ \; 2>/dev/null || true
-          now=$(find versions -name '*.tsv' -type f 2>/dev/null | wc -l)
-          echo "After merging: ${now} (was ${prev})"
-
-          # --- check completeness ---
-          python3 docs/gen_data.py 2>/dev/null || true
-          expected=$(python3 docs/missing_versions.py 2>/dev/null | awk '/^COUNT /{print $3}' || echo "14")
-          missing=$(python3 docs/missing_versions.py 2>/dev/null | awk '/^MISSING /{print $2}' | tr '\n' ' ' || true)
-
-          if [ -z "${missing// /}" ] && [ "$now" -ge "$expected" ] 2>/dev/null; then
-            done="true"
-            echo "=== ALL ${now}/${expected} BACKENDS COLLECTED ==="
-            # Save final TSV set so the state branch can be cleaned later.
-            if git add -f versions/ 2>/dev/null && tree=$(git write-tree) 2>/dev/null; then
-              c=$(echo "final: ${now}/${expected}" | git commit-tree -p "refs/heads/${GITHUB_REF_NAME}" "${tree}" 2>/dev/null) || true
-              [ -n "$c" ] && git push -f origin "${c}:refs/heads/${state_branch}" 2>/dev/null || true
-            fi
-          else
-            echo "=== INCOMPLETE: ${now}/${expected} after retry ${retry} ==="
-            echo "Missing: ${missing}"
-            # Save state branch (best-effort).
-            if git add -f versions/ 2>/dev/null && tree=$(git write-tree) 2>/dev/null; then
-              c=$(echo "state: ${now}/${expected} after retry ${retry}" | git commit-tree -p "refs/heads/${GITHUB_REF_NAME}" "${tree}" 2>/dev/null) || true
-              [ -n "$c" ] && git push -f origin "${c}:refs/heads/${state_branch}" 2>/dev/null || true
-            fi
-          fi
-
-          echo "done=${done}" >> "$GITHUB_OUTPUT"
-          echo "missing=${missing}" >> "$GITHUB_OUTPUT"
-          echo "count=${now}" >> "$GITHUB_OUTPUT"
-          echo "label=${label}" >> "$GITHUB_OUTPUT"
+          # Parse JSON once, write each field to GITHUB_OUTPUT.
+          echo "$result" | python3 -c "
+          import sys, json
+          d = json.load(sys.stdin)
+          for k in ('done', 'count', 'label', 'missing'):
+              print(f'{k}={d[k]}')
+          " | tee -a "$GITHUB_OUTPUT"
 
       - name: Finalize (descriptions + PR) or retry
-        if: always() && steps.collect.outputs.done == 'true'
-        run: |
-          set +e
-          count="${{ steps.collect.outputs.count }}"
-          label="${{ steps.collect.outputs.label }}"
-
-          # Unstage dirty state from the collect step (git add -f versions/
-          # polluted the index).  Keep versions/ on disk — gen_descriptions
-          # reads from VERSIONS_DIR.  restore --staged only touches the index,
-          # reset --hard would also wipe the working tree.
-          git restore --staged .
-          git clean -fd -- versions-dl 2>/dev/null || true
-
-          VERSIONS_DIR="$PWD/versions" python3 docs/gen_descriptions.py
-
-          git config user.name "flagos-ci"
-          git config user.email "noreply@flagos.net"
-          git add docs/content/en/base/*.md docs/content/zh-cn/base/*.md base/*.md
-          if git diff --cached --quiet; then
-            echo "No description changes — nothing to PR."
-            git push origin --delete "auto/versions-${label}" 2>/dev/null || true
-            exit 0
-          fi
-          pr_branch="auto/base-descriptions-${label}"
-          git checkout -b "${pr_branch}" 2>/dev/null || git checkout "${pr_branch}" 2>/dev/null || true
-          git commit -m "docs(base): refresh image descriptions for ${label}"
-          git push origin "${pr_branch}"
-          body="Automated refresh with baked-in system-package versions for ${label}."
-          body+=$'\n\n'"**Version data:** ${count} backends"
-          if [ -z "$(gh pr list --head "${pr_branch}" --json number -q '.[0].number')" ]; then
-            gh pr create --base "${GITHUB_REF_NAME}" --head "${pr_branch}" \
-              --title "docs(base): refresh image descriptions for ${label}" \
-              --body "${body}"
-          fi
-
-          # Clean up state branch.
-          git push origin --delete "auto/versions-${label}" 2>/dev/null || true
-          echo "Done."
-
-      - name: Retry (self-trigger)
-        if: always() && steps.collect.outputs.done == 'false'
+        if: always() && steps.collect.outcome == 'success'
         env:
-          no_proxy: "api.github.com,.github.com,github.com"
+          GH_TOKEN: ${{ github.token }}
+          VERSIONS_DIR: ${{ github.workspace }}/versions
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          set +e
-          retry="${{ env.RETRY_COUNT }}"
-          max="${MAX_RETRIES:-50}"
-          missing="${{ steps.collect.outputs.missing }}"
+          # collect poisons the index (git add -f versions/); unstage it.
+          git restore --staged .
+          git clean -fd -- versions-remote 2>/dev/null || true
 
-          if [ -z "${missing// /}" ]; then
-            echo "::warning::done=false but no missing backends listed — nothing to retry"
-            exit 0
-          fi
-          if [ "$retry" -ge "$max" ] 2>/dev/null; then
-            echo "::error::Retry cap (${max}) reached. Missing: ${missing}"
-            exit 1
-          fi
-          next=$((retry + 1))
-          echo "Self-triggering retry ${next}/${max} for: ${missing}"
-          gh workflow run ".github/workflows/base-descriptions.yml" \
-            -f backend="${missing}" \
-            -f retry_count="${next}"
+          python3 scripts/finalize_descriptions.py \
+            --mode base \
+            --done "${{ steps.collect.outputs.done }}" \
+            --count "${{ steps.collect.outputs.count || 0 }}" \
+            --label "${{ steps.collect.outputs.label || 'unknown' }}" \
+            --missing "${{ steps.collect.outputs.missing || '' }}" \
+            --retry "${{ env.RETRY_COUNT || 0 }}" \
+            --max-retries "${MAX_RETRIES:-50}"

--- a/scripts/collect_version_tsvs.py
+++ b/scripts/collect_version_tsvs.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collect version TSVs from extract jobs and saved state into ``versions/``.
+
+On a fresh run (retry=0), wipes ``versions/`` first so stale TSVs from a
+previous cycle don't mask a missing backend. Retries restore from the state
+branch, then merge freshly-fetched TSVs on top.
+
+After merging, checks completeness against the expected backend list (via
+``generate_matrix.py``) and saves accumulated state to a git branch.
+
+Outputs a single JSON line to stdout consumed by GHA step outputs::
+
+    {"done": true|false, "count": N, "label": "X.Y.Z", "missing": "b1 b2"}
+
+Usage: python scripts/collect_version_tsvs.py \\
+         --versions <dir> --remote <dir> --retry <N>
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _label() -> str:
+    r = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    if r.returncode == 0 and r.stdout.strip():
+        return r.stdout.strip().lstrip("v")
+    return "unknown"
+
+
+def _missing(versions_dir: Path) -> tuple[list[str], int]:
+    """Return (missing_names, expected_count)."""
+    # gen_data.py must run first so images.yaml includes system packages.
+    subprocess.run(
+        [sys.executable, str(REPO_ROOT / "docs" / "gen_data.py")],
+        capture_output=True, cwd=REPO_ROOT,
+    )
+    r = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "docs" / "missing_versions.py")],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    # Shell's missing_versions.py writes lines; parse COUNT and MISSING.
+    missing = []
+    expected = 14
+    for line in r.stdout.strip().splitlines():
+        if line.startswith("COUNT "):
+            parts = line.split()
+            if len(parts) >= 3:
+                expected = int(parts[2])
+        elif line.startswith("MISSING "):
+            missing.append(line.split(None, 1)[1])
+    return missing, expected
+
+
+def _save_state(branch: str, msg: str) -> None:
+    """Save the contents of versions/ as a single commit on *branch*."""
+    subprocess.run(
+        ["git", "add", "-f", "versions/"],
+        check=False, cwd=REPO_ROOT,
+    )
+    p = subprocess.run(
+        ["git", "write-tree"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    if p.returncode != 0 or not p.stdout.strip():
+        return
+    tree = p.stdout.strip()
+    p2 = subprocess.run(
+        ["git", "commit-tree", tree, "-p", "HEAD",
+         "-m", msg],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    if p2.returncode != 0 or not p2.stdout.strip():
+        return
+    commit = p2.stdout.strip()
+    subprocess.run(
+        ["git", "push", "-f", "origin", f"{commit}:refs/heads/{branch}"],
+        capture_output=True, cwd=REPO_ROOT,
+    )
+
+
+def main() -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--versions", required=True, help="Path to versions/ directory")
+    ap.add_argument("--remote", required=True, help="Path to versions-remote/ directory")
+    ap.add_argument("--retry", type=int, default=0, help="Retry count (0 = fresh run)")
+    ap.add_argument("--state-branch", default=None, help="Override state branch name")
+    args = ap.parse_args()
+
+    versions_dir = Path(args.versions)
+    remote_dir = Path(args.remote)
+    retry = args.retry
+    label = _label()
+    state_branch = args.state_branch or f"auto/versions-{label}"
+
+    # Fresh run: wipe versions/ so stale TSVs don't mask missing backends.
+    if retry == 0:
+        if versions_dir.exists():
+            shutil.rmtree(versions_dir)
+    versions_dir.mkdir(parents=True, exist_ok=True)
+
+    prev = 0
+    # Restore state branch on retry.
+    if retry > 0:
+        ls = subprocess.run(
+            ["git", "ls-remote", "--exit-code", "origin",
+             f"refs/heads/{state_branch}"],
+            capture_output=True, cwd=REPO_ROOT,
+        )
+        if ls.returncode == 0:
+            subprocess.run(
+                ["git", "fetch", "origin", state_branch],
+                capture_output=True, cwd=REPO_ROOT,
+            )
+            # git archive the versions/ subtree from the state branch
+            # and extract into the repo root.
+            archive = subprocess.run(
+                ["git", "archive", f"origin/{state_branch}", "versions/"],
+                capture_output=True, cwd=REPO_ROOT,
+            )
+            if archive.returncode == 0 and archive.stdout:
+                subprocess.run(
+                    ["tar", "xf", "-", "-C", str(REPO_ROOT)],
+                    input=archive.stdout, capture_output=True, cwd=REPO_ROOT,
+                )
+        prev = len(list(versions_dir.glob("*.tsv")))
+        print(f"Restored from state: {prev}")
+
+    # Merge this run's fetched TSVs.
+    for tsv in remote_dir.glob("*.tsv"):
+        shutil.copy2(tsv, versions_dir / tsv.name)
+    now = len(list(versions_dir.glob("*.tsv")))
+    print(f"After merging: {now} (was {prev})")
+
+    # Check completeness.
+    missing_names, expected = _missing(versions_dir)
+    done = (not missing_names) and now >= expected
+
+    if done:
+        print(f"=== ALL {now}/{expected} BACKENDS COLLECTED ===")
+        _save_state(state_branch, f"final: {now}/{expected}")
+    else:
+        print(f"=== INCOMPLETE: {now}/{expected} after retry {retry} ===")
+        print(f"Missing: {' '.join(missing_names)}")
+        _save_state(state_branch, f"state: {now}/{expected} after retry {retry}")
+
+    # Output JSON for GHA step outputs.
+    result = {
+        "done": done,
+        "count": now,
+        "label": label,
+        "missing": " ".join(missing_names),
+    }
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_version_tsvs.py
+++ b/scripts/fetch_version_tsvs.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fetch TSV files from per-backend extract branches into a local directory.
+
+Each extract job pushes a single ``<backend>.tsv`` to a branch
+``auto/versions-<label>/<backend>``. This script discovers all such branches
+via ``git ls-remote``, fetches them, and extracts the TSV file into
+``<out-dir>/<backend>.tsv``.
+
+Usage: python scripts/fetch_version_tsvs.py <out-dir>
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _label() -> str:
+    """Version label from the latest git tag, e.g. ``2.1.1``."""
+    r = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    if r.returncode == 0 and r.stdout.strip():
+        return r.stdout.strip().lstrip("v")
+    return "unknown"
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: fetch_version_tsvs.py <out-dir>")
+
+    out_dir = Path(sys.argv[1])
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    label = _label()
+    prefix = f"refs/heads/auto/versions-{label}/"
+
+    # Discover per-backend branches.
+    r = subprocess.run(
+        ["git", "ls-remote", "--heads", "origin", f"{prefix}*"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    if r.returncode != 0:
+        sys.exit(f"Error: git ls-remote failed: {r.stderr.strip()}")
+
+    refs = [line.split()[1] for line in r.stdout.strip().splitlines() if line]
+    if not refs:
+        print(f"No extract branches found under {prefix}")
+        return
+
+    fetched = 0
+    for ref in refs:
+        backend = ref[len(prefix):]  # e.g. "nvidia-cuda13.3"
+        try:
+            subprocess.run(
+                ["git", "fetch", "origin", ref],
+                check=True, capture_output=True, text=True, cwd=REPO_ROOT,
+            )
+            show = subprocess.run(
+                ["git", "show", f"FETCH_HEAD:{backend}.tsv"],
+                check=True, capture_output=True, text=True, cwd=REPO_ROOT,
+            )
+            (out_dir / f"{backend}.tsv").write_text(show.stdout)
+            fetched += 1
+        except subprocess.CalledProcessError:
+            print(f"::warning::Failed to fetch {backend} from {ref}",
+                  file=sys.stderr)
+
+    print(f"Fetched {fetched} TSVs from extract branches")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/finalize_descriptions.py
+++ b/scripts/finalize_descriptions.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Post-collection: generate descriptions and open a PR, or self-trigger a retry.
+
+Two modes, dispatched by ``--done``:
+
+**done=true (finalize)**
+    Run ``gen_descriptions.py`` against the collected TSV files, commit the
+    changed ``--mode`` pages (base or runtime), and open a PR targeting
+    ``main``. Clean up state + per-backend extract branches when done.
+
+**done=false (retry)**
+    Self-trigger the ``base-descriptions.yml`` workflow with only the missing
+    backends (or exit with a warning if there are none). Clean up the
+    per-backend extract branches that were already collected so they don't
+    interfere with the next retry. If the retry cap is hit, exit with error.
+
+Usage:
+    python scripts/finalize_descriptions.py \\
+      --mode base --done true --count 14 --label 2.1.1
+    python scripts/finalize_descriptions.py \\
+      --mode base --done false --missing "nvidia-cuda13.3 sunrise-tangrt1.2.0" \\
+      --retry 3 --max-retries 50 --label 2.1.1
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+MODE_CONFIG = {
+    "base": {
+        "add_paths": [
+            "docs/content/en/base/*.md",
+            "docs/content/zh-cn/base/*.md",
+            "base/*.md",
+        ],
+        "pr_prefix": "auto/base-descriptions",
+        "pr_title": "docs(base): refresh image descriptions for {label}",
+        "pr_body": ("Automated refresh with baked-in system-package versions "
+                    "for {label}.\n\n**Version data:** {count} backends"),
+        "commit_msg": "docs(base): refresh image descriptions for {label}",
+    },
+    "runtime": {
+        "add_paths": [
+            "docs/content/en/runtime/*.md",
+            "docs/content/zh-cn/runtime/*.md",
+            "runtime/*.md",
+        ],
+        "pr_prefix": "auto/runtime-descriptions",
+        "pr_title": "docs(runtime): refresh image descriptions for {label}",
+        "pr_body": ("Automated refresh of runtime image descriptions for "
+                    "{label}.\n\n**Version data:** {count} backends"),
+        "commit_msg": "docs(runtime): refresh image descriptions for {label}",
+    },
+}
+
+
+def _git(*args: str, check: bool = True, cwd=None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git"] + list(args),
+        check=check, capture_output=True, text=True,
+        cwd=cwd or REPO_ROOT,
+    )
+
+
+def _gh(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["gh"] + list(args),
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+
+
+def _cleanup_per_backend_branches(label: str) -> None:
+    """Delete all ``auto/versions-<label>/<backend>`` branches."""
+    prefix = f"refs/heads/auto/versions-{label}/"
+    r = _git("ls-remote", "--heads", "origin", f"{prefix}*", check=False)
+    for line in r.stdout.strip().splitlines():
+        ref = line.split()[1]
+        branch = ref[len("refs/heads/"):]
+        _git("push", "origin", "--delete", branch, check=False)
+
+
+def _cleanup_state_branch(label: str) -> None:
+    _git("push", "origin", "--delete", f"auto/versions-{label}", check=False)
+
+
+def _git_env() -> dict:
+    env = os.environ.copy()
+    env.setdefault("GIT_AUTHOR_NAME", "flagos-ci")
+    env.setdefault("GIT_AUTHOR_EMAIL", "noreply@flagos.net")
+    env.setdefault("GIT_COMMITTER_NAME", "flagos-ci")
+    env.setdefault("GIT_COMMITTER_EMAIL", "noreply@flagos.net")
+    return env
+
+
+def _finalize(args) -> None:
+    """Generate descriptions, commit, and open a PR."""
+    cfg = MODE_CONFIG[args.mode]
+    count = args.count
+    label = args.label
+
+    # Ensure git identity is set for the commit.
+    _git("config", "user.name", "flagos-ci", check=False)
+    _git("config", "user.email", "noreply@flagos.net", check=False)
+
+    # gen_descriptions reads TSV files from VERSIONS_DIR.
+    env = _git_env()
+    env["VERSIONS_DIR"] = str(REPO_ROOT / "versions")
+
+    subprocess.run(
+        [sys.executable, str(REPO_ROOT / "docs" / "gen_descriptions.py")],
+        check=True, cwd=REPO_ROOT, env=env,
+    )
+
+    # Stage only the files for this mode.
+    for pattern in cfg["add_paths"]:
+        _git("add", pattern, check=False)
+
+    # Check if anything changed.
+    dr = _git("diff", "--cached", "--quiet", check=False)
+    if dr.returncode == 0:
+        print("No description changes — nothing to PR.")
+        _cleanup_state_branch(label)
+        _cleanup_per_backend_branches(label)
+        return
+
+    pr_branch = f"{cfg['pr_prefix']}-{label}"
+    cr = _git("checkout", "-b", pr_branch, check=False)
+    if cr.returncode != 0:
+        _git("checkout", pr_branch)
+
+    _git("commit", "-m", cfg["commit_msg"].format(label=label))
+
+    _git("push", "origin", pr_branch, check=False)
+
+    # Don't create a duplicate PR if one already exists.
+    pr_list = _gh("pr", "list", "--head", pr_branch, "--json", "number", "-q", ".[0].number")
+    if not pr_list.stdout.strip():
+        _gh(
+            "pr", "create",
+            "--base", os.environ.get("GITHUB_REF_NAME", "main"),
+            "--head", pr_branch,
+            "--title", cfg["pr_title"].format(label=label),
+            "--body", cfg["pr_body"].format(label=label, count=count),
+        )
+
+    _cleanup_state_branch(label)
+    _cleanup_per_backend_branches(label)
+    print("Done.")
+
+
+def _retry(args) -> None:
+    """Self-trigger the workflow for missing backends."""
+    missing = args.missing.strip()
+    retry = args.retry
+    max_retries = args.max_retries
+    label = args.label
+
+    if not missing:
+        print("::warning::done=false but no missing backends listed — nothing to retry")
+        return
+
+    if retry >= max_retries:
+        print(f"::error::Retry cap ({max_retries}) reached. Missing: {missing}")
+        _cleanup_per_backend_branches(label)
+        _cleanup_state_branch(label)
+        sys.exit(1)
+
+    # Clean already-collected per-backend branches so the next retry
+    # only sees freshly pushed ones.
+    _cleanup_per_backend_branches(label)
+
+    next_retry = retry + 1
+    print(f"Self-triggering retry {next_retry}/{max_retries} for: {missing}")
+    _gh(
+        "workflow", "run", ".github/workflows/base-descriptions.yml",
+        "-f", f"backend={missing}",
+        "-f", f"retry_count={next_retry}",
+    )
+
+
+def main() -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", required=True, choices=["base", "runtime"])
+    ap.add_argument("--done", required=True, choices=["true", "false"])
+    ap.add_argument("--count", type=int, default=0)
+    ap.add_argument("--label", default="unknown")
+    ap.add_argument("--missing", default="")
+    ap.add_argument("--retry", type=int, default=0)
+    ap.add_argument("--max-retries", type=int, default=50)
+    args = ap.parse_args()
+
+    if args.done == "true":
+        _finalize(args)
+    else:
+        _retry(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload_version_tsv.py
+++ b/scripts/upload_version_tsv.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Push the extracted system-package version TSV for a single backend to a git
+branch so the accumulate job can collect it without relying on upload-artifact.
+
+Creates an orphan branch ``auto/versions-<label>/<backend>`` containing exactly
+one file (``<backend>.tsv``) in the empty root tree, then force-pushes it.
+
+Replaces the three ``actions/upload-artifact@v7`` retry-attempt steps in the
+extract job, which hang through HTTP_PROXY on some self-hosted runners.
+
+Usage: python scripts/upload_version_tsv.py <backend> <tsv-dir>
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _label() -> str:
+    """Version label from the latest git tag, e.g. ``2.1.1``."""
+    r = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    if r.returncode == 0 and r.stdout.strip():
+        return r.stdout.strip().lstrip("v")
+    return "unknown"
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        sys.exit("usage: upload_version_tsv.py <backend> <tsv-dir>")
+
+    backend = sys.argv[1]
+    tsv_dir = Path(sys.argv[2])
+    tsv_file = tsv_dir / f"{backend}.tsv"
+
+    if not tsv_file.is_file():
+        sys.exit(f"Error: {tsv_file} not found")
+
+    label = _label()
+    branch = f"auto/versions-{label}/{backend}"
+
+    subprocess.run(
+        ["git", "checkout", "--orphan", branch],
+        check=True, cwd=REPO_ROOT,
+    )
+    # Clean the index (orphan branch starts with a populated index).
+    subprocess.run(
+        ["git", "rm", "-rf", "--cached", "."],
+        check=False, cwd=REPO_ROOT,
+    )
+
+    dest = Path(REPO_ROOT) / f"{backend}.tsv"
+    dest.write_bytes(tsv_file.read_bytes())
+
+    subprocess.run(
+        ["git", "add", f"{backend}.tsv"],
+        check=True, cwd=REPO_ROOT,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", f"versions: {backend}"],
+        check=True, cwd=REPO_ROOT,
+        env={**os.environ, "GIT_AUTHOR_NAME": "flagos-ci",
+             "GIT_AUTHOR_EMAIL": "noreply@flagos.net",
+             "GIT_COMMITTER_NAME": "flagos-ci",
+             "GIT_COMMITTER_EMAIL": "noreply@flagos.net"},
+    )
+    r = subprocess.run(
+        ["git", "push", "-f", "origin", branch],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    if r.returncode == 0:
+        print(f"Pushed {backend}.tsv to {branch}")
+    else:
+        print(f"::warning::git push failed for {backend} — will be retried",
+              file=sys.stderr)
+        if r.stderr:
+            sys.stderr.write(r.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two fixes for `base-descriptions.yml`:

### 1. Replace upload-artifact with git push

`actions/upload-artifact@v7` reliably hangs on some self-hosted runners behind HTTP_PROXY. Each extract job now pushes its TSV to a dedicated orphan branch `auto/versions-<label>/<backend>`. Accumulate collects all per-backend branches via `git ls-remote` + `git fetch`.

New scripts:
- `scripts/upload_version_tsv.py` — extract: create orphan branch, push TSV
- `scripts/fetch_version_tsvs.py` — accumulate: discover + fetch all per-backend branches
- `scripts/collect_version_tsvs.py` — accumulate: restore state → merge → check completeness → save state (outputs JSON)
- `scripts/finalize_descriptions.py` — accumulate: gen descriptions + PR (`--mode base|runtime`), or self-trigger retry

### 2. Reset `versions/` on fresh runs

Fresh runs (retry=0) wipe `versions/` before merging, preventing stale TSVs from masking a missing backend. Retries restore from the state branch.

### Also

- verify step passes raw device flags to `docker run` (from `build-config.yml` `run.vendors.<vendor>.toolkit`)
- Per-backend extract branches cleaned up in Finalize, Retry cap path, and Retry self-trigger path

This PR was written in part with the assistance of generative AI.