### PR TITLE
feat(versioning): default runtime image tag from :latest to :{version}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ configs.yaml + base/ Containerfiles + build-config.yml
 ### Image naming
 
 - **Base:** `flagos-base-{vendor}-{backend}:{version}-{n}` — version from Containerfile `LABEL org.opencontainers.image.version` (repo tag), n = per-backend git revision count since that tag. Only Containerfile changes bump n.
-- **Runtime:** `flagos-runtime-{vendor}-{backend}:latest`
+- **Runtime:** `flagos-runtime-{vendor}-{backend}:{version}` — version from configs.yaml `version:` (same as base)
 - Registry: `harbor.baai.ac.cn/{prefix}/` (prefix from `build-config.yml` registry.prefixes)
 - `base/<name>` Containerfile names match the `{vendor}-{backend}` key (e.g. `base/nvidia-cuda12.8`)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -145,8 +145,8 @@ gh workflow run "Runtime Image Build (manual)" -f backend="all" -f push="true"
 在对应硬件的节点上手动验证：
 
 ```bash
-docker pull harbor.baai.ac.cn/flagos-runtime/flagos-runtime-<vendor>-<backend>:latest
-docker run --gpus all harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:latest \
+docker pull harbor.baai.ac.cn/flagos-runtime/flagos-runtime-<vendor>-<backend>:<version>
+docker run --gpus all harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:<version> \
   python -c "import flag_gems; ..."
 ```
 

--- a/configs.yaml
+++ b/configs.yaml
@@ -27,8 +27,8 @@
 #   {n} = commits to base/{vendor}-{backend} since tag v{version}.
 #
 # Runtime image naming convention:
-#   flagos-runtime-{vendor}-{backend}:latest
-#   e.g. flagos-runtime-nvidia-cuda12.8:latest
+#   flagos-runtime-{vendor}-{backend}:{version}
+#   e.g. flagos-runtime-nvidia-cuda12.8:2.1.1
 #
 # The PyPI index URL is auto-generated: pypi_base.format(vendor=<vendor>).
 # Override per-backend with an explicit "index:" field if needed.

--- a/docs/content/en/runtime/ascend-cann8.5.0.md
+++ b/docs/content/en/runtime/ascend-cann8.5.0.md
@@ -54,7 +54,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -68,7 +68,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:2.1.1 bash
 ```
 
 ## Verify
@@ -76,5 +76,5 @@ docker run --rm -it \
 Inside the container, confirm the accelerator is visible:
 
 ```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
+npu-smi info
 ```

--- a/docs/content/en/runtime/ascend-cann9.0.0.md
+++ b/docs/content/en/runtime/ascend-cann9.0.0.md
@@ -54,7 +54,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -68,7 +68,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:2.1.1 bash
 ```
 
 ## Verify
@@ -76,5 +76,5 @@ docker run --rm -it \
 Inside the container, confirm the accelerator is visible:
 
 ```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
+npu-smi info
 ```

--- a/docs/content/en/runtime/cambricon-neuware4.4.3.md
+++ b/docs/content/en/runtime/cambricon-neuware4.4.3.md
@@ -51,7 +51,7 @@ Start an interactive shell (works with docker or podman):
 docker run --rm -it \
   --device /dev/cambricon_dev0 \
   --device /dev/cambricon_ctl \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-cambricon-neuware4.4.3:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-cambricon-neuware4.4.3:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/enflame-tops1.9.10.md
+++ b/docs/content/en/runtime/enflame-tops1.9.10.md
@@ -59,15 +59,16 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --network host \
   -e TENCENT_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
 docker run --rm -it \
-  --device /dev/gcu \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:latest bash
+  --privileged \
+  -v /dev:/dev \
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/hygon-dtk26.04.md
+++ b/docs/content/en/runtime/hygon-dtk26.04.md
@@ -53,7 +53,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   -e DCU_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -66,7 +66,7 @@ docker run --rm -it \
   --group-add video \
   -v /opt/hyhal:/opt/hyhal \
   --security-opt seccomp=unconfined \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.1 bash
 ```
 
 ## Verify
@@ -74,5 +74,5 @@ docker run --rm -it \
 Inside the container, confirm the accelerator is visible:
 
 ```bash
