### PR TITLE
feat(configs): move runtime prereq packages from Containerfile to configs.yaml

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -44,6 +44,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       harbor_host: ${{ steps.harbor-host.outputs.host }}
+      runtime_prereqs: ${{ steps.runtime-prereqs.outputs.prereqs }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -61,6 +62,12 @@ jobs:
           fi
           cat matrix.json
           echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+      - id: runtime-prereqs
+        shell: bash
+        run: |
+          prereqs=$(python3 -c "import yaml; print(' '.join(yaml.safe_load(open('configs.yaml'))['runtime_prereqs']))")
+          echo "prereqs=$prereqs" >> "$GITHUB_OUTPUT"
 
       - id: harbor-host
         shell: bash
@@ -136,6 +143,7 @@ jobs:
             --build-arg "DAILY_PYPI=${{ matrix.daily_pypi }}" \
             --build-arg "EXTRA_PYPI=${{ matrix.extra_pypi }}" \
             --build-arg "DEPS=${{ matrix.deps }}" \
+            --build-arg "RUNTIME_PREREQS=${{ needs.set-matrix.outputs.runtime_prereqs }}" \
             --build-arg "CPP_EXTRA=${{ matrix.cpp_extra }}" \
             --build-arg "FLAGTREE_PKG=${{ matrix.flagtree_pkg }}" \
             --build-arg "TRITON_PKG=${{ matrix.triton_pkg }}" \

--- a/configs.yaml
+++ b/configs.yaml
@@ -75,6 +75,18 @@ flaggems_cpp_build_deps:
   - "cmake>=3.20,<4"
   - "ninja==1.13.0"
 
+# Common Python packages installed in every runtime image before FlagGems.
+# These are standard PyPI packages (not vendor-specific), installed from
+# the mirror. pybind11 is a runtime dep of flagtree (ascend backend);
+# ninja is needed for C++ extension builds; PyYAML and numpy are FlagGems
+# core deps but must be installed before FlagGems (vendor torch packages
+# import them without declaring the dependency).
+runtime_prereqs:
+  - "pybind11==3.0.3"
+  - "ninja==1.13.0"
+  - "PyYAML==6.0.1"
+  - "numpy==1.26.4"
+
 base_image_prefix: "flagos-base"
 
 pypi_base: "https://resource.flagos.net/repository/flagos-pypi-{vendor}/simple"

--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -28,6 +28,10 @@ ARG INCLUDE_TESTS=true
 ARG PYTHON_VERSION=3.12
 ARG FLAGOS_PYPI=""
 ARG DAILY_PYPI=""
+# Common packages from configs.yaml runtime_prereqs — needed before FlagGems
+# is installed (pybind11 for flagtree, ninja for C++ extension builds,
+# PyYAML/numpy for vendor torch packages that import without declaring).
+ARG RUNTIME_PREREQS=""
 # Dependencies passed explicitly (no extras) — each may be empty.
 # DEPS: space-separated vendor packages from configs.yaml deps: (torch, etc.)
 # CPP_EXTRA: cpp-cuda / cpp-musa / cpp-npu / cpp-gcu / cpp-ix, or empty
@@ -58,6 +62,7 @@ ARG FLAGOS_PYPI
 ARG DAILY_PYPI
 ARG EXTRA_PYPI
 ARG DEPS
+ARG RUNTIME_PREREQS
 ARG CPP_EXTRA
 ARG FLAGTREE_PKG
 ARG TRITON_PKG
@@ -97,24 +102,23 @@ RUN if [ -n "${DEPS}" ]; then \
       [ "$_installed" -eq 0 ] || { echo "ERROR: DEPS install failed after 3 attempts"; exit 1; }; \
     fi
 
-# ── Install runtime packages ───────────────────────────────────
-# pybind11 is a runtime dependency of flagtree (ascend backend,
-# triton/backends/ascend/utils.py imports it). ninja is needed for
-# C++ extension builds. PyYAML and numpy are FlagGems core deps
-# but also needed before FlagGems is installed (torch_npu and other
-# vendor torch packages import them without declaring the dependency).
-# These are standard PyPI packages, not vendor-specific — use mirror.
-RUN for pkg in pybind11==3.0.3 ninja==1.13.0 PyYAML==6.0.1 numpy==1.26.4; do \
+# ── Install runtime prerequisites ───────────────────────────────
+# Common packages from configs.yaml runtime_prereqs, installed from
+# the mirror before FlagGems. pybind11 is a runtime dep of flagtree;
+# ninja is needed for C++ extension builds; PyYAML and numpy are
+# FlagGems core deps that vendor torch packages import without
+# declaring the dependency.
+RUN if [ -n "${RUNTIME_PREREQS}" ]; then \
       _installed=1; \
       for i in 1 2 3; do \
-        if uv pip install --no-cache-dir "$pkg" \
+        if uv pip install --no-cache-dir ${RUNTIME_PREREQS} \
           --index ${EXTRA_PYPI}; then \
           _installed=0; break; \
         fi; \
-        echo "$pkg install attempt $i failed, retrying..."; \
+        echo "RUNTIME_PREREQS install attempt $i failed, retrying..."; \
       done; \
-      [ "$_installed" -eq 0 ] || { echo "ERROR: $pkg install failed after 3 attempts"; exit 1; }; \
-    done
+      [ "$_installed" -eq 0 ] || { echo "ERROR: RUNTIME_PREREQS install failed after 3 attempts"; exit 1; }; \
+    fi
 
 # ── Install FlagTree (default compiler, if configured) ──────────
 # FlagTree installs to site-packages/triton/ — it's the default import.

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -205,6 +205,7 @@ def resolve_build_args(
         "DAILY_PYPI": pypi_daily,
         "EXTRA_PYPI": extra_pypi_override or mirror,
         "DEPS": deps,
+        "RUNTIME_PREREQS": " ".join(configs.get("runtime_prereqs", [])),
         "CPP_EXTRA": cpp_extra,
         "FLAGTREE_PKG": flagtree,
         "TRITON_PKG": triton,


### PR DESCRIPTION
Move the four hardcoded Python packages (pybind11, ninja, PyYAML, numpy) from `runtime/Containerfile` into `configs.yaml` under `runtime_prereqs`, so the single source of truth owns them.

## Changes

- **configs.yaml** — add `runtime_prereqs` list with pinned versions
- **runtime/Containerfile** — replace hardcoded for-loop with `RUNTIME_PREREQS` build arg (same retry pattern as `DEPS`)
- **scripts/build_runtime.py** — read `runtime_prereqs` from configs.yaml and pass as a build arg
- **.github/workflows/runtime.yml** — extract `runtime_prereqs` from configs.yaml in matrix job and pass to docker build

## Verification

```bash
$ python scripts/build_runtime.py nvidia-cuda12.8 --dry-run | grep RUNTIME_PREREQS
RUNTIME_PREREQS=pybind11==3.0.3 ninja==1.13.0 PyYAML==6.0.1 numpy==1.26.4
```

Identical to the previously hardcoded values.

This PR was written in part with the assistance of generative AI.