### PR TITLE
fix(ci): append -build suffix to runtime v1 image tags

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -134,7 +134,8 @@ jobs:
           [[ -z "$flaggems_ver" ]] && flaggems_ver="${{ matrix.flaggems_version }}"
 
           no_flaggems_arg=""
-          [[ "${{ inputs.no_flaggems }}" == "true" ]] && no_flaggems_arg='--build-arg NO_FLAGGEMS=1'
+          image_tag="${{ matrix.image_tag }}"
+          [[ "${{ inputs.no_flaggems }}" == "true" ]] && no_flaggems_arg='--build-arg NO_FLAGGEMS=1' && image_tag="${image_tag}-build"
 
           docker build \
             --build-arg "BASE_IMAGE=${{ matrix.base_image }}" \
@@ -151,9 +152,12 @@ jobs:
             --build-arg "INCLUDE_TESTS=false" \
             --build-arg "FLAGGEMS_VERSION=${flaggems_ver}" \
             ${no_flaggems_arg} \
-            -t "${{ matrix.image_tag }}" \
+            -t "${image_tag}" \
             -f runtime/Containerfile runtime/
 
       - name: Push runtime image
         if: ${{ inputs.push }}
-        run: docker push "${{ matrix.image_tag }}"
+        run: |
+          image_tag="${{ matrix.image_tag }}"
+          [[ "${{ inputs.no_flaggems }}" == "true" ]] && image_tag="${image_tag}-build"
+          docker push "${image_tag}"


### PR DESCRIPTION
## Problem

Runtime v1 (build platform, no FlagGems) images are supposed to be tagged `:{version}-build` per RELEASE.md step 4. The CI workflow uses `matrix.image_tag` from `generate_matrix.py --runtime`, which always produces `:{version}` — no `-build` suffix.

Yesterday's kunlunxin-xre5.37.1 and enflame-tops1.9.17 v1 images are tagged `:2.1.1` instead of `:2.1.1-build`.

`build_runtime.py` CLI already has the suffix logic — but CI doesn't call it. CI builds directly with `docker build` + `--build-arg` plumbing.

## Fix

Append `-build` to the image tag when `no_flaggems=true`, in both the build step (`-t`) and push step (`docker push`).

## Impact

- **v1 builds** (no_flaggems=true) → tag `:2.1.1-build` ✅
- **v2 builds** (no_flaggems=false/default) → tag `:2.1.1` ✅
- No change to `build_runtime.py` CLI (already correct)

The two v1 images already on Harbor (`:2.1.1`) should be re-tagged or rebuilt after merging.

This PR was written in part with the assistance of generative AI.