### PR TITLE
fix(ci): flaggems-release pip stability — mirror, PEP 668, drop upload-artifact

### DIFF
--- a/.github/workflows/flaggems-release.yml
+++ b/.github/workflows/flaggems-release.yml
@@ -56,7 +56,10 @@ jobs:
       - name: Setup Python deps
         run: |
           mirror=$(grep "^mirror:" configs.yaml | sed 's/.*"\(.*\)"/\1/')
-          python3 -m pip install --user --index-url "$mirror" pyyaml twine
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages --index-url "$mirror" pyyaml
+          python3 -c "import twine" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages --index-url "$mirror" twine
       - name: Build wheel
         run: python3 scripts/release_flaggems.py build-python --ref "$FLAGGEMS_REF"
       - name: Upload to all vendor PyPIs
@@ -102,7 +105,10 @@ jobs:
       - name: Setup Python deps
         run: |
           mirror=$(grep "^mirror:" configs.yaml | sed 's/.*"\(.*\)"/\1/')
-          python3 -m pip install --user --index-url "$mirror" pyyaml twine
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages --index-url "$mirror" pyyaml
+          python3 -c "import twine" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages --index-url "$mirror" twine
 
       - name: Pull runtime:v1 image
         run: |

--- a/.github/workflows/flaggems-release.yml
+++ b/.github/workflows/flaggems-release.yml
@@ -54,7 +54,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Python deps
-        run: python3 -m pip install --user pyyaml twine
+        run: |
+          mirror=$(grep "^mirror:" configs.yaml | sed 's/.*"\(.*\)"/\1/')
+          python3 -m pip install --user --index-url "$mirror" pyyaml twine
       - name: Build wheel
         run: python3 scripts/release_flaggems.py build-python --ref "$FLAGGEMS_REF"
       - name: Upload to all vendor PyPIs
@@ -98,7 +100,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Python deps
-        run: python3 -m pip install --user pyyaml twine
+        run: |
+          mirror=$(grep "^mirror:" configs.yaml | sed 's/.*"\(.*\)"/\1/')
+          python3 -m pip install --user --index-url "$mirror" pyyaml twine
 
       - name: Pull runtime:v1 image
         run: |

--- a/.github/workflows/flaggems-release.yml
+++ b/.github/workflows/flaggems-release.yml
@@ -66,10 +66,6 @@ jobs:
         run: |
           wheel=$(ls -t wheels/flag_gems-*.whl 2>/dev/null | head -1)
           python3 scripts/release_flaggems.py upload-python "$wheel"
-      - uses: actions/upload-artifact@v7
-        with:
-          name: flag_gems-wheel
-          path: wheels/flag_gems-*.whl
 
   # ── 5b: cpp operator wheels, inside runtime:v1 ───────────────────────────
   cpp-matrix:
@@ -131,11 +127,6 @@ jobs:
         run: |
           wheel=$(ls -t wheels-cpp/flag_gems_cpp_*.whl 2>/dev/null | head -1)
           python3 scripts/release_flaggems.py upload-cpp "$BACKEND" "$wheel"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: flag_gems_cpp_${{ matrix.name }}-wheel
-          path: wheels-cpp/flag_gems_cpp_*.whl
 
   # ── 5c: update configs.yaml ──────────────────────────────────────────────
   update-config:


### PR DESCRIPTION
## Problem

`FlagGems Release Wheels` workflow failed 3 times because:

1. **h20 self-hosted runner can't reach pypi.org** — `python-wheel` job requires `pyyaml` + `twine`, pip install hangs/timeouts on unstable international connectivity
2. **PEP 668 blocks `pip install --user`** — h20's system Python is externally managed, needs `--break-system-packages`
3. **`upload-artifact@v7` blocks the pipeline** — uploads to GitHub's Azure blob storage from CN self-hosted runners are equally unstable; wheels are already on PyPI so this is redundant

## Changes

1. Use aliyun PyPI mirror (`mirrors.aliyun.com/pypi/simple`) via `--index-url`, parsed from `configs.yaml`
2. Add `--break-system-packages` + skip-if-already-installed guard (same pattern as `imagebuild.yml`)
3. Remove `upload-artifact` from both `python-wheel` and `cpp-wheels` jobs — wheels live on PyPI, no downstream job consumes these artifacts

## Verification

- `python-wheel`: passed in [run 30152746842](https://github.com/flagos-ai/build-infra/actions/runs/30152746842) after fixes applied
- Python wheel uploaded to all 13 vendor PyPIs successfully

## Notes

- cpp-wheels remain a known-scary path (toolchain instability, git clone in-container, runner network) — deferred to a dedicated improvement effort
- `flaggems: "5.3.1"` was already in `configs.yaml`, so step 5c (update-config PR) is a no-op for this release

---

This PR was written in part with the assistance of generative AI.