### PR TITLE
fix(license-tool): preserve line endings, skip non-source files

### DIFF
--- a/license-tool/add_headers.py
+++ b/license-tool/add_headers.py
@@ -43,30 +43,36 @@ def add_header_to_file(filepath, year, owner, license_id, dry_run=False):
         return "unknown_type", 0
 
     try:
-        with open(filepath, "r", errors="replace") as f:
+        with open(filepath, "r", newline="", errors="replace") as f:
             original = f.read()
     except (IOError, OSError, UnicodeDecodeError) as e:
         return f"error: {e}", 0
 
+    # Detect line-ending style so we don't convert CRLF ↔ LF
+    eol = "\r\n" if "\r\n" in original else "\n"
+    header_eol = header.replace("\n", eol)
+    sep = eol
+
     hdr_lines = header.count("\n")
 
     if insert_line == 0:
-        new_content = header + "\n" + original
+        new_content = header_eol + sep + original
     else:
         lines = original.splitlines(keepends=True)
         new_content = "".join(
-            lines[:insert_line] + ["\n", header, "\n"] + lines[insert_line:]
+            lines[:insert_line] + [sep, header_eol, sep] + lines[insert_line:]
         )
-
-    new_content = new_content.rstrip("\n") + "\n"
 
     if new_content == original:
         return "unchanged", 0
 
+    # Ensure exactly one trailing newline, preserving original EOL style
+    new_content = new_content.rstrip("\r\n") + eol
+
     if dry_run:
         return "would_add", hdr_lines
 
-    with open(filepath, "w") as f:
+    with open(filepath, "w", newline="") as f:
         f.write(new_content)
     return "added", hdr_lines
 

--- a/license-tool/lib.py
+++ b/license-tool/lib.py
@@ -125,14 +125,21 @@ def dump_data(data, yaml_path):
 #  File-skip rules
 # =============================================================================
 
-SKIP_PATTERNS = ["LICENSE", "go.sum", ".gitignore", "README.md",
+SKIP_PATTERNS = ["LICENSE", "go.sum", ".gitignore", "README.md", "README_cn.md",
                  "changelog",  # Debian changelog: strict format, dpkg-buildpackage parsing
+                 "PULL_REQUEST_TEMPLATE.md", "CODEOWNERS",
+                 "CODE_OF_CONDUCT.md", "MAINTAINERS.md",
                  ]
 
 # Path prefixes to skip (directories with strict-format files).
 SKIP_PATH_PREFIXES = [
     "packaging/",     # Debian/RPM packaging: strict format (control, rules, spec, etc.)
     "third_party/",   # Forked upstream code — not ours to relicense; headers shift line numbers
+]
+
+# Path substrings to skip (data files where headers break parsing).
+SKIP_PATH_CONTAINS = [
+    "results_gold/",
 ]
 
 SKIP_EXTENSIONS = {
@@ -213,6 +220,9 @@ def should_skip(filepath):
     for prefix in SKIP_PATH_PREFIXES:
         if filepath.startswith(prefix):
             return True
+    for pattern in SKIP_PATH_CONTAINS:
+        if pattern in filepath:
+            return True
     return False
 
 
@@ -221,11 +231,15 @@ def should_skip(filepath):
 # =============================================================================
 
 def classify_ext(filepath):
-    """Return a normalized extension, handling version-number suffixes and
-    .disabled YAML files."""
+    """Return a normalized extension, handling version-number suffixes,
+    .disabled YAML files, and Dockerfile / Containerfile variant suffixes."""
+    basename = os.path.basename(filepath)
     ext = os.path.splitext(filepath)[1].lower()
     if ext == ".disabled":
         return ".yaml"
+    # Dockerfile / Containerfile variants: Dockerfile.all, Containerfile.inference, etc.
+    if basename.startswith(("Dockerfile.", "Containerfile.")):
+        return ""
     if ext and ext[1:].replace(".", "").isdigit():
         return ""
     return ext


### PR DESCRIPTION
## Summary

Fixes discovered during the FlagScale copyright header PR (#1252).

### Changes

**`add_headers.py`:**
- Preserve CRLF/LF line endings — no longer converts files with `\r\n` to `\n`
- Ensure exactly one trailing newline in output — no more dangling last lines without EOL

**`lib.py`:**
- Skip `README_cn.md`, `PULL_REQUEST_TEMPLATE.md`, `CODEOWNERS`, `CODE_OF_CONDUCT.md`, `MAINTAINERS.md` (GitHub meta files, not source code)
- Add `SKIP_PATH_CONTAINS` for `results_gold/` — pure data files where headers break parsing
- Fix `classify_ext()` to recognize Dockerfile variants (`Dockerfile.all`, `Dockerfile.inference`, etc.)

### Motivating Issues
- FlagScale CI format check (end-of-file-fixer, ruff format) was failing because:
  - Missing trailing newlines were being created in some output files
  - CRLF files were incorrectly converted to LF, causing massive diffs
  - `README_cn.md` was getting a copyright header (unnecessary for a README)

This PR was written in part with the assistance of generative AI.