### PR TITLE
fix: parse all apt-get install calls on a logical line

### DIFF
--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -144,13 +144,15 @@ def parse_containerfile(path: Path, extra_vars: dict | None = None) -> dict:
             labels[lm.group(1)] = lm.group(2)
         # apt packages: take valid package tokens only (skip flags, redirects,
         # operators, comments), with ${VAR} resolved.
-        am = re.search(r"apt-get\s+install\s+(.*)", st)
-        if am:
-            frag = re.split(r"&&|\|\||;", am.group(1))[0]
-            for tok in frag.split():
-                tok = _resolve(tok, varmap)
-                if re.fullmatch(r"[a-z0-9][a-z0-9+.:-]*", tok):
-                    system_packages.append(tok)
+        # Split on && / || / ; first — multiple apt-get install calls may
+        # appear in the same logical line (e.g. ascend Containerfile).
+        for frag in re.split(r"&&|\|\||;", st):
+            am = re.search(r"apt-get\s+install\s+(.*)", frag)
+            if am:
+                for tok in am.group(1).split():
+                    tok = _resolve(tok, varmap)
+                    if re.fullmatch(r"[a-z0-9][a-z0-9+.:-]*", tok):
+                        system_packages.append(tok)
 
     return {
         "base_os": base_os,


### PR DESCRIPTION
## Problem

Ascend Containerfiles chain two `apt-get install` calls on the same logical line:

```dockerfile
RUN apt-get install -y --no-install-recommends git vim ca-certificates ... \
    && add-apt-repository -y ppa:deadsnakes/ppa \
    && apt-get update && apt-get install -y --no-install-recommends \
        curl unzip net-tools pciutils \
        gcc g++ build-essential make cmake \
        ...
```

`gen_data.py` used `re.search()` which only finds the first match. Only 4 packages were captured (git, vim, ca-certificates, software-properties-common). The 14 packages from the second `apt-get install` (gcc, g++, cmake, etc.) were silently dropped.

## Fix

Split the logical line on `&&` / `||` / `;` first, then search each fragment independently. This captures packages from every `apt-get install` call.

| Backend | Before | After |
|---|---|---|
| ascend-cann8.5.0 | 4 pkgs | 18 pkgs |
| ascend-cann9.0.0 | 4 pkgs | 18 pkgs |
| All other 14 backends | Unchanged | Unchanged |

This PR was written in part with the assistance of generative AI.