### PR TITLE
feat: add cmake to ascend base, pybind11+ninja to runtime

### DIFF
--- a/base/ascend-cann8.5.0
+++ b/base/ascend-cann8.5.0
@@ -50,7 +50,7 @@ RUN sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://mirrors.aliyun.com/ubu
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update && apt-get install -y --no-install-recommends \
         curl unzip net-tools pciutils \
-        gcc g++ build-essential make \
+        gcc g++ build-essential make cmake \
         python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python3-pip \
         libelf1 \
         libpython3-dev \

--- a/base/ascend-cann9.0.0
+++ b/base/ascend-cann9.0.0
@@ -51,7 +51,7 @@ RUN sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://mirrors.aliyun.com/ubu
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update && apt-get install -y --no-install-recommends \
         curl unzip net-tools pciutils \
-        gcc g++ build-essential make \
+        gcc g++ build-essential make cmake \
         python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python3-pip \
         libelf1 \
         libpython3-dev \

--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -93,6 +93,19 @@ RUN if [ -n "${DEPS}" ]; then \
       done; \
     fi
 
+# ── Install runtime packages (former build deps) ───────────────
+# pybind11 is a runtime dependency of flagtree (ascend backend,
+# triton/backends/ascend/utils.py imports it). ninja is needed for
+# C++ extension builds. Versions pinned to match flaggems_cpp_build_deps.
+# These are standard PyPI packages, not vendor-specific — use mirror.
+RUN for pkg in pybind11==3.0.3 ninja==1.13.0; do \
+      for i in 1 2 3; do \
+        uv pip install --no-cache-dir "$pkg" \
+          --index ${EXTRA_PYPI} && break; \
+        echo "$pkg install attempt $i failed, retrying..."; \
+      done; \
+    done
+
 # ── Install FlagTree (default compiler, if configured) ──────────
 # FlagTree installs to site-packages/triton/ — it's the default import.
 RUN if [ -n "${FLAGTREE_PKG}" ]; then \


### PR DESCRIPTION
## What

| File | Change |
|---|---|
| `base/ascend-cann8.5.0` | Add `cmake` to apt install |
| `base/ascend-cann9.0.0` | Add `cmake` to apt install |
| `runtime/Containerfile` | Install `pybind11==3.0.3` + `ninja==1.13.0` from mirror |

## Why

- **cmake**: ascend base images were missing native cmake (all other backends have
  it via `apt install cmake`). Needed for C++ extension builds inside the
  runtime container.
- **pybind11**: runtime dependency of flagtree ascend backend —
  `triton/backends/ascend/utils.py:33` does `import pybind11` at module load.
  Without it, `import triton` fails on ascend runtimes. Full-fleet verification
  confirmed this only affects ascend — other backends do not import pybind11.
- **ninja**: needed alongside cmake for C++ extension builds. Standard PyPI
  package, tiny (~100K), harmless on all backends.

## Verification

- Full `compiler` check on all 14 backends (on their respective runners)
  confirmed pybind11 is only needed by ascend × 2.
- All other backends (nvidia, kunlunxin, metax, mthreads × 2, sunrise, enflame,
  iluvatar, cambricon, tsingmicro, hygon) work without it.

## Not changed

`configs.yaml` `flaggems_cpp_build_deps` keeps pybind11 and ninja — re-installing them during C++ wheel builds is harmless.

This PR was written in part with the assistance of generative AI.