### PR TITLE
feat(wheel-repack): add tool for stripping torch/triton deps from vendor wheels

### DIFF
--- a/vllm-repack/config.yaml
+++ b/vllm-repack/config.yaml
@@ -1,0 +1,79 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ── Wheel Repack Classification Rules ────────────────────────────────
+# Each key is a set of *package names* (no version, case-sensitive).
+# For the top-level wheel (e.g. vllm): any Requires-Dist matching a name in
+# "remove_torch_chain" / "remove_cuda_only" / "remove_orphaned" gets stripped.
+#
+# For identified indirect-dep wheels (also_repack): the dependency-stripping
+# rules under "strip_from_repacked" apply instead — this is deliberately
+# more conservative than the top-level rules.
+
+# ── Top-level removal rules (applied to e.g. vllm's own METADATA) ──
+
+# Packages that directly or transitively depend on torch / triton.
+# Stripping these from vllm's Requires-Dist prevents the entire torch chain
+# from being pulled in.
+remove_torch_chain:
+  - torch
+  - torchaudio
+  - torchvision
+  - torchcodec
+
+# NVIDIA / CUDA-only packages — meaningless on non-CUDA platforms.
+remove_cuda_only:
+  - PyNvVideoCodec
+  - nvidia-cudnn-frontend
+  - nvidia-cutlass-dsl
+  - nvtx
+  - numba
+
+# Packages whose only consumer was stripped above (no other consumers left).
+remove_orphaned:
+  - apache-tvm-ffi
+
+# ── Indirect dependency handling ─────────────────────────────────────
+# These package names are known to pull in torch / triton via their own
+# Requires-Dist.  The repacker will download their original wheel, patch
+# its METADATA, and place the result in cache/.
+
+also_repack:
+  - compressed-tensors
+  - flashinfer-python
+  - flashinfer-cubin
+  - tilelang
+  - quack-kernels
+  - tokenspeed-mla
+  - humming-kernels
+  - xgrammar
+  - tokenspeed-triton
+  - triton
+
+# ── Stripping rules for also_repack packages ─────────────────────────
+# When repacking an indirect dep wheel, remove these from its Requires-Dist.
+# This is narrower than the top-level rules — we only strip the torch/triton
+# family, never CUDA infrastructure (the repacked dep may still need e.g.
+# nvidia-cudnn-frontend at runtime if the user is on CUDA hardware).
+strip_from_repacked:
+  - torch
+  - torchaudio
+  - torchvision
+  - torchcodec
+  - triton
+  - tokenspeed-triton
+
+# ── Indexes for downloading original wheels ──────────────────────────
+# The repacker tries pypi.org first; if --extra-index is given, it appends
+# that URL to the index list.

