### PR TITLE
fix(config): metax-docker toolkit command — remove broken --gpus all

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -83,8 +83,8 @@ run:
       # errors "Open mkfd failed"; /dev/mkfd carries that telemetry.
       raw: "--device /dev/kfd --device /dev/mkfd --device /dev/dri --group-add video -v /opt/hyhal:/opt/hyhal --security-opt seccomp=unconfined"
     metax:
-      # metax-docker is a wrapper launcher (replaces `docker run`), not flags.
-      toolkit_cmd: "metax-docker --gpus all {image} bash"
+      # metax-docker is a `docker` wrapper (drop-in replacement), not flags.
+      toolkit_cmd: "metax-docker run --rm -it {image} bash"
       raw: "--device /dev/mxcd --device /dev/dri --group-add video"
     mthreads:
       toolkit: "--runtime mthreads --env MTHREADS_VISIBLE_DEVICES=all"

--- a/docs/content/en/runtime/metax-maca3.7.2.1.md
+++ b/docs/content/en/runtime/metax-maca3.7.2.1.md
@@ -55,7 +55,9 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 
 ```bash
 metax-docker \
-  --gpus all \
+  run \
+  --rm \
+  -it \
   harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:2.1.1 bash
 ```
 

--- a/docs/content/zh-cn/runtime/metax-maca3.7.2.1.md
+++ b/docs/content/zh-cn/runtime/metax-maca3.7.2.1.md
@@ -55,7 +55,9 @@ title: "metax-maca3.7.2.1"
 
 ```bash
 metax-docker \
-  --gpus all \
+  run \
+  --rm \
+  -it \
   harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:2.1.1 bash
 ```
 

--- a/runtime/metax-maca3.7.2.1.md
+++ b/runtime/metax-maca3.7.2.1.md
@@ -35,7 +35,9 @@ This image includes both FlagTree (default) and Triton. To switch, run `compiler
 
 ```bash
 metax-docker \
-  --gpus all \
+  run \
+  --rm \
+  -it \
   harbor.baai.ac.cn/flagos-runtime/flagos-runtime-metax-maca3.7.2.1:2.1.1 bash
 ```
 


### PR DESCRIPTION
metax-docker is a drop-in `docker` replacement; it does not accept `--gpus all` (panics with `"invalid arg --gpus"`). Fix the `toolkit_cmd` in `build-config.yml` to use the correct form.

## Before
```
metax-docker --gpus all {image} bash
```
→ panics: `invalid arg --gpus`

## After
```
metax-docker run --rm -it {image} bash
```
→ works correctly (verified on metax123, 8 devices visible)

Also verified: raw (device passthrough `--device /dev/mxcd --device /dev/dri --group-add video`) works.

This PR was written in part with the assistance of generative AI.