### PR TITLE
fix(runtime): cpp wheel build improvements and dependency hardening

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -93,12 +93,14 @@ RUN if [ -n "${DEPS}" ]; then \
       done; \
     fi
 
-# ── Install runtime packages (former build deps) ───────────────
+# ── Install runtime packages ───────────────────────────────────
 # pybind11 is a runtime dependency of flagtree (ascend backend,
 # triton/backends/ascend/utils.py imports it). ninja is needed for
-# C++ extension builds. Versions pinned to match flaggems_cpp_build_deps.
+# C++ extension builds. PyYAML and numpy are FlagGems core deps
+# but also needed before FlagGems is installed (torch_npu and other
+# vendor torch packages import them without declaring the dependency).
 # These are standard PyPI packages, not vendor-specific — use mirror.
-RUN for pkg in pybind11==3.0.3 ninja==1.13.0; do \
+RUN for pkg in pybind11==3.0.3 ninja==1.13.0 PyYAML==6.0.1 numpy==1.26.4; do \
       for i in 1 2 3; do \
         uv pip install --no-cache-dir "$pkg" \
           --index ${EXTRA_PYPI} && break; \
@@ -162,6 +164,10 @@ RUN if [ -n "${NO_FLAGGEMS}" ]; then \
           "flag_gems${CPP_EXTRA:+[${CPP_EXTRA}]}==${FLAGGEMS_VERSION}" && break; \
         echo "FlagGems install attempt $i failed, retrying..."; \
       done; \
+      if find /flagos -name 'c_operators*.so' 2>/dev/null | grep -q .; then \
+        echo "cpp extension .so detected — enabling USE_C_EXTENSION"; \
+        printf 'export USE_C_EXTENSION=1\n' > /etc/profile.d/use_c_extension.sh; \
+      fi; \
     fi
 
 # ── Tests — deferred (image not finalized) ────────────────────
@@ -195,10 +201,13 @@ COPY --from=builder /app /app
 ENV VIRTUAL_ENV=/flagos \
     PATH="/flagos/bin:${PATH}"
 
-# Enable C++ operator extensions (the flag-gems-cpp-<backend> .so files
-# won't load without this). The default compiler is FlagTree (installed to
-# /flagos); use 'compiler triton' or 'compiler flagtree' to switch.
-ENV USE_C_EXTENSION=1
+# C++ operator extensions are opt-in — set USE_C_EXTENSION=1 at runtime
+# AFTER installing the flag-gems-cpp-<vendor> wheel. The env is NOT set
+# here as a default because runtime:v1 (NO_FLAGGEMS) has no cpp wheel and
+# setting it prematurely causes FlagGems to crash on import.
+#
+# The default compiler is FlagTree (installed to /flagos); use
+# 'compiler triton' or 'compiler flagtree' to switch.
 
 # ── Compiler switching function ────────────────────────────────
 # Written to /etc/profile.d/compiler.sh; available in login shells (via

--- a/scripts/build_cpp_wheel.sh
+++ b/scripts/build_cpp_wheel.sh
@@ -61,7 +61,7 @@ fi
 
 # ── build ─────────────────────────────────────────────────────
 mkdir -p "$OUTDIR"
-pip wheel ./cpp --no-deps -w "$OUTDIR"
+pip wheel ./cpp --no-deps --no-build-isolation -w "$OUTDIR"
 
 # ── install + inspect .so ─────────────────────────────────────
 pip install --no-deps "$OUTDIR"/*.whl


### PR DESCRIPTION
## Changes

- Add `PyYAML==6.0.1` and `numpy==1.26.4` to runtime packages — torch vendor packages (torch_npu, etc.) import them without declaring the dependency, causing import failures in runtime:v1 containers
- Add `--no-build-isolation` to `pip wheel` in `build_cpp_wheel.sh` — reuses the venv's pre-installed build deps instead of creating an isolated pip environment that may pull wrong versions from PyPI
- Remove hardcoded `ENV USE_C_EXTENSION=1` from Containerfile — runtime:v1 has no cpp wheel, and setting it prematurely causes FlagGems import failures on some backends
- Auto-detect cpp `.so` at build time: only write `use_c_extension.sh` to profile.d when the cpp extension actually exists (runtime:v2 with CPP_EXTRA set)

## Motivation

Discovered during NPU (Ascend) cpp wheel build verification on hw25. The runtime:v1 image (--no-flaggems) is used as the build platform for cpp wheel compilation; it needed to import torch_npu which silently depends on PyYAML and numpy.

This PR was written in part with the assistance of generative AI.