### PR TITLE
refactor(runtime): pre-compute build args in matrix, zero deps on self-hosted

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -17,6 +17,9 @@ name: Runtime Image Build (manual)
 # Runtime images are built on demand, not on every push/PR. They layer
 # FlagGems (pure Python + optional C++ extension) on top of a base image
 # via wheel install. Trigger this manually to build a backend (or all).
+#
+# Self-hosted runners do NOT need Python/pyyaml.  All build arguments are
+# pre-computed by set-matrix (ubuntu-latest) via generate_matrix.py --runtime.
 
 on:
   workflow_dispatch:
@@ -43,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      harbor_host: ${{ steps.harbor-host.outputs.host }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -54,12 +58,18 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.backend }}" == "all" ]]; then
-            python3 scripts/generate_matrix.py > matrix.json
+            python3 scripts/generate_matrix.py --runtime > matrix.json
           else
-            python3 scripts/generate_matrix.py ${{ inputs.backend }} > matrix.json
+            python3 scripts/generate_matrix.py --runtime ${{ inputs.backend }} > matrix.json
           fi
           cat matrix.json
           echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+      - id: harbor-host
+        shell: bash
+        run: |
+          host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
+          echo "host=$host" >> "$GITHUB_OUTPUT"
 
   build-matrix:
     needs: set-matrix
@@ -72,21 +82,13 @@ jobs:
     steps:
       - name: Checkout build-infra
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
-      - name: Setup Python deps
-        run: python3 -m pip install --user pyyaml twine
-
-      - name: Harbor login (pull base image + push runtime)
+      - name: Harbor login (push only)
         if: ${{ inputs.push }}
         env:
           HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
-          HTTP_PROXY: ""
-          HTTPS_PROXY: ""
-          no_proxy: "harbor.baai.ac.cn,.baai.ac.cn"
         run: |
