### PR TITLE
fix(ci): stale branch cleanup + sunrise raw flags

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -110,8 +110,7 @@ run:
       toolkit: "--network host -e TENCENT_VISIBLE_DEVICES=all"
       raw: "--privileged -v /dev:/dev"
     sunrise:
-      # generic launch only — no device flags / toolkit known.
-      raw: ""
+      raw: "--privileged -v /dev:/dev"
 
   # Host prerequisite (container toolkit) for the toolkit tier, per vendor. Rendered
   # only when the vendor has a toolkit/toolkit_cmd launch style.

--- a/scripts/finalize_descriptions.py
+++ b/scripts/finalize_descriptions.py
@@ -139,6 +139,8 @@ def _finalize(args) -> None:
     dr = _git("diff", "--cached", "--quiet", check=False)
     if dr.returncode == 0:
         print("No description changes — nothing to PR.")
+        # Clean up the stale PR branch from a previous run as well.
+        _git("push", "origin", "--delete", f"{cfg['pr_prefix']}-{label}", check=False)
         _cleanup_state_branch(label)
         _cleanup_per_backend_branches(label)
         return
@@ -150,7 +152,9 @@ def _finalize(args) -> None:
 
     _git("commit", "-m", cfg["commit_msg"].format(label=label))
 
-    _git("push", "origin", pr_branch, check=False)
+    # Force-push: a stale branch from a previous run (closed/unmerged PR)
+    # may already exist with a different commit.
+    _git("push", "--force", "origin", pr_branch, check=False)
 
     # Don't create a duplicate PR if one already exists.
     pr_list = _gh("pr", "list", "--head", pr_branch, "--json", "number", "-q", ".[0].number")


### PR DESCRIPTION
## Changes

### 1. Stale PR branch handling (finalize_descriptions.py)

- Force-push the PR branch so a stale branch from a previous closed/unmerged run does not block the next run.
- No-changes path: also delete the stale PR branch alongside state + extract branches.

Leaving auto/base-descriptions-2.1.1 (from closed #168) on remote as a test case — the next descriptions workflow run should handle it gracefully.

### 2. Sunrise raw flags (build-config.yml)

Sunrise pt_smi needs full device access to verify. Set raw to --privileged -v /dev:/dev, matching enflame.

This PR was written in part with the assistance of generative AI.
