### PR TITLE
fix(ci): add runtime descriptions workflow + flag_gems versioning + -build tag

### DIFF
--- a/.github/workflows/runtime-descriptions.yml
+++ b/.github/workflows/runtime-descriptions.yml
@@ -1,0 +1,71 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Runtime Image Descriptions
+
+# Post-build: generate runtime image description markdown (single source for the
+# docs site, the in-repo runtime/<name>.md file, and the Harbor repository
+# description), then commit + upload.
+#
+# Triggered automatically when a runtime image build completes successfully, or
+# manually via workflow_dispatch.
+#
+# Simpler than base-descriptions: runtime descriptions don't need dpkg-query
+# version extraction — they render the Python software stack from configs.yaml.
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Runtime Image Build (manual)"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  finalize:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+
+      - name: Generate data and descriptions
+        env:
+          VERSIONS_DIR: ${{ github.workspace }}/versions
+        run: |
+          python3 docs/gen_data.py
+          mkdir -p versions
+          python3 docs/gen_descriptions.py
+
+      - name: Finalize (commit + PR)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          git config user.name flagos-ci
+          git config user.email noreply@flagos.net
+
+          LABEL=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo latest)
+          python3 scripts/finalize_descriptions.py \
+            --mode runtime \
+            --done true \
+            --count 14 \
+            --label "$LABEL" \
+            --verify-ok 0 --verify-fail 0 --verify-skip 0

--- a/.github/workflows/runtime-descriptions.yml
+++ b/.github/workflows/runtime-descriptions.yml
@@ -18,17 +18,13 @@ name: Runtime Image Descriptions
 # docs site, the in-repo runtime/<name>.md file, and the Harbor repository
 # description), then commit + upload.
 #
-# Triggered automatically when a runtime image build completes successfully, or
-# manually via workflow_dispatch.
-#
-# Simpler than base-descriptions: runtime descriptions don't need dpkg-query
-# version extraction — they render the Python software stack from configs.yaml.
+# Triggered manually when the final runtime image (v2, with flag_gems) has been
+# built and pushed. Not triggered by workflow_run because runtime:v2 is rebuilt
+# repeatedly during the FlagGems testing phase — automatic triggering would
+# produce noisy empty PRs.
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Runtime Image Build (manual)"]
-    types: [completed]
 
 permissions:
   contents: write

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -81,11 +81,14 @@ gh pr list --head auto/image-descriptions-*
 
 ## 4. 构建 runtime:v1（构建平台）
 
-> **手动触发。** 产出不含 FlagGems 的运行时镜像，用于步骤 5 的 cpp wheel 编译。仅本地保存，不推 Harbor。
+> **手动触发。** 产出不含 FlagGems 的运行时镜像（`:{version}-build`），用于步骤 5 的 FlagGems wheel 编译。
 
 ```bash
-gh workflow run "Runtime Image Build (manual)" -f backend="all" -f push="false" -f no_flaggems="true"
+gh workflow run "Runtime Image Build (manual)" -f backend="all" -f push="true" -f no_flaggems="true"
 ```
+
+镜像 tag: `:{version}-build`（如 `:2.2.0-build`）。
+推送到 Harbor 供 FlagGems CI 拉取。
 
 验证方式：
 ```bash
@@ -98,6 +101,7 @@ gh run view <RUN_ID> --json jobs -q '...'  # 同步骤 2
 如果只有部分 backend 需要 runtime:v1（比如只验证 nvidia），可以只触发指定 backend：
 ```bash
 gh workflow run "Runtime Image Build (manual)" -f backend="nvidia-cuda13.3" -f no_flaggems="true"