-source /opt/hyhal/env.sh && hy-smi
+hy-smi
 ```

--- a/docs/content/en/runtime/iluvatar-corex4.4.0.md
+++ b/docs/content/en/runtime/iluvatar-corex4.4.0.md
@@ -51,7 +51,7 @@ title: "iluvatar-corex4.4.0"
 docker run --rm -it \
   --runtime iluvatar \
   --env IX_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -60,7 +60,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/iluvatar0 \
   -v /usr/local/corex:/usr/local/corex:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/kunlunxin-xre5.29.0.md
+++ b/docs/content/en/runtime/kunlunxin-xre5.29.0.md
@@ -68,7 +68,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --runtime xpu \
   -e CXPU_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -77,7 +77,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/xpu0 \
   --device /dev/xpuctrl \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/metax-maca3.7.2.1.md
+++ b/docs/content/en/runtime/metax-maca3.7.2.1.md
@@ -56,7 +56,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 metax-docker \
   --gpus all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -66,7 +66,7 @@ docker run --rm -it \
   --device /dev/mxcd \
   --device /dev/dri \
   --group-add video \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/mthreads-musa4.3.6.md
+++ b/docs/content/en/runtime/mthreads-musa4.3.6.md
@@ -61,7 +61,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -71,7 +71,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/mthreads-musa5.2.0.md
+++ b/docs/content/en/runtime/mthreads-musa5.2.0.md
@@ -40,7 +40,7 @@ title: "mthreads-musa5.2.0"
 - `flag_gems`
 - `flagtree==0.6.0+mthreads3.6`
 - `mkl==2024.0.0`
-- `torch==2.9.0+musa5.2.0`
+- `torch==2.9.1+musa5.2.0`
 - `torch_musa==2.9.1`
 - <span class="muted"><code class="plain">triton==3.6.0</code></span>
 
@@ -61,7 +61,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -71,7 +71,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/nvidia-cuda12.8.md
+++ b/docs/content/en/runtime/nvidia-cuda12.8.md
@@ -60,7 +60,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -73,7 +73,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/nvidia-cuda13.3.md
+++ b/docs/content/en/runtime/nvidia-cuda13.3.md
@@ -60,7 +60,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -73,7 +73,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/sunrise-tangrt1.2.0.md
+++ b/docs/content/en/runtime/sunrise-tangrt1.2.0.md
@@ -45,11 +45,13 @@ title: "sunrise-tangrt1.2.0"
 
 ## Launch
 
-Start an interactive shell in the container:
+Start an interactive shell (works with docker or podman):
 
 ```bash
 docker run --rm -it \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-sunrise-tangrt1.2.0:latest bash
+  --privileged \
+  -v /dev:/dev \
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-sunrise-tangrt1.2.0:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/en/runtime/tsingmicro-tsm260604.md
+++ b/docs/content/en/runtime/tsingmicro-tsm260604.md
@@ -63,7 +63,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --runtime=tsingmicro \
   -e TSINGMICRO_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -72,7 +72,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/accel \
   --device /dev/accel_drv_mgr \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:2.1.1 bash
 ```
 
 ## Verify

--- a/docs/content/zh-cn/runtime/ascend-cann8.5.0.md
+++ b/docs/content/zh-cn/runtime/ascend-cann8.5.0.md
@@ -54,7 +54,7 @@ title: "ascend-cann8.5.0"
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -68,7 +68,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:2.1.1 bash
 ```
 
 ## 验证
@@ -76,5 +76,5 @@ docker run --rm -it \
 在容器内，确认加速器可见：
 
 ```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
+npu-smi info
 ```

--- a/docs/content/zh-cn/runtime/ascend-cann9.0.0.md
+++ b/docs/content/zh-cn/runtime/ascend-cann9.0.0.md
@@ -54,7 +54,7 @@ title: "ascend-cann9.0.0"
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -68,7 +68,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:2.1.1 bash
 ```
 
 ## 验证
@@ -76,5 +76,5 @@ docker run --rm -it \
 在容器内，确认加速器可见：
 
 ```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
+npu-smi info
 ```

--- a/docs/content/zh-cn/runtime/cambricon-neuware4.4.3.md
+++ b/docs/content/zh-cn/runtime/cambricon-neuware4.4.3.md
@@ -51,7 +51,7 @@ title: "cambricon-neuware4.4.3"
 docker run --rm -it \
   --device /dev/cambricon_dev0 \
   --device /dev/cambricon_ctl \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-cambricon-neuware4.4.3:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-cambricon-neuware4.4.3:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/enflame-tops1.9.10.md
+++ b/docs/content/zh-cn/runtime/enflame-tops1.9.10.md
@@ -59,15 +59,16 @@ title: "enflame-tops1.9.10"
 docker run --rm -it \
   --network host \
   -e TENCENT_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
 
 ```bash
 docker run --rm -it \
