### PR TITLE
Update configuration for enflame 1.9.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 *.pyc
+.mcp.json
 .claude/
 .github/workflows/.runtime.yml.swp

--- a/base/enflame-tops1.9.17
+++ b/base/enflame-tops1.9.17
@@ -1,0 +1,59 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ============================================================
+# Base image for Enflame 1.9.17 on Ubuntu 24.04
+# ============================================================
+# History:
+# - 20260727: Initial version
+
+FROM ubuntu:24.04
+
+LABEL org.opencontainers.image.authors="FlagOS contributors"
+
+# ── Build arguments ────────────────────────────────────────────
+ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/enflame
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl git vim ca-certificates libelf1 \
+        gcc g++ build-essential make cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Enflame Runtime packages ───────────────────────────────────
+RUN curl -fsSL -o enflame.run \
+      ${FILE_STORE}/enflame-x86_64-gcc-1.9.17-20260604115152.run \
+    && chmod +x enflame.run \
+    && ./enflame.run --no-kernel-modules \
+    && rm -f enflame.run
+
+RUN curl -fsSL -O ${FILE_STORE}/topsruntime_1.9.17-1_amd64.deb \
+      -O ${FILE_STORE}/topscc_1.9.17-1_amd64.deb \
+      -O ${FILE_STORE}/efml_1.9.17-1_amd64.deb \
+      -O ${FILE_STORE}/topspti_1.9.17-1_amd64.deb \
+      -O ${FILE_STORE}/gculare-perftest_1.9.17-1_amd64.deb \
+      -O ${FILE_STORE}/topsaten_3.7.20260602-1_amd64.deb \
+      -O ${FILE_STORE}/eccl_3.6.3.11-1_amd64.deb \
+      -O ${FILE_STORE}/eccl-tests_3.6.3.11-1_amd64.deb \
+      -O ${FILE_STORE}/triton-gcu_3.6.0+1.0.20260610.cc.1.9.17-1_amd64.deb \
+      -O ${FILE_STORE}/topstx_1.9.17-1_amd64.deb \
+    && dpkg -i *.deb || true \
+    && apt-get install -yf 2>/dev/null || true \
+    && rm -f *.deb
+
+# flagtree toolkit.py expects /opt/triton_gcu but triton-gcu deb
+# installs to /opt/triton/triton_gcu.
+# RUN ln -sf /opt/triton/triton_gcu /opt/triton_gcu

--- a/configs.yaml
+++ b/configs.yaml
@@ -225,7 +225,9 @@ vendors:
       driver: "1.9.10"
       python: "3.12"
       cmake_backend: GCU
-      triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
+      triton: triton==3.6.0
+      triton_post_install:
+        - triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
       flagtree: flagtree==0.6.0+enflame3.6
       deps:
         - pyefml==1.9.10
@@ -245,6 +247,36 @@ vendors:
         - ECCL 3.6.3.11           # eccl_3.6.3.11-1_amd64.deb
         - Triton GCU 3.6.0+1.0.20260521.cc.1.9.10  # triton-gcu_3.6.0+1.0.20260521.cc.1.9.10-1_amd64.deb
         - Gculare-perftest 1.9.10 # gculare-perftest_1.9.10-1_amd64.deb
+
+    tops1.9.17:
+      extras: enflame
+      hardware: ["Enflame Zixiao C200 (S60)"]
+      driver: "1.9.17"
+      python: "3.12"
+      cmake_backend: GCU
+      triton: triton==3.6.0
+      triton_post_install:
+        - triton-gcu==3.6.0+1.0.20260722
+      flagtree: flagtree==0.6.0+enflame.git657f543d
+      deps:
+        - pyefml==1.9.17
+        - torch==2.10.0+cpu
+        - torchaudio==2.10.0+cpu
+        - torchvision==0.25.0+cpu
+        - torch-gcu==2.10.0+3.7.20260408
+        - topstx==1.9.17
+      sdk:
+        - Enflame driver 1.9.17   # enflame-x86_64-gcc-1.9.17-20260604115152.run
+        - TOPS Runtime 1.9.17     # topsruntime_1.9.17-1_amd64.deb
+        - TOPS CC 1.9.17          # topscc_1.9.17-1_amd64.deb
+        - TOPS PTI 1.9.17         # topspti_1.9.17-1_amd64.deb
+        - TOPSTX 1.9.17           # topstx_1.9.17-1_amd64.deb
+        - TOPS ATen 3.7.20260602  # topsaten_3.7.20260602-1_amd64.deb
+        - EFML 1.9.17             # efml_1.9.17-1_amd64.deb
+        - ECCL 3.6.3.11           # eccl_3.6.3.11-1_amd64.deb
+        - ECCL Tests 3.6.3.11           # eccl-tests_3.6.3.11-1_amd64.deb
+        - Triton GCU 3.6.0+1.0.20260610.cc.1.9.17  # triton-gcu_3.6.0+1.0.20260610.cc.1.9.17-1_amd64.deb
+        - Gculare-perftest 1.9.17 # gculare-perftest_1.9.17-1_amd64.deb
 
   hygon:
     dtk26.04:


### PR DESCRIPTION
This PR updates the configuration for new Enflame 1.9.17 base image.
The SDK has been bumped to a new version.