+gh workflow run "Runtime Image Build (manual)" -f backend="nvidia-cuda13.3" -f push="true" -f no_flaggems="true"
 ```
 
 ## 5. FlagGems 构建 wheels
@@ -140,6 +144,12 @@ gh workflow run "Runtime Image Build (manual)" -f backend="all" -f push="true"
 
 `flaggems` 留空 — 自动读取 `configs.yaml` 中的版本。
 
+镜像 tag: `:{version}`（如 `:2.2.0`）。注意与步骤 4 的 `:{version}-build` 区分 — 后者是构建平台，不含 FlagGems；前者是最终交付物。
+
+> **注意：** 步骤 5（FlagGems 迭代测试）可能持续数周，期间步骤 6 会被反复执行。
+> 每次 `configs.yaml` 更新 deps 或 FlagGems 修复后，都需要重新构建 runtime:v2 来验证。
+> 步骤 8（生成 runtime 描述）只在最终验证通过后执行一次。
+
 ## 7. 验证 runtime v2（端到端）
 
 在对应硬件的节点上手动验证：
@@ -156,13 +166,16 @@ docker run --gpus all harbor.baai.ac.cn/flagos-runtime/flagos-runtime-nvidia-cud
 
 ## 8. 更新 runtime 描述
 
-> **手动触发**
+> **手动触发。**
 
 ```bash
-gh workflow run "Base image descriptions"
+gh workflow run "Runtime Image Descriptions"
 ```
 
 生成 runtime 页面最终版本（含 `flag_gems` 版本号）。Review + merge PR。
+
+> **注意：** 此步骤只在 runtime:v2 最终验证通过后执行一次。
+> 描述内容来自 `configs.yaml`，runtime 镜像构建本身不触发此工作流。
 
 ## 9. 打 release tag
 

--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -175,7 +175,7 @@ def pick(deps, name):
     return ""
 
 
-def runtime_packages(spec: dict) -> list:
+def runtime_packages(spec: dict, flaggems_version: str = "") -> list:
     """Merged, sorted 'Major Python packages' list for the runtime image:
     deps + the compiler (flagtree and/or triton) + FlagGems.
 
@@ -195,7 +195,8 @@ def runtime_packages(spec: dict) -> list:
         label = f"{triton} (+ {', '.join(post)})" if post else triton
         items.append({"pkg": label, "muted": bool(flagtree)})
 
-    items.append({"pkg": "flag_gems", "muted": False})
+    fg = f"flag_gems=={flaggems_version}" if flaggems_version else "flag_gems"
+    items.append({"pkg": fg, "muted": False})
     items.sort(key=lambda x: x["pkg"].lower())
     return items
 
@@ -296,7 +297,7 @@ def main():
                     "runtime": {
                         "image": image(runtime_prefix, "runtime", name, configs["version"]),
                         "python": spec.get("python", ""),
-                        "packages": runtime_packages(spec),
+                        "packages": runtime_packages(spec, configs.get("flaggems", "")),
                         "env": env.get("runtime") or {},
                     },
                 }

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -289,11 +289,13 @@ def main():
 
     if args.tag:
         tag = args.tag
-    elif args.registry:
-        tag = f"{args.registry}/{image_name}:{version}"
     else:
-        registry = runtime_registry(repo_root)
-        tag = f"{registry}/{image_name}:{version}" if registry else f"{image_name}:{version}"
+        suffix = "-build" if args.no_flaggems else ""
+        if args.registry:
+            tag = f"{args.registry}/{image_name}:{version}{suffix}"
+        else:
+            registry = runtime_registry(repo_root)
+            tag = f"{registry}/{image_name}:{version}{suffix}" if registry else f"{image_name}:{version}{suffix}"
 
     cmd = ["docker", "build"]
     for key, value in build_args.items():


### PR DESCRIPTION
## Summary

- New `runtime-descriptions.yml` workflow (`workflow_dispatch` only — not auto-triggered because runtime:v2 is rebuilt repeatedly during FlagGems testing)
- `gen_data.py`: runtime packages now include flag_gems version from `configs.yaml` (`flag_gems==5.3.1` instead of just `flag_gems`)
- `build_runtime.py`: `--no-flaggems` automatically appends `-build` suffix to image tag (`:{version}-build`)
- `RELEASE.md`: steps 4/6/8 updated with `-build` tagging scheme and new workflow

## Image tag scheme

| Phase | Tag |
|---|---|
| Build platform (no flag_gems) | `:{version}-build` |
| Final release (with flag_gems) | `:{version}` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)