### PR TITLE
fix(ci): stale branch cleanup + verify metadata in TSV

### DIFF
--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -95,6 +95,14 @@ jobs:
         run: |
           python3 -c "import yaml" 2>/dev/null \
             || python3 -m pip install --user --break-system-packages pyyaml
+
+      - name: Delete stale version branch
+        if: always()
+        run: |
+          label="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 'unknown')"
+          git push origin --delete "auto/versions-${label}/${{ matrix.name }}" 2>/dev/null || true
+          echo "Cleared auto/versions-${label}/${{ matrix.name }}"
+
       - name: Harbor login (for image pull)
         env:
           HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
@@ -120,6 +128,7 @@ jobs:
 
       - name: Verify base image (best-effort)
         continue-on-error: true
+        id: verify
         run: |
           python3 docs/gen_data.py
           python3 scripts/verify_base.py "${{ matrix.name }}"
@@ -128,6 +137,12 @@ jobs:
         run: |
           python3 docs/gen_data.py
           python3 docs/extract_versions.py "${{ matrix.name }}" versions
+
+      - name: Record verify status
+        if: always()
+        run: |
+          mkdir -p versions
+          echo "${{ steps.verify.outcome }}" > "versions/${{ matrix.name }}.verify_outcome"
 
       - name: Push version TSV via git
         run: python3 scripts/upload_version_tsv.py "${{ matrix.name }}" versions
@@ -145,6 +160,9 @@ jobs:
       missing: ${{ steps.collect.outputs.missing }}
       count: ${{ steps.collect.outputs.count }}
       label: ${{ steps.collect.outputs.label }}
