### PR TITLE
fix(docs): separate SDK dpkg packages from system packages in descriptions

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -445,6 +445,11 @@ vendors:
       python: "3.10"
       triton: triton==3.3.0+gitfe2a28fa
       flagtree: flagtree==0.5.0.post20260612+git705a4064
+      system_dpkg:
+        # libfmt8 is a system-level dependency for torch_txda (links
+        # libfmt.so.8). Ubuntu 24.04 ships libfmt9, so we install the
+        # 22.04 .deb via dpkg. It is NOT an SDK component.
+        - libfmt8
       env:
         base:
           KUIPER_PATH: /usr/local/kuiper

--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -152,15 +152,6 @@ def parse_containerfile(path: Path, extra_vars: dict | None = None) -> dict:
                 if re.fullmatch(r"[a-z0-9][a-z0-9+.:-]*", tok):
                     system_packages.append(tok)
 
-        # dpkg-installed .deb packages: extract Debian source package names
-        # from .deb filenames (name_version_arch.deb or name-version_arch.deb)
-        # appearing in curl / ENV / dpkg lines. Catches packages that aren't in
-        # apt-get install lines.
-        for dm in re.finditer(
-            r'\b([a-z][a-z0-9+.-]*?)[_-]\d[^ ]*\.deb\b', st
-        ):
-            system_packages.append(_resolve(dm.group(1), varmap))
-
     return {
         "base_os": base_os,
         "labels": labels,
@@ -277,6 +268,13 @@ def main():
 
             ver = image_version(repo_root, name) or _git_describe(repo_root)
 
+            # Merge dpkg-installed system-level packages (e.g. libfmt8 for
+            # tsingmicro) — these are exceptions declared in configs.yaml, not
+            # the SDK .debs that get their own section.
+            sys_pkgs = list(meta["system_packages"])
+            for p in spec.get("system_dpkg", []) or []:
+                sys_pkgs.append(p)
+
             backends.append(
                 {
                     "name": name,
@@ -291,7 +289,7 @@ def main():
                         "arch": arch,
                         "hardware": spec.get("hardware") or [],
                         "driver": spec.get("driver", ""),
-                        "system_packages": meta["system_packages"],
+                        "system_packages": _dedup(sys_pkgs),
                         "sdk": sdk,
                         "env": env.get("base") or {},
                     },


### PR DESCRIPTION
`gen_data.py` was extracting dpkg .deb filenames and injecting them into `system_packages`. This worked for tsingmicro's `libfmt8` (a genuine system-level dpkg install), but also pulled in cambricon's 23 Neuware SDK .debs, enflame's 9 .debs, etc. — bloating the system packages list and duplicating SDK components.

## Fix

1. Remove dpkg .deb parsing from `parse_containerfile()` entirely — SDK .debs are already listed in `configs.yaml` `sdk:` and rendered in their own section
2. Add `system_dpkg` field to `configs.yaml` for the real exception: tsingmicro's `libfmt8`
3. `gen_data.py` merges `system_dpkg` into `system_packages` per-backend

## Result

| | Before | After |
|---|---|---|
| cambricon system_packages | 40+ | 15 |
| enflame system_packages | 17 | 8 |
| tsingmicro system_packages | 14 (incl libfmt8) | 14 (incl libfmt8) |
| hygon system_packages | 9 | 9 (unchanged) |

This PR was written in part with the assistance of generative AI.