### PR TITLE
fix: add numpy==1.26.4 to iluvatar deps

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -317,6 +317,7 @@ vendors:
         - torch==2.7.1+corex.4.4.0
         - torchaudio==2.7.1+corex.4.4.0
         - torchvision==0.22.1+corex.4.4.0
+        - numpy==1.26.4
       sdk:
         - Corex Runtime 4.4.0      # corex-installer-linux64-4.4.0_x86_64_10.2.run
         - CUDA Header files 260604 # cuda-header-260604.zip


### PR DESCRIPTION
## Problem

Iluvatar is the only backend missing numpy in its deps after PR #230 moved numpy from global `runtime_prereqs` to per-backend deps.

iluvatar's torch (2.7.1+corex.4.4.0) was compiled against NumPy 1.x ABI — numpy 2.x crashes at import. numpy 1.26.4 is the last 1.x release and compatible with Python 3.10.

Without this, iluvatar runtime images have no numpy at all, which breaks FlagGems C++ wheel compilation and runtime usage.

## Fix

Add `numpy==1.26.4` to iluvatar's deps.

Once merged, iluvatar runtime v1 needs a rebuild (the current v1 image from the full-backend batch was built without numpy).

This PR was written in part with the assistance of generative AI.