-  --device /dev/gcu \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:latest bash
+  --privileged \
+  -v /dev:/dev \
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/hygon-dtk26.04.md
+++ b/docs/content/zh-cn/runtime/hygon-dtk26.04.md
@@ -53,7 +53,7 @@ title: "hygon-dtk26.04"
 ```bash
 docker run --rm -it \
   -e DCU_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -66,7 +66,7 @@ docker run --rm -it \
   --group-add video \
   -v /opt/hyhal:/opt/hyhal \
   --security-opt seccomp=unconfined \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.1 bash
 ```
 
 ## 验证
@@ -74,5 +74,5 @@ docker run --rm -it \
 在容器内，确认加速器可见：
 
 ```bash
-source /opt/hyhal/env.sh && hy-smi
+hy-smi
 ```

--- a/docs/content/zh-cn/runtime/iluvatar-corex4.4.0.md
+++ b/docs/content/zh-cn/runtime/iluvatar-corex4.4.0.md
@@ -51,7 +51,7 @@ title: "iluvatar-corex4.4.0"
 docker run --rm -it \
   --runtime iluvatar \
   --env IX_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -60,7 +60,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/iluvatar0 \
   -v /usr/local/corex:/usr/local/corex:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/kunlunxin-xre5.29.0.md
+++ b/docs/content/zh-cn/runtime/kunlunxin-xre5.29.0.md
@@ -68,7 +68,7 @@ title: "kunlunxin-xre5.29.0"
 docker run --rm -it \
   --runtime xpu \
   -e CXPU_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -77,7 +77,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/xpu0 \
   --device /dev/xpuctrl \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/metax-maca3.7.2.1.md
+++ b/docs/content/zh-cn/runtime/metax-maca3.7.2.1.md
@@ -56,7 +56,7 @@ title: "metax-maca3.7.2.1"
 ```bash
 metax-docker \
   --gpus all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -66,7 +66,7 @@ docker run --rm -it \
   --device /dev/mxcd \
   --device /dev/dri \
   --group-add video \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/mthreads-musa4.3.6.md
+++ b/docs/content/zh-cn/runtime/mthreads-musa4.3.6.md
@@ -61,7 +61,7 @@ title: "mthreads-musa4.3.6"
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -71,7 +71,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/mthreads-musa5.2.0.md
+++ b/docs/content/zh-cn/runtime/mthreads-musa5.2.0.md
@@ -40,7 +40,7 @@ title: "mthreads-musa5.2.0"
 - `flag_gems`
 - `flagtree==0.6.0+mthreads3.6`
 - `mkl==2024.0.0`
-- `torch==2.9.0+musa5.2.0`
+- `torch==2.9.1+musa5.2.0`
 - `torch_musa==2.9.1`
 - <span class="muted"><code class="plain">triton==3.6.0</code></span>
 
@@ -61,7 +61,7 @@ title: "mthreads-musa5.2.0"
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -71,7 +71,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/nvidia-cuda12.8.md
+++ b/docs/content/zh-cn/runtime/nvidia-cuda12.8.md
@@ -60,7 +60,7 @@ title: "nvidia-cuda12.8"
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -73,7 +73,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/nvidia-cuda13.3.md
+++ b/docs/content/zh-cn/runtime/nvidia-cuda13.3.md
@@ -60,7 +60,7 @@ title: "nvidia-cuda13.3"
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -73,7 +73,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/sunrise-tangrt1.2.0.md
+++ b/docs/content/zh-cn/runtime/sunrise-tangrt1.2.0.md
@@ -45,11 +45,13 @@ title: "sunrise-tangrt1.2.0"
 
 ## 启动
 
-在容器中启动交互式 shell：
+启动交互式 shell（docker 或 podman 均可）：
 
 ```bash
 docker run --rm -it \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-sunrise-tangrt1.2.0:latest bash
+  --privileged \
+  -v /dev:/dev \
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-sunrise-tangrt1.2.0:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/content/zh-cn/runtime/tsingmicro-tsm260604.md
+++ b/docs/content/zh-cn/runtime/tsingmicro-tsm260604.md
@@ -63,7 +63,7 @@ title: "tsingmicro-tsm260604"
 docker run --rm -it \
   --runtime=tsingmicro \
   -e TSINGMICRO_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:2.1.1 bash
 ```
 
 **无需工具包** —— 直接使用 docker / podman：
@@ -72,7 +72,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/accel \
   --device /dev/accel_drv_mgr \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:2.1.1 bash
 ```
 
 ## 验证

