### PR TITLE
fix(base): add BASH_ENV plumbing to ascend/hygon base images, append in runtime

### DIFF
--- a/base/ascend-cann8.5.0
+++ b/base/ascend-cann8.5.0
@@ -88,3 +88,12 @@ RUN env_before=$(env | sort) && \
       > /etc/profile.d/vendor.sh && \
     rm -f /tmp/_v_before /tmp/_v_after && \
     echo "vendor.sh: captured $(wc -l < /etc/profile.d/vendor.sh) env vars"
+
+# ── Bash plumbing — make profile.d/*.sh available everywhere ─────
+# /etc/profile.d/vendor.sh is sourced in login shells only by default.
+# This makes it active in non-login interactive (bash.bashrc) and
+# non-interactive (BASH_ENV) shells too — so `bash -c "cmd"` works.
+RUN printf 'for f in /etc/profile.d/*.sh; do [ -r "$f" ] && . "$f"; done\n' \
+    > /etc/bash_env.sh; \
+    printf '. /etc/bash_env.sh\n%s' "$(cat /etc/bash.bashrc)" > /etc/bash.bashrc
+ENV BASH_ENV=/etc/bash_env.sh

--- a/base/ascend-cann9.0.0
+++ b/base/ascend-cann9.0.0
@@ -95,3 +95,9 @@ RUN env_before=$(env | sort) && \
       > /etc/profile.d/vendor.sh && \
     rm -f /tmp/_v_before /tmp/_v_after && \
     echo "vendor.sh: captured $(wc -l < /etc/profile.d/vendor.sh) env vars"
+
+# ── Bash plumbing — make profile.d/*.sh available everywhere ─────
+RUN printf 'for f in /etc/profile.d/*.sh; do [ -r "$f" ] && . "$f"; done\n' \
+    > /etc/bash_env.sh; \
+    printf '. /etc/bash_env.sh\n%s' "$(cat /etc/bash.bashrc)" > /etc/bash.bashrc
+ENV BASH_ENV=/etc/bash_env.sh

--- a/base/hygon-dtk26.04
+++ b/base/hygon-dtk26.04
@@ -68,4 +68,11 @@ RUN env_before=$(env | sort) && \
       > /etc/profile.d/vendor.sh && \
     rm -f /tmp/_v_before /tmp/_v_after && \
     echo "vendor.sh: captured $(wc -l < /etc/profile.d/vendor.sh) env vars"
+
+# ── Bash plumbing — make profile.d/*.sh available everywhere ─────
+RUN printf 'for f in /etc/profile.d/*.sh; do [ -r "$f" ] && . "$f"; done\n' \
+    > /etc/bash_env.sh; \
+    printf '. /etc/bash_env.sh\n%s' "$(cat /etc/bash.bashrc)" > /etc/bash.bashrc
+ENV BASH_ENV=/etc/bash_env.sh
+
 SHELL ["/bin/sh", "-c"]

--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -276,13 +276,18 @@ compiler() {\n\
 #   bash.bashrc          → profile.d/*.sh   (non-login interactive)
 #   BASH_ENV             → profile.d/*.sh   (non-interactive, bash -c)
 #
-# Base images may also drop files into /etc/profile.d/ (e.g. vendor SDK env).
-# This plumbing sources everything so user never needs to source env scripts.
-# vendor.sh (from base image) captures PATH from the base's set_env.sh,
-# which may override the venv prefix. Restore /flagos/bin after sourcing.
-RUN printf 'for f in /etc/profile.d/*.sh; do [ -r "$f" ] && . "$f"; done\n\nexport PATH="/flagos/bin:$PATH"\n' \
-    > /etc/bash_env.sh; \
-    printf '. /etc/bash_env.sh\n%%s' "$(cat /etc/bash.bashrc)" > /etc/bash.bashrc
+# Base images with vendor SDK env (ascend, hygon) already set up
+# /etc/bash_env.sh to source profile.d/*.sh. For those, we only append
+# the PATH fix so /flagos/bin stays first (vendor.sh may have prepended
+# SDK paths). For all others, create the full plumbing here.
+# This way base and runtime don't do the same work twice and never conflict.
+RUN if [ -f /etc/bash_env.sh ]; then \
+      printf 'export PATH="/flagos/bin:$PATH"\n' >> /etc/bash_env.sh; \
+    else \
+      printf 'for f in /etc/profile.d/*.sh; do [ -r "$f" ] && . "$f"; done\n\nexport PATH="/flagos/bin:$PATH"\n' \
+        > /etc/bash_env.sh; \
+      printf '. /etc/bash_env.sh\n%%s' "$(cat /etc/bash.bashrc)" > /etc/bash.bashrc; \
+    fi
 ENV BASH_ENV=/etc/bash_env.sh
 
 WORKDIR /app


### PR DESCRIPTION
## Problem

Three vendor base images (ascend-cann8.5.0, ascend-cann9.0.0, hygon-dtk26.04) capture SDK env to `/etc/profile.d/vendor.sh`, but this file is only sourced in **login shells**. Three real-world scenarios break:

1. **CI verify**:  `docker run <img> bash -c cmd` —  non-interactive, `vendor.sh` never sourced
2. **User**:  `docker run -it <img> bash` — non-login interactive, same problem
3. **Runtime inherit**: runtime Containerfile previously **overwrote** `/etc/bash_env.sh` and `/etc/bash.bashrc` — when base already had these, they clashed

## Fix

### Base (3 Containerfiles)
Add standard BASH_ENV plumbing after the vendor.sh capture block:
- `/etc/bash_env.sh` = source all `profile.d/*.sh` (new)
- `/etc/bash.bashrc` = `. /etc/bash_env.sh` + original content (modified)
- `ENV BASH_ENV=/etc/bash_env.sh` (new)

### Runtime (1 Containerfile)
Replace overwrite with append logic: if base already has `/etc/bash_env.sh`, only append `/flagos/bin` to PATH. Otherwise create full plumbing (backward compat for 11 images without vendor.sh).

## Affected

| Base image | Has vendor.sh? | Before | After |
|---|---|---|---|
| ascend-cann8.5.0 | yes | BASH_ENV missing | BASH_ENV added |
| ascend-cann9.0.0 | yes | BASH_ENV missing | BASH_ENV added |
| hygon-dtk26.04 | yes | BASH_ENV missing | BASH_ENV added |
| 11 others | no | (no vendor.sh) | untouched |

Runtime: all 14 backends get consistent BASH_ENV, no conflict.

This PR was written in part with the assistance of generative AI.
