### PR TITLE
fix(ci): rename state branch to avoid ref namespace collision

### DIFF
--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -225,7 +225,7 @@ jobs:
           GIT_COMMITTER_EMAIL: noreply@flagos.net
         run: |
           label="$(git describe --tags --abbrev=0 | sed 's/^v//')"
-          state_branch="auto/versions-${label}"
+          state_branch="auto/versions-${label}-state"
           if git ls-remote --heads origin "refs/heads/${state_branch}" | grep -q refs; then
             echo "Restoring state from ${state_branch}"
             git fetch origin "${state_branch}"
@@ -273,7 +273,7 @@ jobs:
           GIT_COMMITTER_EMAIL: noreply@flagos.net
         run: |
           label="$(git describe --tags --abbrev=0 | sed 's/^v//')"
-          state_branch="auto/versions-${label}"
+          state_branch="auto/versions-${label}-state"
 
           if [ ! -d versions ] || [ -z "$(ls -A versions 2>/dev/null)" ]; then
             echo "No version data to save"

--- a/scripts/finalize_descriptions.py
+++ b/scripts/finalize_descriptions.py
@@ -106,7 +106,7 @@ def _cleanup_per_backend_branches(label: str) -> None:
 
 
 def _cleanup_state_branch(label: str) -> None:
-    _git("push", "origin", "--delete", f"auto/versions-{label}", check=False)
+    _git("push", "origin", "--delete", f"auto/versions-{label}-state", check=False)
 
 
 def _git_env() -> dict:


### PR DESCRIPTION
## Problem

The accumulate job's "Save state" step failed with:

```
! [remote rejected] ... -> auto/versions-2.1.1 (directory file conflict)
```

Git treats `auto/versions-2.1.1` as a directory because per-backend branches exist at `auto/versions-2.1.1/nvidia-cuda12.8` etc. You can't have a branch at the same path as a directory.

## Fix

Rename the state branch from `auto/versions-<label>` to `auto/versions-<label>-state`. The cleanse glob (`auto/versions*`) already matches both patterns, so no other changes needed.

| File | Change |
|---|---|
| `base-descriptions.yml` | Restore + Save state: rename to `auto/versions-${label}-state` |
| `finalize_descriptions.py` | `_cleanup_state_branch`: same rename |

This PR was written in part with the assistance of generative AI.