### PR TITLE
fix(base): add libelf1 to enflame base image

### DIFF
--- a/base/enflame-tops1.9.10
+++ b/base/enflame-tops1.9.10
@@ -29,7 +29,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # ── System packages ────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl git vim ca-certificates \
+        curl git vim ca-certificates libelf1 \
         gcc g++ build-essential cmake \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Enflame SDK library `libefrt.so` links against `libelf.so.1`, but the base image does not install `libelf1`. This causes `torch.gcu.is_available()` to fail with:

```
efosLoadLibrary efos dlopen(libefrt.so) failed: libelf.so.1: cannot open shared object file
Failed to load EFDRV library.
```

## Fix

Add `libelf1` to the apt install line in `base/enflame-tops1.9.10`.

## Verification

- Container launches fine (both raw and toolkit modes)
- GCU device access fails before fix, passes after

This PR was written in part with the assistance of generative AI.