-          host=$(/tmp/ci-venv/bin/python -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
+          host="${{ needs.set-matrix.outputs.harbor_host }}"
           for i in 1 2 3; do
             if printf '%s' "$HARBOR_PW" | docker login "$host" -u tengqm --password-stdin; then
               exit 0
@@ -101,14 +103,29 @@ jobs:
         env:
           NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
         run: |
-          push_flag=""
+          flaggems_ver="${{ inputs.flaggems }}"
+          [[ -z "$flaggems_ver" ]] && flaggems_ver="${{ matrix.flaggems_version }}"
+
+          no_flaggems_arg=""
+          [[ "${{ inputs.no_flaggems }}" == "true" ]] && no_flaggems_arg='--build-arg NO_FLAGGEMS=1'
+
+          docker build \
+            --build-arg "BASE_IMAGE=${{ matrix.base_image }}" \
+            --build-arg "PYTHON_VERSION=${{ matrix.python_version }}" \
+            --build-arg "FLAGOS_PYPI=${{ matrix.flagos_pypi }}" \
+            --build-arg "DAILY_PYPI=${{ matrix.daily_pypi }}" \
+            --build-arg "EXTRA_PYPI=${{ matrix.extra_pypi }}" \
+            --build-arg "DEPS=${{ matrix.deps }}" \
+            --build-arg "CPP_EXTRA=${{ matrix.cpp_extra }}" \
+            --build-arg "FLAGTREE_PKG=${{ matrix.flagtree_pkg }}" \
+            --build-arg "TRITON_PKG=${{ matrix.triton_pkg }}" \
+            --build-arg "TRITON_EXTRA_PKGS=${{ matrix.triton_extra_pkgs }}" \
+            --build-arg "INCLUDE_TESTS=false" \
+            --build-arg "FLAGGEMS_VERSION=${flaggems_ver}" \
+            ${no_flaggems_arg} \
+            -t "${{ matrix.image_tag }}" \
+            -f runtime/Containerfile runtime/
+
           if [[ "${{ inputs.push }}" == "true" ]]; then
-            push_flag="--push"
+            docker push "${{ matrix.image_tag }}"
           fi
-          no_flag=""
-          if [[ "${{ inputs.no_flaggems }}" == "true" ]]; then
-            no_flag="--no-flaggems"
-          fi
-          python3 scripts/build_runtime.py "${{ matrix.name }}" \
-            --flaggems "${{ inputs.flaggems }}" \
-            ${push_flag} ${no_flag}

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -17,9 +17,6 @@ name: Runtime Image Build (manual)
 # Runtime images are built on demand, not on every push/PR. They layer
 # FlagGems (pure Python + optional C++ extension) on top of a base image
 # via wheel install. Trigger this manually to build a backend (or all).
-#
-# Self-hosted runners do NOT need Python/pyyaml.  All build arguments are
-# pre-computed by set-matrix (ubuntu-latest) via generate_matrix.py --runtime.
 
 on:
   workflow_dispatch:

--- a/scripts/generate_matrix.py
+++ b/scripts/generate_matrix.py
@@ -14,24 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generate a GitHub Actions build matrix for the FlagOS base images.
+"""Generate a GitHub Actions build matrix for FlagOS images.
 
-Reads configs.yaml (the source of truth for vendors/backends) and the runner
-mapping in .github/build-config.yml, then emits a matrix of the base images
-that are actually buildable — i.e. each vendor/backend that has a
-base/{vendor}-{backend} containerfile.
-
-Output (compact JSON on stdout):
-    {"include": [{"name": "nvidia-cuda12.8", "runson": "..."}, ...]}
+Reads configs.yaml and the runner mapping in .github/build-config.yml,
+then emits a matrix of buildable backends.
 
 Usage:
-    python scripts/generate_matrix.py                       # all buildable backends
-    python scripts/generate_matrix.py nvidia-cuda12.8 metax-maca3.7.2.1  # subset
+    python scripts/generate_matrix.py                         # base: all backends
+    python scripts/generate_matrix.py nvidia-cuda12.8         # base: subset
+    python scripts/generate_matrix.py --runtime                # runtime: all
+    python scripts/generate_matrix.py --runtime nvidia-cuda12.8  # runtime: subset
 
-Backends without a base/ file (e.g. thead-ppu2.0.0, spacemit-spacemit) are
-skipped with a note on stderr.
+--runtime mode pre-computes all docker build args so self-hosted
+runners don't need Python/pyyaml installed.
 """
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -63,12 +61,7 @@ def buildable_backends(repo_root: Path, configs: dict):
 
 
 def runson_for(name: str, runners: dict) -> str:
-    """Return the runner as a JSON-encoded array string.
-
-    A reusable workflow's `runs-on` must come from a string input, so we pass
-    the labels JSON-encoded and `fromJSON` them in imagebuild.yml. A bare label
-    is normalised to a single-element array (e.g. "ubuntu-latest" -> ["ubuntu-latest"]).
-    """
+    """Return the runner as a JSON-encoded array string."""
     overrides = runners.get("overrides") or {}
     val = overrides.get(name, runners.get("default", "ubuntu-latest"))
     if isinstance(val, str):
@@ -76,15 +69,94 @@ def runson_for(name: str, runners: dict) -> str:
     return json.dumps(val)
 
 
+def _base_matrix(runners: dict, selected: list[str]) -> dict:
+    """Original matrix: {name, runson} only."""
+    return {"include": [{"name": n, "runson": runson_for(n, runners)} for n in selected]}
+
+
+def _runtime_matrix(configs: dict, runners: dict, repo_root: Path, selected: list[str]) -> dict:
+    """Extended matrix for runtime builds: includes all docker build args.
+
+    All values come from configs.yaml + build-config.yml.  No git tag
+    dependency — the version is read directly from configs.yaml ``version:``.
+    """
+    build_config = load_yaml(repo_root / ".github" / "build-config.yml")
+    registry = build_config.get("registry") or {}
+    host = registry.get("host", "")
+    prefixes = registry.get("prefixes") or {}
+    base_prefix = prefixes.get("base", "flagos-base")
+    runtime_prefix = prefixes.get("runtime", "flagos-runtime")
+
+    stack_version = configs.get("version", "latest")
+    pypi_base_tpl = configs.get("pypi_base", "")
+    pypi_daily = configs.get("pypi_daily", "")
+    mirror = configs.get("mirror", "https://mirrors.aliyun.com/pypi/simple")
+    flaggems_ver = configs.get("flaggems", "")
+
+    include = []
+    for name in selected:
+        vendor, backend = name.split("-", 1)
+        backend_info = configs["vendors"][vendor][backend]
+
+        # Image refs — version from configs.yaml
+        base_img = (
+            f"{host}/{base_prefix}/flagos-base-{name}:{stack_version}"
+            if host else f"flagos-base-{name}:{stack_version}"
+        )
+        runtime_tag = (
+            f"{host}/{runtime_prefix}/flagos-runtime-{name}:{stack_version}"
+            if host else f"flagos-runtime-{name}:{stack_version}"
+        )
+
+        # Per-backend build args
+        deps = " ".join(backend_info.get("deps", []))
+        cpp_backend = str(backend_info.get("cmake_backend", "")).lower()
+        cpp_extra = f"cpp-{cpp_backend}" if cpp_backend else ""
+
+        include.append({
+            "name": name,
+            "runson": runson_for(name, runners),
+            "image_tag": runtime_tag,
+            "flaggems_version": flaggems_ver,
+            "base_image": base_img,
+            "python_version": backend_info.get("python", "3.12"),
+            "flagos_pypi": pypi_base_tpl.format(vendor=vendor) if pypi_base_tpl else "",
+            "daily_pypi": pypi_daily,
+            "extra_pypi": mirror,
+            "deps": deps,
+            "cpp_extra": cpp_extra,
+            "flagtree_pkg": backend_info.get("flagtree", ""),
+            "triton_pkg": backend_info.get("triton", ""),
+            "triton_extra_pkgs": " ".join(
+                backend_info.get("triton_post_install", [])
+            ) if isinstance(backend_info.get("triton_post_install"), list) else "",
+        })
+
+    return {"include": include}
+
+
 def main():
-    requested = sys.argv[1:]  # optional subset of names
+    parser = argparse.ArgumentParser(
+        description="Generate GitHub Actions build matrix for FlagOS images",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--runtime", action="store_true",
+        help="Generate runtime build matrix (includes docker build args)",
+    )
+    parser.add_argument(
+        "backends", nargs="*",
+        help="Optional subset of backend names",
+    )
+    args = parser.parse_args()
 
     repo_root = find_repo_root()
     configs = load_yaml(repo_root / "configs.yaml")
 
     config_path = repo_root / ".github" / "build-config.yml"
-    config = load_yaml(config_path) if config_path.exists() else {}
-    runners = config.get("runners") or {}
+    build_config = load_yaml(config_path) if config_path.exists() else {}
+    runners = build_config.get("runners") or {}
 
     all_backends = list(buildable_backends(repo_root, configs))
     buildable = {name for name, has_file in all_backends if has_file}
@@ -96,17 +168,21 @@ def main():
             file=sys.stderr,
         )
 
