### PR TITLE
fix(runtime): split FlagGems install — pure wheel first, cpp extra separate

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -187,16 +187,27 @@ RUN if [ -n "${NO_FLAGGEMS}" ]; then \
       for i in 1 2 3; do \
         if uv pip install --no-cache-dir --prerelease=allow \
           --index-strategy unsafe-first-match \
-          --default-index ${FLAGOS_PYPI} \
+          --index ${FLAGOS_PYPI} \
           --index ${DAILY_PYPI} \
           --index ${EXTRA_PYPI} \
           --trusted-host resource.flagos.net \
-          "flag_gems${CPP_EXTRA:+[${CPP_EXTRA}]}==${FLAGGEMS_VERSION}"; then \
+          "flag_gems==${FLAGGEMS_VERSION}"; then \
           _installed=0; break; \
         fi; \
         echo "FlagGems install attempt $i failed, retrying..."; \
       done; \
       [ "$_installed" -eq 0 ] || { echo "ERROR: FlagGems install failed after 3 attempts"; exit 1; }; \
+      if [ -n "${CPP_EXTRA}" ]; then \
+        uv pip install --no-cache-dir --prerelease=allow \
+          --index-strategy unsafe-first-match \
+          --index ${FLAGOS_PYPI} \
+          --index ${DAILY_PYPI} \
+          --index ${EXTRA_PYPI} \
+          --trusted-host resource.flagos.net \
+          "flag-gems-${CPP_EXTRA}==${FLAGGEMS_VERSION}" 2>/dev/null \
+          && echo "cpp extension ${CPP_EXTRA} installed" \
+          || echo "cpp extension ${CPP_EXTRA} not available (skipped)"; \
+      fi; \
       if find /flagos -name 'c_operators*.so' 2>/dev/null | grep -q .; then \
         echo "cpp extension .so detected — enabling USE_C_EXTENSION"; \
         printf 'export USE_C_EXTENSION=1\n' > /etc/profile.d/use_c_extension.sh; \


### PR DESCRIPTION
Previously `flag_gems[cpp-gcu]==X.Y.Z` was installed as one step; when the cpp wheel is not yet published to the index, uv refuses the entire install even though extras are declared optional.

Split into two steps:
1. `flag_gems==X.Y.Z` — pure Python wheel, 3× retry (must succeed)
2. `flag-gems-cpp-<vendor>==X.Y.Z` — best-effort, failure is non-fatal

The existing auto-detect logic (find `c_operators*.so` → `USE_C_EXTENSION=1`) is unchanged.

This PR was written in part with the assistance of generative AI.