### PR TITLE
fix(ci): use lowercase JSON strings for done flag

### DIFF
--- a/scripts/collect_version_tsvs.py
+++ b/scripts/collect_version_tsvs.py
@@ -170,9 +170,11 @@ def main() -> None:
         print(f"Missing: {' '.join(missing_names)}", file=sys.stderr)
         _save_state(state_branch, f"state: {now}/{expected} after retry {retry}")
 
-    # Output JSON for GHA step outputs.
+    # Output JSON for GHA step outputs.  Use "true"/"false" strings rather than
+    # Python bool so that downstream `--done` parsing in finalize_descriptions.py
+    # matches the argparse choices (lowercase).
     result = {
-        "done": done,
+        "done": "true" if done else "false",
         "count": now,
         "label": label,
         "missing": " ".join(missing_names),


### PR DESCRIPTION
`json.dumps({"done": True})` → `json.load` → f-string `"True"` — uppercase, rejected by argparse `choices=["true","false"]`.

Fix: output `"true"/"false"` strings.

Run 29911532157: 14/14 extract all green, accumulate died on `--done True`.

This PR was written in part with the assistance of generative AI.