### PR TITLE
Bump FlagGems version to 5.3.2

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -62,7 +62,7 @@
 #
 # At release: bump both fields → git tag v<VERSION> → done.
 version: "2.1.1"
-flaggems: "5.3.1"
+flaggems: "5.3.2"
 
 # Versions of build tools needed to compile the cpp operator wheel inside the
 # runtime:v1 container.  Pinned so a future pip install won't silently pull an


### PR DESCRIPTION
We bumped the FlagGems version to 5.3.2 to fix a numpy version lock problem.