--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -294,7 +294,7 @@ def main():
                         "env": env.get("base") or {},
                     },
                     "runtime": {
-                        "image": image(runtime_prefix, "runtime", name, "latest"),
+                        "image": image(runtime_prefix, "runtime", name, configs["version"]),
                         "python": spec.get("python", ""),
                         "packages": runtime_packages(spec),
                         "env": env.get("runtime") or {},

--- a/runtime/ascend-cann8.5.0.md
+++ b/runtime/ascend-cann8.5.0.md
@@ -34,7 +34,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -48,7 +48,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann8.5.0:2.1.1 bash
 ```
 
 ## Verify
@@ -56,5 +56,5 @@ docker run --rm -it \
 Inside the container, confirm the accelerator is visible:
 
 ```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
+npu-smi info
 ```

--- a/runtime/ascend-cann9.0.0.md
+++ b/runtime/ascend-cann9.0.0.md
@@ -34,7 +34,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   -e ASCEND_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -48,7 +48,7 @@ docker run --rm -it \
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
   -v /usr/local/dcmi:/usr/local/dcmi \
   -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-ascend-cann9.0.0:2.1.1 bash
 ```
 
 ## Verify
@@ -56,5 +56,5 @@ docker run --rm -it \
 Inside the container, confirm the accelerator is visible:
 
 ```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh && npu-smi info
+npu-smi info
 ```

--- a/runtime/cambricon-neuware4.4.3.md
+++ b/runtime/cambricon-neuware4.4.3.md
@@ -31,7 +31,7 @@ Start an interactive shell (works with docker or podman):
 docker run --rm -it \
   --device /dev/cambricon_dev0 \
   --device /dev/cambricon_ctl \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-cambricon-neuware4.4.3:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-cambricon-neuware4.4.3:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/enflame-tops1.9.10.md
+++ b/runtime/enflame-tops1.9.10.md
@@ -39,15 +39,16 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --network host \
   -e TENCENT_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
 
 ```bash
 docker run --rm -it \
-  --device /dev/gcu \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:latest bash
+  --privileged \
+  -v /dev:/dev \
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-enflame-tops1.9.10:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/hygon-dtk26.04.md
+++ b/runtime/hygon-dtk26.04.md
@@ -33,7 +33,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   -e DCU_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -46,7 +46,7 @@ docker run --rm -it \
   --group-add video \
   -v /opt/hyhal:/opt/hyhal \
   --security-opt seccomp=unconfined \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.1 bash
 ```
 
 ## Verify
@@ -54,5 +54,5 @@ docker run --rm -it \
 Inside the container, confirm the accelerator is visible:
 
 ```bash
-source /opt/hyhal/env.sh && hy-smi
+hy-smi
 ```

--- a/runtime/iluvatar-corex4.4.0.md
+++ b/runtime/iluvatar-corex4.4.0.md
@@ -31,7 +31,7 @@
 docker run --rm -it \
   --runtime iluvatar \
   --env IX_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -40,7 +40,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/iluvatar0 \
   -v /usr/local/corex:/usr/local/corex:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-iluvatar-corex4.4.0:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/kunlunxin-xre5.29.0.md
+++ b/runtime/kunlunxin-xre5.29.0.md
@@ -48,7 +48,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --runtime xpu \
   -e CXPU_VISIBLE_DEVICES=0 \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -57,7 +57,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/xpu0 \
   --device /dev/xpuctrl \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-kunlunxin-xre5.29.0:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/metax-maca3.7.2.1.md
+++ b/runtime/metax-maca3.7.2.1.md
@@ -36,7 +36,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 metax-docker \
   --gpus all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -46,7 +46,7 @@ docker run --rm -it \
   --device /dev/mxcd \
   --device /dev/dri \
   --group-add video \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/mthreads-musa4.3.6.md
+++ b/runtime/mthreads-musa4.3.6.md
@@ -41,7 +41,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -51,7 +51,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa4.3.6:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/mthreads-musa5.2.0.md
+++ b/runtime/mthreads-musa5.2.0.md
@@ -20,7 +20,7 @@
 - `flag_gems`
 - `flagtree==0.6.0+mthreads3.6`
 - `mkl==2024.0.0`
-- `torch==2.9.0+musa5.2.0`
+- `torch==2.9.1+musa5.2.0`
 - `torch_musa==2.9.1`
 - `triton==3.6.0` *(alternative)*
 
@@ -41,7 +41,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --runtime mthreads \
   --env MTHREADS_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -51,7 +51,7 @@ docker run --rm -it \
   --device /dev/mtgpu.0 \
   --device /dev/dri \
   -v /usr/bin/mthreads-gmi:/usr/bin/mthreads-gmi:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-mthreads-musa5.2.0:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/nvidia-cuda12.8.md
+++ b/runtime/nvidia-cuda12.8.md
@@ -40,7 +40,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -53,7 +53,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/nvidia-cuda13.3.md
+++ b/runtime/nvidia-cuda13.3.md
@@ -40,7 +40,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 ```bash
 docker run --rm -it \
   --gpus all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -53,7 +53,7 @@ docker run --rm -it \
   -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro \
   -v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro \
   -v /usr/lib/x86_64-linux-gnu/libcuda.so.1:/usr/lib/x86_64-linux-gnu/libcuda.so.1:ro \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda13.3:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/sunrise-tangrt1.2.0.md
+++ b/runtime/sunrise-tangrt1.2.0.md
@@ -25,11 +25,13 @@
 
 ## Launch
 
-Start an interactive shell in the container:
+Start an interactive shell (works with docker or podman):
 
 ```bash
 docker run --rm -it \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-sunrise-tangrt1.2.0:latest bash
+  --privileged \
+  -v /dev:/dev \
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-sunrise-tangrt1.2.0:2.1.1 bash
 ```
 
 ## Verify

--- a/runtime/tsingmicro-tsm260604.md
+++ b/runtime/tsingmicro-tsm260604.md
@@ -43,7 +43,7 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 docker run --rm -it \
   --runtime=tsingmicro \
   -e TSINGMICRO_VISIBLE_DEVICES=all \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:2.1.1 bash
 ```
 
 **Without a toolkit** — plain docker / podman:
@@ -52,7 +52,7 @@ docker run --rm -it \
 docker run --rm -it \
   --device /dev/accel \
   --device /dev/accel_drv_mgr \
-  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:latest bash
+  harbor.baai.ac.cn/flagos-runtime/flagos-runtime-tsingmicro-tsm260604:2.1.1 bash
 ```
 
 ## Verify

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -284,14 +284,15 @@ def main():
     build_args["NO_FLAGGEMS"] = "1" if args.no_flaggems else ""
 
     image_name = f"flagos-runtime-{vendor}-{backend}"
+    version = configs["version"]
 
     if args.tag:
         tag = args.tag
     elif args.registry:
-        tag = f"{args.registry}/{image_name}:latest"
+        tag = f"{args.registry}/{image_name}:{version}"
     else:
         registry = runtime_registry(repo_root)
-        tag = f"{registry}/{image_name}:latest" if registry else f"{image_name}:latest"
+        tag = f"{registry}/{image_name}:{version}" if registry else f"{image_name}:{version}"
 
     cmd = ["docker", "build"]
     for key, value in build_args.items():


### PR DESCRIPTION
Runtime images now use `configs.yaml version:` (e.g. `:2.1.1`) instead of `:latest`, matching the base image convention. The CI matrix (`generate_matrix.py`) already used versioned tags; this aligns `build_runtime.py` and `gen_data.py`.

## Changes

- **scripts/build_runtime.py** — default tag from `configs["version"]` (no `latest` fallback)
- **docs/gen_data.py** — runtime image entries use `configs["version"]`
- **configs.yaml / CLAUDE.md / RELEASE.md** — updated naming convention
- **Generated files** — `gen_data.py` + `gen_descriptions.py` regenerated (`runtime/*.md`, Hugo pages)

`--tag` / `--registry` overrides still work for manual/dev builds.

## Verification

```bash
# Default is now versioned
$ python scripts/build_runtime.py nvidia-cuda12.8 --dry-run | grep flagos-runtime-nvidia-cuda12.8
-t harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:2.1.1

# --tag latest still works as explicit override
$ python scripts/build_runtime.py nvidia-cuda12.8 --dry-run --tag latest
-t latest

# CI matrix unchanged (already used version)
$ python scripts/generate_matrix.py --runtime | jq ".include[0].image_tag"
"harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cuda12.8:2.1.1"
```

This PR was written in part with the assistance of generative AI.