### PR TITLE
fix: prevent scoped base-descriptions runs from auto-retrying all backends

### DIFF
--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -247,9 +247,20 @@ jobs:
           GIT_COMMITTER_NAME: flagos-ci
           GIT_COMMITTER_EMAIL: noreply@flagos.net
         run: |
+          # Collect: merge TSVs → check completeness.
+          # Determine the expected backend set — the same scope set-matrix
+          # used, so scoped runs don't auto-retry for backends that were
+          # never requested.
+          SCOPE="${{ github.event.inputs.backend || 'all' }}"
+          if [[ "${SCOPE}" == "all" ]]; then
+            EXPECTED=""
+          else
+            EXPECTED="${SCOPE}"
+          fi
           result=$(python3 scripts/collect_version_tsvs.py \
             --versions versions --remote versions-remote \
-            --retry "${RETRY_COUNT:-0}")
+            --retry "${RETRY_COUNT:-0}" \
+            --expected "${EXPECTED}")
           echo "$result"
 
           # Parse JSON once, write each field to GITHUB_OUTPUT.

--- a/scripts/collect_version_tsvs.py
+++ b/scripts/collect_version_tsvs.py
@@ -65,9 +65,19 @@ def _label() -> str:
     return "unknown"
 
 
-def _missing(versions_dir: Path) -> tuple[list[str], int]:
-    """Return (missing_names, expected_count)."""
-    # gen_data.py must run first so images.yaml includes system packages.
+def _missing(versions_dir: Path, expected_backends: list[str] | None = None) -> tuple[list[str], int]:
+    """Return (missing_names, expected_count).
+
+    When *expected_backends* is given, compute missing directly.  Otherwise
+    delegate to ``missing_versions.py`` (which runs ``generate_matrix.py`` and
+    enumerates every backend — correct for a full run, wrong for a scoped one)."""
+    if expected_backends is not None:
+        expected_set = set(expected_backends)
+        got = {f.stem for f in versions_dir.glob("*.tsv")} if versions_dir.is_dir() else set()
+        missing = sorted(expected_set - got)
+        return missing, len(expected_set)
+
+    # Full run: discover expected backends from generate_matrix.py.
     subprocess.run(
         [sys.executable, str(REPO_ROOT / "docs" / "gen_data.py")],
         capture_output=True, cwd=REPO_ROOT,
@@ -76,7 +86,6 @@ def _missing(versions_dir: Path) -> tuple[list[str], int]:
         [sys.executable, str(REPO_ROOT / "docs" / "missing_versions.py")],
         capture_output=True, text=True, cwd=REPO_ROOT,
     )
-    # Shell's missing_versions.py writes lines; parse COUNT and MISSING.
     missing = []
     expected = 14
     for line in r.stdout.strip().splitlines():
@@ -96,6 +105,9 @@ def main() -> None:
     ap.add_argument("--versions", required=True, help="Path to versions/ directory")
     ap.add_argument("--remote", required=True, help="Path to versions-remote/ directory")
     ap.add_argument("--retry", type=int, default=0, help="Retry count (0 = fresh run)")
+    ap.add_argument("--expected", default="",
+                    help="Space-separated expected backend names (from set-matrix). "
+                         "When empty, discover from generate_matrix.py.")
     args = ap.parse_args()
 
     versions_dir = Path(args.versions)
@@ -119,7 +131,8 @@ def main() -> None:
     print(f"After merging: {now} (was {prev})", file=sys.stderr)
 
     # Check completeness.
-    missing_names, expected = _missing(versions_dir)
+    expected_backends = args.expected.split() if args.expected else None
+    missing_names, expected = _missing(versions_dir, expected_backends)
     done = (not missing_names) and now >= expected
 
     if done:


### PR DESCRIPTION
## Problem

Running the base-descriptions workflow with a scoped backend (e.g., `ascend-cann8.5.0 ascend-cann9.0.0`) triggers a runaway retry of all 16 backends.

Root cause: `collect_version_tsvs.py` calls `missing_versions.py` which always runs `generate_matrix.py` (no scope) — it reports 16 expected backends regardless of the input scope. With only 2 TSVs collected, the accumulate job sees 14 "missing" and auto-triggers a full retry (run #30372732976).

## Fix

Pass the original scope from the workflow input through to `collect_version_tsvs.py` as `--expected`.

| `--expected` | Behavior |
|---|---|
| Empty / not set | Old behavior — discover from `generate_matrix.py` (all backends) |
| `ascend-cann8.5.0 ascend-cann9.0.0` | Only check those two in `versions/` |

When expected is given, `_missing()` diffs directly against `versions/*.tsv` instead of delegating. On retries, the retry's `backend` input is the same subset — no drift.

**Files changed:**
- `collect_version_tsvs.py` — `--expected` arg, `_missing()` with explicit list
- `base-descriptions.yml` — pass scope from `inputs.backend`

This PR was written in part with the assistance of generative AI.