### PR TITLE
Update configuration for kunlunxin base image

### DIFF
--- a/base/kunlunxin-xre5.37.1
+++ b/base/kunlunxin-xre5.37.1
@@ -13,16 +13,10 @@
 # limitations under the License.
 
 # ============================================================
-# Base image for Kunlunxin XPU 5.29.0 on Ubuntu 24.04
+# Base image for Kunlunxin XPU 5.37.1 on Ubuntu 24.04
 # ============================================================
 # History:
-# - 20260608: Initial version
-# - 20260716: Bump base OS 22.04 -> 24.04 for flagtree (needs newer libstdc++).
-#   Kunlunxin's XRE/XCUDART packages carry no OS tag and are unchanged here:
-#   their binaries link older glibc/libstdc++ and run on 24.04's newer libs
-#   (forward-compatible), while the 24.04 base satisfies flagtree's GLIBCXX floor.
-# - 20260727: Rever base OS to 22.04 after confirmation with vendor. The
-#   promise is that flagtree 0.6x+xpu3.6 works on 22.04.
+# - 20260727: Initial version
 
 FROM ubuntu:22.04
 
@@ -31,7 +25,7 @@ LABEL org.opencontainers.image.authors="FlagOS contributors"
 # ── Build arguments ────────────────────────────────────────────
 ARG FILE_STORE=https://resource.flagos.net/repository/flagos-filestore
 ARG CUDA_PACKAGE=cuda_12.9.0_575.51.03_linux.run
-ARG XRE_PACKAGE=xre-Linux-x86_64-cuda12-5.29.0.0.run
+ARG XRE_PACKAGE=xre-Linux-x86_64-cuda12-5.37.1.0.run
 ARG XCUDART_PACKAGE=xcudart-5.13.0_amd64.deb
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -40,7 +34,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
        git vim ca-certificates curl \
        gcc g++ build-essential make cmake \
-       pciutils kmod \
+       pciutils \
    && rm -rf /var/lib/apt/lists/*
 
 # ── Install CUDA ────────────────────────────────────────────────
@@ -51,9 +45,7 @@ RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /cuda.run ${FILE_STORE}
 # ── Install XRE ────────────────────────────────────────────────
 RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/xre.run ${FILE_STORE}/kunlunxin/${XRE_PACKAGE} \
     && cd /tmp \
-    && bash xre.run --extract-only \
-    && cd /tmp/xre-Linux-x86_64 \
-    && ./xpu-installer --no-kernel-modules --skip-module-load --no-kunlun-modprobe --no-peermem --no-dkms --no-questions \
+    && bash /tmp/xre.run --no-kernel-modules --skip-module-load --no-kunlun-modprobe --no-peermem --no-dkms --no-questions \
     && rm -fr /tmp/*
 
 # ── Install XCUDART ────────────────────────────────────────────

--- a/configs.yaml
+++ b/configs.yaml
@@ -85,7 +85,7 @@ runtime_prereqs:
   - "pybind11==3.0.3"
   - "ninja==1.13.0"
   - "PyYAML==6.0.1"
-  - "numpy==1.26.4"
+  - "numpy==2.3.5"
 
 base_image_prefix: "flagos-base"
 
@@ -287,7 +287,7 @@ vendors:
     xre5.29.0:
       extras: kunlunxin
       hardware: ["Kunlunxin P800"]
-      driver: "5.29.0.0"
+      driver: "5.29.0"
       python: "3.10"
       triton: triton==3.0.0+a48aedef
       flagtree: flagtree==0.5.1+xpu3.0
@@ -311,6 +311,20 @@ vendors:
         - torch_xray==2.0.4
         - xformers==0.0.29+1e7a8ec.d20260114
         - xmlir==1.0.0.1
+      sdk:
+        - CUDA 12.9.0_575.51.03     # cuda_12.9.0_575.51.03_linux.run
+        - XRE-CUDA12 5.29.0.0       # xre-Linux-x86_64-cuda12-5.29.0.0.run
+        - XCUDART 5.13.0            # xcudart-5.13.0_amd64.deb
+
+    xre5.37.1:
+      extras: kunlunxin
+      hardware: ["Kunlunxin P800"]
+      driver: "5.37.1"
+      python: "3.10"
+      env:
+        base:
+          PATH: /usr/local/xpu/bin:$PATH
+          LD_LIBRARY_PATH: /usr/local/xpu/lib:/usr/local/xcudart/lib
       sdk:
         - CUDA 12.9.0_575.51.03     # cuda_12.9.0_575.51.03_linux.run
         - XRE-CUDA12 5.29.0.0       # xre-Linux-x86_64-cuda12-5.29.0.0.run


### PR DESCRIPTION
This PR updates the base image container files.

- Downgrade base OS from 24.04 to 22.04 for 5.29.0 SDK.
- Add make to 5.29.0 SDK.
- Add new 5.37.1 SDK.
- New SDK copies the contents from 5.29.0, except for:
  1. No `kmod` installation.
  2. Updated the xre run version.
 