### PR TITLE
fix(runtime): use --default-index for vendor index, --index for mirror

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -94,8 +94,8 @@ RUN if [ -n "${DEPS}" ]; then \
       for i in 1 2 3; do \
         if uv pip install --no-cache-dir ${DEPS} \
           --index-strategy unsafe-best-match \
-          --index ${FLAGOS_PYPI} \
-          --extra-index-url ${EXTRA_PYPI}; then \
+          --default-index ${FLAGOS_PYPI} \
+          --index ${EXTRA_PYPI}; then \
           _installed=0; break; \
         fi; \
         echo "DEPS install attempt $i failed, retrying..."; \
@@ -128,8 +128,8 @@ RUN if [ -n "${FLAGTREE_PKG}" ]; then \
       for i in 1 2 3; do \
         if uv pip install --no-cache-dir ${FLAGTREE_PKG} \
           --index-strategy unsafe-best-match \
-          --index ${FLAGOS_PYPI} \
-          --extra-index-url ${EXTRA_PYPI}; then \
+          --default-index ${FLAGOS_PYPI} \
+          --index ${EXTRA_PYPI}; then \
           _installed=0; break; \
         fi; \
         echo "FlagTree install attempt $i failed, retrying..."; \
@@ -150,8 +150,8 @@ RUN if [ -n "${TRITON_PKG}" ]; then \
       for i in 1 2 3; do \
         if uv pip install --no-cache-dir ${target_flag} \
           --index-strategy unsafe-best-match \
-          --index ${FLAGOS_PYPI} \
-          --extra-index-url ${EXTRA_PYPI} \
+          --default-index ${FLAGOS_PYPI} \
+          --index ${EXTRA_PYPI} \
           ${TRITON_PKG}; then \
           _installed=0; break; \
         fi; \
@@ -163,8 +163,8 @@ RUN if [ -n "${TRITON_PKG}" ]; then \
         for i in 1 2 3; do \
           if uv pip install --no-cache-dir ${target_flag} \
             --index-strategy unsafe-best-match \
-            --index ${FLAGOS_PYPI} \
-            --extra-index-url ${EXTRA_PYPI} \
+            --default-index ${FLAGOS_PYPI} \
+            --index ${EXTRA_PYPI} \
             ${TRITON_EXTRA_PKGS}; then \
             _installed=0; break; \
           fi; \
@@ -187,9 +187,9 @@ RUN if [ -n "${NO_FLAGGEMS}" ]; then \
       for i in 1 2 3; do \
         if uv pip install --no-cache-dir --prerelease=allow \
           --index-strategy unsafe-first-match \
-          --index ${FLAGOS_PYPI} \
+          --default-index ${FLAGOS_PYPI} \
           --index ${DAILY_PYPI} \
-          --extra-index-url ${EXTRA_PYPI} \
+          --index ${EXTRA_PYPI} \
           --trusted-host resource.flagos.net \
           "flag_gems${CPP_EXTRA:+[${CPP_EXTRA}]}==${FLAGGEMS_VERSION}"; then \
           _installed=0; break; \


### PR DESCRIPTION
uv with `--index` + `--extra-index-url` may still fall back to pypi.org for transitive deps not found in either index. Switch to `--default-index` (which replaces pypi.org as the default) for the vendor index, and `--index` for the Aliyun mirror fallback.

## Pattern

```
--default-index ${FLAGOS_PYPI}   # vendor index is the default primary source
--index ${EXTRA_PYPI}            # mirror catches transitive deps (numpy, etc.)
```

## Changed install steps

- DEPS (vendor packages)
- FlagTree
- Triton
- Triton extra
- FlagGems (additional `--index ${DAILY_PYPI}` kept for pre-release)

This PR was written in part with the assistance of generative AI.