--- a/vllm-repack/repack.py
+++ b/vllm-repack/repack.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Repack a Python wheel by removing unwanted Requires-Dist entries from its
+METADATA, recording every change in a .deps-manifest.yaml for traceability.
+
+Usage:
+    python repack.py /path/to/vllm-0.25.1-xxx.whl          # single wheel
+    python repack.py --from pypi vllm==0.25.1               # download first
+    python repack.py --extra-index https://... vllm.whl     # add search index
+
+The script puts repacked wheels + manifests under output/ and patched
+indirect-dependency wheels under cache/.
+"""
+
+import argparse
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+CONFIG_PATH = SCRIPT_DIR / "config.yaml"
+CACHE_DIR = SCRIPT_DIR / "cache"
+OUTPUT_DIR = SCRIPT_DIR / "output"
+DEPS_INDEX_PATH = SCRIPT_DIR / "deps-index.yaml"
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def load_config():
+    with open(CONFIG_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def ensure_dirs():
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_deps_index():
+    if not DEPS_INDEX_PATH.exists():
+        return {}
+    with open(DEPS_INDEX_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def save_deps_index(index):
+    with open(DEPS_INDEX_PATH, "w", encoding="utf-8") as f:
+        yaml.dump(index, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+
+# ── METADATA parsing ────────────────────────────────────────────────────
+
+
+_REQUIRES_DIST_RE = re.compile(r"^Requires-Dist:\s*(.+)$", re.IGNORECASE)
+_NAME_RE = re.compile(r"^([A-Za-z0-9_.-]+)")
+
+
+def parse_requires_dist(metadata_text: str) -> list[dict]:
+    """Return list of {raw, name, extra} for each Requires-Dist line."""
+    results = []
+    for line in metadata_text.splitlines():
+        m = _REQUIRES_DIST_RE.match(line)
+        if not m:
+            continue
+        raw = m.group(1).strip()
+        name_match = _NAME_RE.match(raw)
+        name = name_match.group(1) if name_match else raw
+        # Detect extras marker e.g. humming-kernels[cu13]==0.1.10
+        extra = None
+        em = re.match(r"^[^[]+\[([^\]]+)\]", raw)
+        if em:
+            extra = em.group(1)
+        results.append({"raw": raw, "name": name, "extra": extra})
+    return results
+
+
+def _normalize(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _strip_requires_dist_lines(metadata_text: str, names_to_remove: set[str]) -> str:
+    """Remove lines whose package name (case-insensitive, normalised) is in the set."""
+    keep: list[str] = []
+    for line in metadata_text.splitlines():
+        m = _REQUIRES_DIST_RE.match(line)
+        if m:
+            name = _NAME_RE.match(m.group(1).strip())
+            if name and _normalize(name.group(1)) in names_to_remove:
+                continue
+        keep.append(line)
+    return "\n".join(keep) + "\n"
+
+
+_METADATA_VERSION_RE = re.compile(r"^Metadata-Version:\s*.+$", re.MULTILINE | re.IGNORECASE)
+_LICENSE_EXPRESSION_RE = re.compile(r"^License-Expression:\s*.+$", re.MULTILINE | re.IGNORECASE)
+_LICENSE_FILE_RE = re.compile(r"^License-File:\s*.+$", re.MULTILINE | re.IGNORECASE)
+_DYNAMIC_RE = re.compile(r"^Dynamic:\s*.+$", re.MULTILINE | re.IGNORECASE)
+
+
+def _downgrade_metadata_version(text: str) -> str:
+    """Rewrite Metadata-Version 2.4 → 2.2, converting 2.4-only fields.
+
+    Core Metadata 2.4 (PEP 639) introduced License-Expression and License-File,
+    and bumped the Dynamic list. Nexus rejects 2.4 wheels, so we downgrade to
+    2.2 by rewriting the version line and converting license fields.
+    """
+    # Check if already 2.2 or earlier
+    m = re.search(r"^Metadata-Version:\s*([\d.]+)", text, re.MULTILINE | re.IGNORECASE)
+    if not m:
+        return text
+    ver = m.group(1)
+    if float(ver) < 2.3:
+        return text  # already 2.2 or older — nothing to do
+
+    # Extract License-Expression value (we'll convert it to License:)
+    license_text = None
+    mle = re.search(r"^License-Expression:\s*(.+)$", text, re.MULTILINE | re.IGNORECASE)
+    if mle:
+        license_text = mle.group(1).strip()
+
+    # 1. Rewrite Metadata-Version
+    text = _METADATA_VERSION_RE.sub("Metadata-Version: 2.2", text)
+
+    # 2. Replace License-Expression with License (2.2 format)
+    if license_text:
+        text = _LICENSE_EXPRESSION_RE.sub(f"License: {license_text}", text)
+
+    # 3. Remove License-File (not supported in 2.2)
+    text = _LICENSE_FILE_RE.sub("", text)
+
+    # 4. Remove Dynamic fields (2.2 Dynamic list is incomplete for 2.4-made wheels)
+    text = _DYNAMIC_RE.sub("", text)
+
+    # 5. Collapse multiple blank lines
+    text = re.sub(r"\n{3,}", "\n\n", text)
+
+    return text
+
+
+def _extract_name_version(requires_dist_line: str):
+    """Return (name, version_spec) from a raw Requires-Dist string."""
+    m = _NAME_RE.match(requires_dist_line)
+    name = m.group(1).strip() if m else requires_dist_line
+    version_spec = requires_dist_line[len(name):].strip()
+    if version_spec.startswith(";"):
+        name_and_extra = name
+        rest = version_spec
+        version_spec = ""
+        # marker-only: e.g. "apache-tvm-ffi==0.1.9; platform ..."
+        # The semicolon starts the marker; version is before it if present.
+        semicolon = name_and_extra.find(";")
+        if semicolon != -1:
+            name = name_and_extra[:semicolon].strip()
+            rest = name_and_extra[semicolon:]
+    return name, version_spec
+
+
+# ── classification ─────────────────────────────────────────────────────
+
+
+def classify(rd: dict, config: dict):
+    """Return one of: 'torch_chain', 'cuda_only', 'orphaned', 'repack', 'keep'."""
+    nn = _normalize(rd["name"])
+    for item in config.get("remove_torch_chain", []):
+        if _normalize(item) == nn:
+            return "torch_chain"
+    for item in config.get("remove_cuda_only", []):
+        if _normalize(item) == nn:
+            return "cuda_only"
+    for item in config.get("remove_orphaned", []):
+        if _normalize(item) == nn:
+            return "orphaned"
+    for item in config.get("also_repack", []):
+        if _normalize(item) == nn:
+            return "repack"
+    return "keep"
+
+
+# ── wheel I/O ──────────────────────────────────────────────────────────
+
+
+def read_wheel_metadata(whl_path: Path) -> tuple[str, str]:
+    """Return (metadata_text, dist_info_dir_name)."""
+    with zipfile.ZipFile(whl_path) as z:
+        for name in z.namelist():
+            if name.endswith(".dist-info/METADATA"):
+                return z.read(name).decode("utf-8"), name.split("/")[0]
+    raise ValueError(f"No .dist-info/METADATA found in {whl_path}")
+
+
+def rewrite_wheel(src: Path, dst: Path, metadata_text: str, dist_info_dir: str):
+    """Copy src → dst, replacing METADATA content."""
+    with zipfile.ZipFile(src) as zin:
+        with zipfile.ZipFile(dst, "w", zipfile.ZIP_DEFLATED) as zout:
+            for item in zin.infolist():
+                data = zin.read(item.filename)
+                if item.filename == f"{dist_info_dir}/METADATA":
+                    zout.writestr(item, metadata_text)
+                else:
+                    zout.writestr(item, data)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def wheel_name_to_filename(name: str, version: str) -> str:
+    """Convert package name + version to a wheel filename.
+    Since we only replace METADATA we reuse the original (correct) tag."""
+    safe_name = re.sub(r"[-_.]+", "_", name)
+    return f"{safe_name}-{version}-py3-none-any.whl"
+
+
+# ── indirect dep repacking ─────────────────────────────────────────────
+
+
+def resolve_wheel(name: str, version_spec: str, extra_indexes: list[str]) -> Path:
+    """Download a wheel from PyPI (or extra indexes) via 'uv pip download'.
+    Returns path to downloaded .whl file.
+    """
+    if version_spec:
+        spec = f"{name}{version_spec}"
+    else:
+        spec = name
+    with tempfile.TemporaryDirectory() as td:
+        cmd = [
+            "uv", "pip", "download",
+            "--no-deps",
+            "--dest", td,
+            "--index-url", "https://pypi.org/simple/",
+        ]
+        for ei in extra_indexes:
+            cmd.extend(["--extra-index-url", ei])
+        cmd.append(spec)
+        subprocess.run(cmd, check=True, capture_output=True)
+        whls = list(Path(td).glob("*.whl"))
+        if not whls:
+            raise RuntimeError(f"uv pip download {spec} produced no wheel files")
+        # Move to cache so it persists
+        dst = CACHE_DIR / whls[0].name
+        shutil.move(str(whls[0]), dst)
+        return dst
+
+
+def repack_indirect(name: str, version_spec: str, extra_indexes: list[str],
+                    deps_index: dict, config: dict):
+    """Download and repack an indirect dep wheel.  Returns (cache_whl_path, manifest_path)."""
+    # Resolve to exact version via index lookup
+    with tempfile.TemporaryDirectory() as td:
+        cmd = [
+            "uv", "pip", "compile",
+            "--no-deps",
+            "--no-annotate",
+            "--no-header",
+            "--index-url", "https://pypi.org/simple/",
+        ]
+        for ei in extra_indexes:
+            cmd.extend(["--extra-index-url", ei])
+        if version_spec:
+            cmd.append(f"{name}{version_spec}")
+        else:
+            cmd.append(name)
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        spec_line = None
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and not line.startswith("-"):
+                spec_line = line
+                break
+        if not spec_line:
+            raise RuntimeError(f"uv pip compile could not resolve {name}{version_spec}")
+        # spec_line looks like "xgrammar==0.2.3"
+        pkg_name, _, pkg_version = spec_line.partition("==")
+        if not pkg_version:
+            pkg_name, _, pkg_version = spec_line.partition(">=")
+        resolved_version = pkg_version.strip()
+
+    key = f"{_normalize(pkg_name)}-{resolved_version}"
+
+    # Already processed?
+    if key in deps_index:
+        cached = deps_index[key]
+        cache_whl = CACHE_DIR / cached["whl"]
+        manifest = CACHE_DIR / cached["manifest"]
+        if cache_whl.exists() and manifest.exists():
+            print(f"  (cached) {key}")
+            return cache_whl, manifest
+
+    print(f"  processing {key} ...")
+
+    # Download original wheel
+    wheel_path = resolve_wheel(pkg_name, f"=={resolved_version}", extra_indexes)
+
+    # Read its METADATA
+    meta_text, dist_info_dir = read_wheel_metadata(wheel_path)
+    all_rd = parse_requires_dist(meta_text)
+
+    # Classify & record
+    removed = []
+    for rd in all_rd:
+        nn = _normalize(rd["name"])
+        if nn in {_normalize(x) for x in config.get("strip_from_repacked", [])}:
+            removed.append(rd)
+            print(f"    strip {rd['raw']}")
+
+    # Write manifest
+    manifest_path = CACHE_DIR / f"{_normalize(pkg_name)}-{resolved_version}.deps-manifest.yaml"
+    manifest_data = {
+        "source_wheel": wheel_path.name,
+        "source_sha256": sha256_file(wheel_path),
+        "package": pkg_name,
+        "version": resolved_version,
+        "modified_at": datetime.now(timezone.utc).isoformat(),
+        "all_requires_dist": [rd["raw"] for rd in all_rd],
+        "removed": [rd["raw"] for rd in removed],
+    }
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        yaml.dump(manifest_data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+    # Strip & rewrite
+    strip_names = {_normalize(x) for x in config.get("strip_from_repacked", [])}
+    new_meta = _strip_requires_dist_lines(meta_text, strip_names)
+    new_meta = _downgrade_metadata_version(new_meta)
+    output_name = wheel_name_to_filename(pkg_name, resolved_version)
+    output_path = CACHE_DIR / output_name
+    rewrite_wheel(wheel_path, output_path, new_meta, dist_info_dir)
+
+    # Don't keep original — was only needed for METADATA extraction
+    wheel_path.unlink()
+
+    # Register
+    deps_index[key] = {
+        "whl": output_path.name,
+        "manifest": manifest_path.name,
+    }
+    save_deps_index(deps_index)
+
+    return output_path, manifest_path
+
+
+# ── main repack ────────────────────────────────────────────────────────
+
+
+def repack_top_level(whl_path: Path, extra_indexes: list[str]):
+    config = load_config()
+    ensure_dirs()
+    deps_index = load_deps_index()
+
+    print(f"Repacking: {whl_path.name}")
+
+    # 1. Read METADATA
+    meta_text, dist_info_dir = read_wheel_metadata(whl_path)
+    all_rd = parse_requires_dist(meta_text)
+
+    # 2. Classify every Requires-Dist
+    removed: dict[str, list[str]] = {"torch_chain": [], "cuda_only": [], "orphaned": []}
+    repack_targets: list[dict] = []
+    retained: list[str] = []
+
+    for rd in all_rd:
+        cat = classify(rd, config)
+        if cat in ("torch_chain", "cuda_only", "orphaned"):
+            removed[cat].append(rd["raw"])
+        elif cat == "repack":
+            repack_targets.append(rd)
+            removed.setdefault("repack", []).append(rd["raw"])
+        else:
+            retained.append(rd["raw"])
+
+    print(f"  keep:     {len(retained)}")
+    for cat in ("torch_chain", "cuda_only", "orphaned", "repack"):
+        if removed[cat]:
+            print(f"  {cat}: {len(removed[cat])}")
+
+    # 3. Repack indirect deps (also_repack)
+    repacked_refs: list[dict] = []
+    for rd in repack_targets:
+        name, version_spec = _extract_name_version(rd["raw"])
+        cache_whl, manifest = repack_indirect(
+            name, version_spec, extra_indexes, deps_index, config
+        )
+        repacked_refs.append({
+            "original": rd["raw"],
+            "repacked": str(cache_whl.relative_to(SCRIPT_DIR)),
+            "manifest": str(manifest.relative_to(SCRIPT_DIR)),
+        })
+
+    # 4. Write top-level manifest
+    pkg_name = None
+    pkg_version = None
+    mvn = re.search(r"^Name:\s*(.+)$", meta_text, re.MULTILINE | re.IGNORECASE)
+    mvv = re.search(r"^Version:\s*(.+)$", meta_text, re.MULTILINE | re.IGNORECASE)
+    if mvn:
+        pkg_name = mvn.group(1).strip()
+    if mvv:
+        pkg_version = mvv.group(1).strip()
+
+    manifest_path = OUTPUT_DIR / f"{_normalize(pkg_name or 'unknown')}-{pkg_version or 'unknown'}.deps-manifest.yaml"
+    manifest_data = {
+        "source_wheel": whl_path.name,
+        "source_sha256": sha256_file(whl_path),
+        "package": pkg_name,
+        "version": pkg_version,
+        "modified_at": datetime.now(timezone.utc).isoformat(),
+        "removed": {k: v for k, v in removed.items() if v},
+        "repacked_deps": repacked_refs,
+        "retained": retained,
+    }
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        yaml.dump(manifest_data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+    # 5. Strip & rewrite top-level wheel
+    names_to_remove: set[str] = set()
+    for cat in ("torch_chain", "cuda_only", "orphaned", "repack"):
+        for rd_raw in removed.get(cat, []):
+            nm = _NAME_RE.match(rd_raw)
+            if nm:
+                names_to_remove.add(_normalize(nm.group(1)))
+
+    new_meta = _strip_requires_dist_lines(meta_text, names_to_remove)
+    new_meta = _downgrade_metadata_version(new_meta)
+    output_name = wheel_name_to_filename(pkg_name or "package", pkg_version or "0.0.0")
+    output_path = OUTPUT_DIR / output_name
+    rewrite_wheel(whl_path, output_path, new_meta, dist_info_dir)
+
+    print(f"\nDone:")
+    print(f"  wheel:    {output_path}")
+    print(f"  manifest: {manifest_path}")
+    if repacked_refs:
+        print(f"  indirect: {len(repacked_refs)} repacked → cache/")
+
+    return output_path, manifest_path
+
+
+# ── CLI ────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Repack a Python wheel, stripping unwanted Requires-Dist entries."
+    )
+    parser.add_argument(
+        "wheel",
+        help="Path to .whl file to repack.",
+    )
+    parser.add_argument(
+        "--extra-index",
+        action="append",
+        default=[],
+        dest="extra_indexes",
+        help="Additional PyPI index for resolving indirect dependencies.",
+    )
+    args = parser.parse_args()
+
+    whl_path = Path(args.wheel).resolve()
+    if not whl_path.exists():
+        print(f"Error: {whl_path} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    repack_top_level(whl_path, args.extra_indexes)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

For vendor platforms that ship their own PyTorch (Ascend, MetaX, Iluvatar, etc.), installing vllm pulls in a stock `torch` + `triton` chain as a transitive dependency. This PR adds a tool that rewrites a wheel's METADATA to strip those dependencies, recording every change in a `.deps-manifest.yaml` for full traceability.

## Files

| File | Purpose |
|------|---------|
| `wheel-repack/config.yaml` | Classification rules — which packages pull torch/triton, are CUDA-only, or are indirect deps that need their own METADATA patched |
| `wheel-repack/repack.py` | Reads METADATA, classifies every `Requires-Dist` line, downloads & patches indirect-dependency wheels (cached in `cache/`), writes manifests, repacks the wheel into `output/` |

## Usage (on ix15 or any target node)

```bash
cd wheel-repack
python repack.py /path/to/vllm-0.25.1-xxx.whl --extra-index https://resource.flagos.net/...
```

Produces:
- `output/vllm-0.25.1-py3-none-any.whl` — cleaned wheel
- `output/vllm-0.25.1.deps-manifest.yaml` — full audit trail
- `cache/xgrammar-0.2.3-*.whl` — patched indirect deps (one per version, never re-processed)

## Design

- Config-driven — adding a new package or vllm version only needs `config.yaml` edits
- Idempotent — `deps-index.yaml` tracks already-processed packages, same version never repacked twice
- Manifest per wheel — original `Requires-Dist` lines, which were removed, which indirect deps were repacked

This PR was written in part with the assistance of generative AI.