### PR TITLE
fix: add missing shutil import in collect_version_tsvs.py

### DIFF
--- a/scripts/collect_version_tsvs.py
+++ b/scripts/collect_version_tsvs.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path


### PR DESCRIPTION
PR #228 removed `import shutil` along with the `shutil.rmtree` call, but `shutil.copy2` is still used to merge freshly-fetched TSV files. This causes a `NameError: name 'shutil' is not defined` in the accumulate job.

One-line fix: add `import shutil` back.

This PR was written in part with the assistance of generative AI.