### PR TITLE
docs(base): refresh image descriptions for 2.1.1

### DIFF
--- a/base/cambricon-neuware4.4.3.md
+++ b/base/cambricon-neuware4.4.3.md
@@ -17,6 +17,29 @@ Explicitly installed; the version is the one baked into this image:
 - `build-essential` — 12.10ubuntu1
 - `ca-certificates` — 20260601~24.04.1
 - `cmake` — 3.28.3
+- `cnas` — 5.4.3
+- `cnbin` — 2.4.2
+- `cncc` — 5.4.3
+- `cncl` — 1.29.4
+- `cnclep` — 1.1.1
+- `cncodec3` — 2.4.1
+- `cndev` — 6.5.25
+- `cndev-compat` — 6.5.25
+- `cndrv` — 3.4.3
+- `cngdb` — 4.4.2
+- `cnjpeg` — 0.5.1
+- `cnlicense` — 1.2.0
+- `cnnl` — 2.1.829
+- `cnnlextra` — 2.2.7
+- `cnpapi` — 4.4.2
+- `cnperf`
+- `cnpx` — 1.6.0
+- `cnrt` — 7.4.0
+- `cnrtc` — 0.7.4
+- `cnsanitizer` — 0.12.3
+- `cnstudio` — 1.2.1
+- `cntoolkit` — 4.4.3
+- `cntoolkit-cloud`
 - `curl` — 8.5.0
 - `g++` — 13.2.0
 - `gcc` — 13.2.0
@@ -26,6 +49,7 @@ Explicitly installed; the version is the one baked into this image:
 - `libncurses6` — 6.4+20240113
 - `libtinfo6` — 6.4+20240113
 - `make` — 4.3
+- `mluops` — 1.8.1
 - `pciutils` — 3.10.0
 - `unzip` — 6.0
 - `vim` — 9.1.0016

--- a/base/enflame-tops1.9.10.md
+++ b/base/enflame-tops1.9.10.md
@@ -19,9 +19,18 @@ Explicitly installed; the version is the one baked into this image:
 - `ca-certificates` — 20260601~24.04.1
 - `cmake` — 3.28.3
 - `curl` — 8.5.0
+- `eccl` — 3.6.3.11
+- `efml` — 1.9.10
 - `g++` — 13.2.0
 - `gcc` — 13.2.0
+- `gculare-perftest` — 1.9.10
 - `git` — 2.43.0
+- `topsaten` — 3.7.20260514
+- `topscc` — 1.9.10
+- `topspti` — 1.9.10
+- `topsruntime` — 1.9.10
+- `topstx` — 1.9.10
+- `triton-gcu`
 - `vim` — 9.1.0016
 
 ### SDK components

--- a/base/kunlunxin-xre5.29.0.md
+++ b/base/kunlunxin-xre5.29.0.md
@@ -25,6 +25,7 @@ Explicitly installed; the version is the one baked into this image:
 - `kmod` — 31+20240202
 - `pciutils` — 3.10.0
 - `vim` — 9.1.0016
+- `xcudart` — 0.0.1
 
 ### SDK components
 

--- a/base/tsingmicro-tsm260604.md
+++ b/base/tsingmicro-tsm260604.md
@@ -23,7 +23,7 @@ Explicitly installed; the version is the one baked into this image:
 - `g++` — 13.2.0
 - `gcc` — 13.2.0
 - `git` — 2.43.0
-- `libfmt-dev` — 9.1.0+ds1
+- `libfmt8` — 8.1.1+ds1
 - `libopenmpi3`
 - `libpython3-dev` — 3.12.3
 - `libunwind8` — 1.6.2

--- a/docs/content/en/base/cambricon-neuware4.4.3.md
+++ b/docs/content/en/base/cambricon-neuware4.4.3.md
@@ -37,6 +37,29 @@ Explicitly installed; the version is the one baked into this image:
 - `build-essential` — 12.10ubuntu1
 - `ca-certificates` — 20260601~24.04.1
 - `cmake` — 3.28.3
+- `cnas` — 5.4.3
+- `cnbin` — 2.4.2
+- `cncc` — 5.4.3
+- `cncl` — 1.29.4
+- `cnclep` — 1.1.1
+- `cncodec3` — 2.4.1
+- `cndev` — 6.5.25
+- `cndev-compat` — 6.5.25
+- `cndrv` — 3.4.3
+- `cngdb` — 4.4.2
+- `cnjpeg` — 0.5.1
+- `cnlicense` — 1.2.0
+- `cnnl` — 2.1.829
+- `cnnlextra` — 2.2.7
+- `cnpapi` — 4.4.2
+- `cnperf`
+- `cnpx` — 1.6.0
+- `cnrt` — 7.4.0
+- `cnrtc` — 0.7.4
+- `cnsanitizer` — 0.12.3
+- `cnstudio` — 1.2.1
+- `cntoolkit` — 4.4.3
+- `cntoolkit-cloud`
 - `curl` — 8.5.0
 - `g++` — 13.2.0
 - `gcc` — 13.2.0
@@ -46,6 +69,7 @@ Explicitly installed; the version is the one baked into this image:
 - `libncurses6` — 6.4+20240113
 - `libtinfo6` — 6.4+20240113
 - `make` — 4.3
+- `mluops` — 1.8.1
 - `pciutils` — 3.10.0
 - `unzip` — 6.0
 - `vim` — 9.1.0016

--- a/docs/content/en/base/enflame-tops1.9.10.md
+++ b/docs/content/en/base/enflame-tops1.9.10.md
@@ -39,9 +39,18 @@ Explicitly installed; the version is the one baked into this image:
 - `ca-certificates` — 20260601~24.04.1
 - `cmake` — 3.28.3
 - `curl` — 8.5.0