+      verify_ok: ${{ steps.collect.outputs.verify_ok }}
+      verify_fail: ${{ steps.collect.outputs.verify_fail }}
+      verify_skip: ${{ steps.collect.outputs.verify_skip }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -152,7 +170,7 @@ jobs:
       - run: python3 -m pip install --user pyyaml
 
       - name: Fetch version TSVs from extract jobs
-        run: python3 scripts/fetch_version_tsvs.py versions-remote
+        run: python3 scripts/fetch_version_tsvs.py versions-remote --retry "${RETRY_COUNT:-0}"
 
       # collect: restore state → merge TSVs → check completeness → save state.
       # Always exits 0 — the next step (Finalize or Retry) acts on the
@@ -173,7 +191,8 @@ jobs:
           echo "$result" | python3 -c "
           import sys, json
           d = json.load(sys.stdin)
-          for k in ('done', 'count', 'label', 'missing'):
+          for k in ('done', 'count', 'label', 'missing',
+                    'verify_ok', 'verify_fail', 'verify_skip'):
               print(f'{k}={d[k]}')
           " | tee -a "$GITHUB_OUTPUT"
 
@@ -194,5 +213,8 @@ jobs:
             --count "${{ steps.collect.outputs.count || 0 }}" \
             --label "${{ steps.collect.outputs.label || 'unknown' }}" \
             --missing "${{ steps.collect.outputs.missing || '' }}" \
+            --verify-ok "${{ steps.collect.outputs.verify_ok || 0 }}" \
+            --verify-fail "${{ steps.collect.outputs.verify_fail || 0 }}" \
+            --verify-skip "${{ steps.collect.outputs.verify_skip || 0 }}" \
             --retry "${{ env.RETRY_COUNT || 0 }}" \
             --max-retries "${MAX_RETRIES:-50}"

--- a/scripts/collect_version_tsvs.py
+++ b/scripts/collect_version_tsvs.py
@@ -16,16 +16,22 @@
 
 """Collect version TSVs from extract jobs and saved state into ``versions/``.
 
-On a fresh run (retry=0), wipes ``versions/`` first so stale TSVs from a
-previous cycle don't mask a missing backend. Retries restore from the state
-branch, then merge freshly-fetched TSVs on top.
+On a fresh run (retry=0), wipes ``versions/`` and deletes all stale
+per-backend branches. Retries merge freshly-fetched TSVs from the remote
+directory (produced by ``fetch_version_tsvs.py``).
+
+Each TSV carries two metadata headers prepended by ``upload_version_tsv.py``::
+
+    # run: <github_run_id>
+    # verify: success|failure|skipped
 
 After merging, checks completeness against the expected backend list (via
-``generate_matrix.py``) and saves accumulated state to a git branch.
+``generate_matrix.py``) and reports a verify summary.
 
 Outputs a single JSON line to stdout consumed by GHA step outputs::
 
-    {"done": true|false, "count": N, "label": "X.Y.Z", "missing": "b1 b2"}
+    {"done": "true", "count": 14, "label": "2.1.1",
+     "missing": "", "verify_ok": 12, "verify_fail": 2, "verify_skip": 0}
 
 Usage: python scripts/collect_version_tsvs.py \\
          --versions <dir> --remote <dir> --retry <N>
@@ -34,6 +40,7 @@ Usage: python scripts/collect_version_tsvs.py \\
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -119,11 +126,24 @@ def main() -> None:
     # Output JSON for GHA step outputs.  Use "true"/"false" strings rather than
     # Python bool so that downstream `--done` parsing in finalize_descriptions.py
     # matches the argparse choices (lowercase).
+    #
+    # Also include a verify summary: counts of success/failure/skipped from the
+    # metadata headers in each collected TSV.
+    verify_counts = {"success": 0, "failure": 0, "skipped": 0}
+    for tsv in versions_dir.glob("*.tsv"):
+        head = tsv.read_text()[:256]
+        m = re.search(r"^# verify: (success|failure|skipped)", head, re.MULTILINE)
+        if m:
+            verify_counts[m.group(1)] += 1
+
     result = {
         "done": "true" if done else "false",
         "count": now,
         "label": label,
         "missing": " ".join(missing_names),
+        "verify_ok": verify_counts["success"],
+        "verify_fail": verify_counts["failure"],
+        "verify_skip": verify_counts["skipped"],
     }
     print(json.dumps(result))
 

--- a/scripts/fetch_version_tsvs.py
+++ b/scripts/fetch_version_tsvs.py
@@ -17,11 +17,12 @@
 """Fetch TSV files from per-backend extract branches into a local directory.
 
 Each extract job pushes a single ``<backend>.tsv`` to a branch
-``auto/versions-<label>/<backend>``. This script discovers all such branches
-via ``git ls-remote``, fetches them, and extracts the TSV file into
-``<out-dir>/<backend>.tsv``.
+``auto/versions-<label>/<backend>``.  On a fresh run (``--retry 0``), all
+existing per-backend branches are deleted first so that stale data from a
+previous cycle doesn't mask a missing backend.
 
-Usage: python scripts/fetch_version_tsvs.py <out-dir>
+Usage:
+    python scripts/fetch_version_tsvs.py <out-dir> --retry <N>
 """
 
 import subprocess
@@ -43,14 +44,33 @@ def _label() -> str:
 
 
 def main() -> None:
-    if len(sys.argv) != 2:
-        sys.exit("usage: fetch_version_tsvs.py <out-dir>")
+    import argparse
 
-    out_dir = Path(sys.argv[1])
+    ap = argparse.ArgumentParser()
+    ap.add_argument("out_dir", help="Path to output directory (versions-remote)")
+    ap.add_argument("--retry", type=int, default=0, help="Retry count (0 = fresh run)")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     label = _label()
     prefix = f"refs/heads/auto/versions-{label}/"
+
+    # Fresh run: delete all per-backend branches so stale data from a
+    # previous cycle doesn't mask a missing backend.
+    if args.retry == 0:
+        r = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", f"{prefix}*"],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+        for line in r.stdout.strip().splitlines():
+            ref = line.split()[1] if line else ""
+            if ref:
+                subprocess.run(
+                    ["git", "push", "origin", "--delete", ref[len("refs/heads/"):]],
+                    check=False, capture_output=True, cwd=REPO_ROOT,
+                )
 
     # Discover per-backend branches.
     r = subprocess.run(

--- a/scripts/finalize_descriptions.py
+++ b/scripts/finalize_descriptions.py
@@ -55,8 +55,11 @@ MODE_CONFIG = {
         ],
         "pr_prefix": "auto/base-descriptions",
         "pr_title": "docs(base): refresh image descriptions for {label}",
-        "pr_body": ("Automated refresh with baked-in system-package versions "
-                    "for {label}.\n\n**Version data:** {count} backends"),
+        "pr_body": (
+            "Automated refresh with baked-in system-package versions for {label}."
+            "\n\n**Version data:** {count} backends"
+            "\n\n**Verify:** {verify_ok} passed, {verify_fail} failed, {verify_skip} skipped"
+        ),
         "commit_msg": "docs(base): refresh image descriptions for {label}",
     },
     "runtime": {
@@ -67,8 +70,11 @@ MODE_CONFIG = {
         ],
         "pr_prefix": "auto/runtime-descriptions",
         "pr_title": "docs(runtime): refresh image descriptions for {label}",
-        "pr_body": ("Automated refresh of runtime image descriptions for "
-                    "{label}.\n\n**Version data:** {count} backends"),
+        "pr_body": (
+            "Automated refresh of runtime image descriptions for {label}."
+            "\n\n**Version data:** {count} backends"
+            "\n\n**Verify:** {verify_ok} passed, {verify_fail} failed, {verify_skip} skipped"
+        ),
         "commit_msg": "docs(runtime): refresh image descriptions for {label}",
     },
 }
@@ -159,12 +165,17 @@ def _finalize(args) -> None:
     # Don't create a duplicate PR if one already exists.
     pr_list = _gh("pr", "list", "--head", pr_branch, "--json", "number", "-q", ".[0].number")
     if not pr_list.stdout.strip():
+        body = cfg["pr_body"].format(
+            label=label, count=count,
+            verify_ok=args.verify_ok, verify_fail=args.verify_fail,
+            verify_skip=args.verify_skip,
+        )
         _gh(
             "pr", "create",
             "--base", os.environ.get("GITHUB_REF_NAME", "main"),
             "--head", pr_branch,
             "--title", cfg["pr_title"].format(label=label),
-            "--body", cfg["pr_body"].format(label=label, count=count),
+            "--body", body,
         )
 
     _cleanup_state_branch(label)
@@ -212,6 +223,9 @@ def main() -> None:
     ap.add_argument("--count", type=int, default=0)
     ap.add_argument("--label", default="unknown")
     ap.add_argument("--missing", default="")
+    ap.add_argument("--verify-ok", type=int, default=0)
+    ap.add_argument("--verify-fail", type=int, default=0)
+    ap.add_argument("--verify-skip", type=int, default=0)
     ap.add_argument("--retry", type=int, default=0)
     ap.add_argument("--max-retries", type=int, default=50)
     args = ap.parse_args()

--- a/scripts/upload_version_tsv.py
+++ b/scripts/upload_version_tsv.py
@@ -15,15 +15,18 @@
 # limitations under the License.
 
 """Push the extracted system-package version TSV for a single backend to a git
-branch so the accumulate job can collect it without relying on upload-artifact.
+branch so the accumulate job can collect it.
 
-Writes the TSV into git's object database directly (hash-object + mktree +
-commit-tree + push), never switching branches or touching the working tree.
-This keeps the runner's local repo state pristine across runs and avoids the
-orphan-branch residue that broke concurrent/retry runs.
+Preconditions: the caller records the verify step outcome to
+``<tsv-dir>/<backend>.verify_outcome`` (contents: ``success``, ``failure``,
+or ``skipped``).  ``GITHUB_RUN_ID`` must be set in the environment.
 
