### PR TITLE
fix(base): wrap hygon vendor.sh capture in bash -c

### DIFF
--- a/base/hygon-dtk26.04
+++ b/base/hygon-dtk26.04
@@ -52,16 +52,16 @@ RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /dtk.tar.gz ${FILE_STOR
 # Users and downstream Dockerfiles no longer need to source env.sh —
 # the vendor env loads automatically in login, non-login interactive,
 # and non-interactive shells (via runtime's profile.d plumbing).
-RUN env_before=$(env | sort) && \
+RUN bash -c 'env_before=$(env | sort) && \
     set -a && . /opt/dtk-26.04/env.sh > /dev/null 2>&1 || true && set +a && \
     env_after=$(env | sort) && \
-    printf '%s\n' "$env_before" > /tmp/_v_before && \
-    printf '%s\n' "$env_after" > /tmp/_v_after && \
+    printf "%s\n" "$env_before" > /tmp/_v_before && \
+    printf "%s\n" "$env_after" > /tmp/_v_after && \
     comm -13 /tmp/_v_before /tmp/_v_after \
-      | grep -v '^_\|^PWD=\|^SHLVL=\|^OLDPWD=' \
-      | while IFS='=' read -r var val; do \
-          printf 'export %s="%s"\n' "$var" "$val"; \
+      | grep -v "^_\|^PWD=\|^SHLVL=\|^OLDPWD=" \
+      | while IFS="=" read -r var val; do \
+          printf "export %s=\"%s\"\n" "$var" "$val"; \
         done \
       > /etc/profile.d/vendor.sh && \
     rm -f /tmp/_v_before /tmp/_v_after && \
-    echo "vendor.sh: captured $(wc -l < /etc/profile.d/vendor.sh) env vars"
+    echo "vendor.sh: captured $(wc -l < /etc/profile.d/vendor.sh) env vars'


### PR DESCRIPTION
 → dash on Ubuntu.  uses  which doesn't work in dash. DTKROOT resolved to / causing  not found when switching to triton.