-    if requested:
-        unknown = [n for n in requested if n not in buildable]
+    if args.backends:
+        unknown = [n for n in args.backends if n not in buildable]
         for n in unknown:
             print(f"warning: '{n}' is not a buildable base backend, ignoring",
                   file=sys.stderr)
-        selected = [n for n in requested if n in buildable]
+        selected = [n for n in args.backends if n in buildable]
     else:
         selected = [name for name, has_file in all_backends if has_file]
 
-    include = [{"name": name, "runson": runson_for(name, runners)} for name in selected]
-    print(json.dumps({"include": include}))
+    if args.runtime:
+        matrix = _runtime_matrix(configs, runners, repo_root, selected)
+    else:
+        matrix = _base_matrix(runners, selected)
+
+    print(json.dumps(matrix))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Self-hosted runners no longer need Python, pip, pyyaml, or venv to build runtime images.

All docker build-arg resolution now happens in `set-matrix` (ubuntu-latest) via `generate_matrix.py --runtime`.  The `build-matrix` job is pure shell: checkout + docker build + docker push.

**Changes:**
- `generate_matrix.py` gains `--runtime` mode — outputs extended matrix with image_tag, flaggems_version, and all 12 build args per backend
- `runtime.yml` build-matrix: removed pip install, Harbor login extraction, and venv; replaced with direct `docker build` using matrix fields
- Harbor host extracted in set-matrix, passed through outputs — no yaml parsing on self-hosted
- Runtime version from `configs.yaml version:`, no git tag dependency

Backward compatible: `trigger.yml` (base image build) still uses `generate_matrix.py` without `--runtime`.