### PR TITLE
fix(ci): switch SDK reminder to pull_request_target for fork PRs

### DIFF
--- a/.github/workflows/sdk-reminder.yaml
+++ b/.github/workflows/sdk-reminder.yaml
@@ -18,9 +18,14 @@ name: SDK section reminder
 # the maintainer to update that backend's `sdk:` list in configs.yaml if the
 # installed SDK packages changed. The decision is left to a human — no automated
 # package tracking.
+#
+# Uses pull_request_target (not pull_request) so that the GITHUB_TOKEN retains
+# pull-requests: write on fork PRs. Safe: this workflow never checks out PR code
+# or runs user-controlled content — it only calls the GitHub API via a trusted
+# github-script action.
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'base/**'
 


### PR DESCRIPTION
## Problem

PR #224 ("Update configuration for cambricon base image") is from a fork. The "SDK section reminder" workflow silently fails because `pull_request` events on fork PRs get a **read-only** `GITHUB_TOKEN`, regardless of declared permissions.

Error: `HttpError: Resource not accessible by integration` (403) from `github.rest.issues.createComment`.

## Fix

Switch trigger from `pull_request` to `pull_request_target`. This is safe because:

- The workflow **never checks out PR code** — it only calls the GitHub API
- It only runs a trusted `actions/github-script@v9` action
- No user-controlled content is executed on the runner

## Reproducer

Any fork PR that modifies `base/**` will hit this. Before this fix, the job silently fails 403. After, the comment should post normally.

This PR was written in part with the assistance of generative AI.