+- `eccl` — 3.6.3.11
+- `efml` — 1.9.10
 - `g++` — 13.2.0
 - `gcc` — 13.2.0
+- `gculare-perftest` — 1.9.10
 - `git` — 2.43.0
+- `topsaten` — 3.7.20260514
+- `topscc` — 1.9.10
+- `topspti` — 1.9.10
+- `topsruntime` — 1.9.10
+- `topstx` — 1.9.10
+- `triton-gcu`
 - `vim` — 9.1.0016
 
 ### SDK components

--- a/docs/content/en/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/base/kunlunxin-xre5.29.0.md
@@ -45,6 +45,7 @@ Explicitly installed; the version is the one baked into this image:
 - `kmod` — 31+20240202
 - `pciutils` — 3.10.0
 - `vim` — 9.1.0016
+- `xcudart` — 0.0.1
 
 ### SDK components
 

--- a/docs/content/en/base/tsingmicro-tsm260604.md
+++ b/docs/content/en/base/tsingmicro-tsm260604.md
@@ -43,7 +43,7 @@ Explicitly installed; the version is the one baked into this image:
 - `g++` — 13.2.0
 - `gcc` — 13.2.0
 - `git` — 2.43.0
-- `libfmt-dev` — 9.1.0+ds1
+- `libfmt8` — 8.1.1+ds1
 - `libopenmpi3`
 - `libpython3-dev` — 3.12.3
 - `libunwind8` — 1.6.2

--- a/docs/content/zh-cn/base/cambricon-neuware4.4.3.md
+++ b/docs/content/zh-cn/base/cambricon-neuware4.4.3.md
@@ -37,6 +37,29 @@ title: "cambricon-neuware4.4.3"
 - `build-essential` — 12.10ubuntu1
 - `ca-certificates` — 20260601~24.04.1
 - `cmake` — 3.28.3
+- `cnas` — 5.4.3
+- `cnbin` — 2.4.2
+- `cncc` — 5.4.3
+- `cncl` — 1.29.4
+- `cnclep` — 1.1.1
+- `cncodec3` — 2.4.1
+- `cndev` — 6.5.25
+- `cndev-compat` — 6.5.25
+- `cndrv` — 3.4.3
+- `cngdb` — 4.4.2
+- `cnjpeg` — 0.5.1
+- `cnlicense` — 1.2.0
+- `cnnl` — 2.1.829
+- `cnnlextra` — 2.2.7
+- `cnpapi` — 4.4.2
+- `cnperf`
+- `cnpx` — 1.6.0
+- `cnrt` — 7.4.0
+- `cnrtc` — 0.7.4
+- `cnsanitizer` — 0.12.3
+- `cnstudio` — 1.2.1
+- `cntoolkit` — 4.4.3
+- `cntoolkit-cloud`
 - `curl` — 8.5.0
 - `g++` — 13.2.0
 - `gcc` — 13.2.0
@@ -46,6 +69,7 @@ title: "cambricon-neuware4.4.3"
 - `libncurses6` — 6.4+20240113
 - `libtinfo6` — 6.4+20240113
 - `make` — 4.3
+- `mluops` — 1.8.1
 - `pciutils` — 3.10.0
 - `unzip` — 6.0
 - `vim` — 9.1.0016

--- a/docs/content/zh-cn/base/enflame-tops1.9.10.md
+++ b/docs/content/zh-cn/base/enflame-tops1.9.10.md
@@ -39,9 +39,18 @@ title: "enflame-tops1.9.10"
 - `ca-certificates` — 20260601~24.04.1
 - `cmake` — 3.28.3
 - `curl` — 8.5.0
+- `eccl` — 3.6.3.11
+- `efml` — 1.9.10
 - `g++` — 13.2.0
 - `gcc` — 13.2.0
+- `gculare-perftest` — 1.9.10
 - `git` — 2.43.0
+- `topsaten` — 3.7.20260514
+- `topscc` — 1.9.10
+- `topspti` — 1.9.10
+- `topsruntime` — 1.9.10
+- `topstx` — 1.9.10
+- `triton-gcu`
 - `vim` — 9.1.0016
 
 ### SDK 组件

--- a/docs/content/zh-cn/base/kunlunxin-xre5.29.0.md
+++ b/docs/content/zh-cn/base/kunlunxin-xre5.29.0.md
@@ -45,6 +45,7 @@ title: "kunlunxin-xre5.29.0"
 - `kmod` — 31+20240202
 - `pciutils` — 3.10.0
 - `vim` — 9.1.0016
+- `xcudart` — 0.0.1
 
 ### SDK 组件
 

--- a/docs/content/zh-cn/base/tsingmicro-tsm260604.md
+++ b/docs/content/zh-cn/base/tsingmicro-tsm260604.md
@@ -43,7 +43,7 @@ title: "tsingmicro-tsm260604"
 - `g++` — 13.2.0
 - `gcc` — 13.2.0
 - `git` — 2.43.0
-- `libfmt-dev` — 9.1.0+ds1
+- `libfmt8` — 8.1.1+ds1
 - `libopenmpi3`
 - `libpython3-dev` — 3.12.3
 - `libunwind8` — 1.6.2


### PR DESCRIPTION
Auto-generated base image descriptions update.

- cambricon-neuware4.4.3: new sections
- enflame-tops1.9.10: updated
- hygon-dtk26.04: removed sections
- kunlunxin-xre5.29.0: updated
- tsingmicro-tsm260604: updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)