### PR TITLE
fix(vllm-repack): prevent blank lines in METADATA after 2.4→2.2 downgrade

### DIFF
--- a/vllm-repack/repack.py
+++ b/vllm-repack/repack.py
@@ -121,8 +121,8 @@ def _strip_requires_dist_lines(metadata_text: str, names_to_remove: set[str]) ->
 
 _METADATA_VERSION_RE = re.compile(r"^Metadata-Version:\s*.+$", re.MULTILINE | re.IGNORECASE)
 _LICENSE_EXPRESSION_RE = re.compile(r"^License-Expression:\s*.+$", re.MULTILINE | re.IGNORECASE)
-_LICENSE_FILE_RE = re.compile(r"^License-File:\s*.+$", re.MULTILINE | re.IGNORECASE)
-_DYNAMIC_RE = re.compile(r"^Dynamic:\s*.+$", re.MULTILINE | re.IGNORECASE)
+_LICENSE_FILE_RE = re.compile(r"^License-File:\s*.+\n?", re.MULTILINE | re.IGNORECASE)
+_DYNAMIC_RE = re.compile(r"^Dynamic:\s*.+\n?", re.MULTILINE | re.IGNORECASE)
 
 
 def _downgrade_metadata_version(text: str) -> str:


### PR DESCRIPTION
## What

Fix a critical bug in repack.py's `_downgrade_metadata_version()`: when stripping `License-File` and `Dynamic` fields (Metadata-Version 2.4→2.2 downgrade), the regex replaced them with empty strings, leaving blank lines in the METADATA header section.

## Why it matters

In email-format METADATA headers, **the first blank line marks the end of header fields**. All `Requires-Dist` lines after a stray blank line are invisible to pip — pip treats them as message body, not headers. 

The symptom: pip installs the repacked wheel but doesn't resolve any of its safe dependencies. vllm import fails because packages like `regex`, `fastapi` etc. are never installed.

## Fix

Add `\n?` to the regex patterns to eat the trailing newline:

```python
# Before (leaves blank line):
_LICENSE_FILE_RE = re.compile(r"^License-File:\s*.+$", re.M)
_DYNAMIC_RE = re.compile(r"^Dynamic:\s*.+$", re.M)

# After (no blank line):
_LICENSE_FILE_RE = re.compile(r"^License-File:\s*.+\n?", re.M)
_DYNAMIC_RE = re.compile(r"^Dynamic:\s*.+\n?", re.M)
```

## Verification

Tested on H20 node with vllm 0.20.2: before this fix, `pip install repacked-vllm.whl` installed 0 dependencies; after fix, all 82 safe Requires-Dist entries are properly resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)