-Replaces the three ``actions/upload-artifact@v7`` retry-attempt steps in the
-extract job, which hang through HTTP_PROXY on some self-hosted runners.
+The script prepends two metadata headers (``# run:``, ``# verify:``) to the
+TSV so the accumulate job can tell whether the data is fresh and whether the
+verify step passed.
+
+Before pushing, deletes the remote branch so a failed extract leaves no stale
+branch behind.
 
 Usage: python scripts/upload_version_tsv.py <backend> <tsv-dir>
 """
@@ -54,17 +57,31 @@ def main() -> None:
     backend = sys.argv[1]
     tsv_dir = Path(sys.argv[2])
     tsv_file = tsv_dir / f"{backend}.tsv"
+    verify_file = tsv_dir / f"{backend}.verify_outcome"
 
     if not tsv_file.is_file():
         sys.exit(f"Error: {tsv_file} not found")
 
     label = _label()
     branch = f"auto/versions-{label}/{backend}"
+    run_id = os.environ.get("GITHUB_RUN_ID", "unknown")
+    verify = verify_file.read_text().strip() if verify_file.is_file() else "unknown"
 
-    # Write the TSV as a git blob, never touching the working tree or index.
+    # Prepend metadata headers to the TSV content.
+    tsv_raw = tsv_file.read_text()
+    payload = f"# run: {run_id}\n# verify: {verify}\n{tsv_raw}"
+
+    # Delete any stale branch so a failed extract leaves no trace.
+    subprocess.run(
+        ["git", "push", "origin", "--delete", branch],
+        check=False, capture_output=True, cwd=REPO_ROOT,
+    )
+
+    # Write the annotated TSV as a git blob, never touching the working tree.
     blob = subprocess.run(
-        ["git", "hash-object", "-w", str(tsv_file)],
-        check=True, capture_output=True, text=True, cwd=REPO_ROOT,
+        ["git", "hash-object", "-w", "--stdin"],
+        input=payload, check=True, capture_output=True, text=True,
+        cwd=REPO_ROOT,
     ).stdout.strip()
 
     # Build a tree containing just <backend>.tsv.


### PR DESCRIPTION
## Changes

### 1. Stale branch cleanup
- `upload_version_tsv.py`: delete remote branch before pushing, so a failed extract leaves no stale data.
- `fetch_version_tsvs.py`: on fresh runs (--retry 0), delete all per-backend branches before fetching.

Together these ensure that a failed extract job results in the backend being reported as MISSING by the accumulate job, triggering a retry — rather than silently reusing stale data from a previous cycle.

### 2. TSV metadata headers
`upload_version_tsv.py` prepends two headers to the TSV:
```
# run: <github_run_id>
# verify: success|failure|skipped
```

The verify outcome is recorded by a new workflow step that captures the verify step result status.

### 3. Verify summary in PR body
`collect_version_tsvs.py` parses the verify metadata and includes counts in the JSON output. `finalize_descriptions.py` surfaces them in the PR body:
```
**Verify:** 12 passed, 1 failed, 1 skipped
```

This PR was written in part with the assistance of generative AI.
