### PR TITLE
fix(base): tsingmicro libfmt8 + enflame triton_gcu symlink

### DIFF
--- a/base/enflame-tops1.9.10
+++ b/base/enflame-tops1.9.10
@@ -52,3 +52,7 @@ RUN curl -fsSL -O ${FILE_STORE}/topsruntime_1.9.10-1_amd64.deb \
     && dpkg -i *.deb || true \
     && apt-get install -yf 2>/dev/null || true \
     && rm -f *.deb
+
+# flagtree toolkit.py expects /opt/triton_gcu but triton-gcu deb
+# installs to /opt/triton/triton_gcu.
+RUN ln -sf /opt/triton/triton_gcu /opt/triton_gcu

--- a/base/tsingmicro-tsm260604
+++ b/base/tsingmicro-tsm260604
@@ -31,17 +31,25 @@ ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/tsingmicr
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# libfmt, libunwind8, libopenmpi3 are depdencies for torch_txda;
-# clang is dendency from triton;
+# libunwind8, libopenmpi3 are depdencies for torch_txda;
+# clang is dependency from triton;
+# libfmt8 (22.04) — torch_txda links libfmt.so.8; 24.04 ships libfmt.so.9;
 # sudo is hardcoded dependency from TSM installers.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl git vim ca-certificates \
       gcc g++ build-essential cmake clang \
       libopenmpi3 sudo \
-      libfmt-dev libunwind8 \
+      libunwind8 \
       libpython3-dev \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
+
+# torch_txda links libfmt.so.8; Ubuntu 24.04 only ships libfmt.so.9.
+# Install the 22.04 package from filestore (59K, no conflict with libfmt9).
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /tmp/libfmt8.deb ${FILE_STORE}/libfmt8_8.1.1+ds1-2_amd64.deb \
+    && dpkg -i /tmp/libfmt8.deb \
+    && rm /tmp/libfmt8.deb
 
 # ── TsingMicro Runtime packages ───────────────────────────────────
 ENV PACKAGE_NAME="Tsm_validation_suite Tsm_runtime Tsm_ccl Tsm_profiler"


### PR DESCRIPTION
## What

| File | Change |
|---|---|
| `base/tsingmicro-tsm260604` | Replace `libfmt-dev` (→ libfmt.so.9) with `libfmt8` (→ libfmt.so.8) from filestore |
| `base/enflame-tops1.9.10` | Add `ln -sf /opt/triton/triton_gcu /opt/triton_gcu` after triton-gcu deb install |

## Why

- **tsingmicro**: `torch_txda` was compiled against libfmt.so.8 (Ubuntu 22.04). After
  the 22.04→24.04 migration only libfmt.so.9 is available → `ImportError: libfmt.so.8`
- **enflame**: flagtree `toolkit.py` hardcodes `/opt/triton_gcu` but the vendor
  `triton-gcu` deb installs to `/opt/triton/triton_gcu` → `Exception: Cannot find
  data directory in /opt/triton_gcu`

Both caught during 2026-07-24 full-fleet runtime:v2 verification.

This PR was written in part with the assistance of generative AI.