### PR TITLE
fix(docs): extract dpkg-installed .deb packages in gen_data.py

### DIFF
--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -146,6 +146,15 @@ def parse_containerfile(path: Path, extra_vars: dict | None = None) -> dict:
                 if re.fullmatch(r"[a-z0-9][a-z0-9+.:-]*", tok):
                     system_packages.append(tok)
 
+        # dpkg-installed .deb packages: extract Debian source package names
+        # from .deb filenames (name_version_arch.deb or name-version_arch.deb)
+        # appearing in curl / ENV / dpkg lines. Catches packages that aren't in
+        # apt-get install lines.
+        for dm in re.finditer(
+            r'\b([a-z][a-z0-9+.-]*?)[_-]\d[^ ]*\.deb\b', st
+        ):
+            system_packages.append(_resolve(dm.group(1), varmap))
+
     return {
         "base_os": base_os,
         "labels": labels,


### PR DESCRIPTION
## What

`gen_data.py` now extracts package names from `.deb` filenames in Containerfile
lines, not just from `apt-get install` lines.

## Why

The old code only parsed `apt-get install ...` lines for system package names.
Packages installed via `curl + dpkg -i *.deb` were invisible to the description
generator, causing them to be omitted from generated docs.

This was spotted during review of [#185](https://github.com/flagos-ai/build-infra/pull/185/files):

| Backend | Missing packages |
|---|---|
| tsingmicro | `libfmt8` |
| cambricon | `cnlicense`, `cndev`, `cnbin`, `cndrv`, `cnrt`, ... (20+ packages) |
| enflame | `topsruntime`, `topscc`, `efml`, `triton-gcu`, `topstx`, ... |
| kunlunxin | `xcudart` |

## Verification

```python
# All four affected backends now include .deb packages:
for name in [tsingmicro, cambricon, enflame, kunlunxin]:
    meta = parse_containerfile(Path(f"base/{name}"))
```

- tsingmicro: `libfmt8` now listed (was missing)
- cambricon: all 20+ SDK packages listed (were missing)
- enflame: all 7 SDK packages listed (were missing)
- kunlunxin: `xcudart` listed (was missing)
- hygon: no change (no .deb packages)

## Post-merge

After merging, trigger `base-descriptions` workflow for the affected backends
to regenerate descriptions with the newly discovered packages.

This PR was written in part with the assistance of generative AI.