### PR TITLE
feat(ci): add skip_cpp input to runtime workflow

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -37,6 +37,10 @@ on:
         description: 'skip flag_gems install — produce build-platform image (step 4)'
         type: boolean
         default: false
+      skip_cpp:
+        description: 'skip flag_gems cpp extension install (install pure Python wheel only)'
+        type: boolean
+        default: false
 
 jobs:
   set-matrix:
@@ -137,6 +141,9 @@ jobs:
           image_tag="${{ matrix.image_tag }}"
           [[ "${{ inputs.no_flaggems }}" == "true" ]] && no_flaggems_arg='--build-arg NO_FLAGGEMS=1' && image_tag="${image_tag}-build"
 
+          cpp_extra="${{ matrix.cpp_extra }}"
+          [[ "${{ inputs.skip_cpp }}" == "true" ]] && cpp_extra=""
+
           docker build \
             --build-arg "BASE_IMAGE=${{ matrix.base_image }}" \
             --build-arg "PYTHON_VERSION=${{ matrix.python_version }}" \
@@ -145,7 +152,7 @@ jobs:
             --build-arg "EXTRA_PYPI=${{ matrix.extra_pypi }}" \
             --build-arg "DEPS=${{ matrix.deps }}" \
             --build-arg "RUNTIME_PREREQS=${{ needs.set-matrix.outputs.runtime_prereqs }}" \
-            --build-arg "CPP_EXTRA=${{ matrix.cpp_extra }}" \
+            --build-arg "CPP_EXTRA=${cpp_extra}" \
             --build-arg "FLAGTREE_PKG=${{ matrix.flagtree_pkg }}" \
             --build-arg "TRITON_PKG=${{ matrix.triton_pkg }}" \
             --build-arg "TRITON_EXTRA_PKGS=${{ matrix.triton_extra_pkgs }}" \


### PR DESCRIPTION
## Problem

When C++ wheels (flag-gems-cpp-cuda, flag-gems-cpp-npu, etc.) are unstable or not yet published, there is no way to build runtime v2 with pure Python FlagGems only — `CPP_EXTRA` is always derived from `configs.yaml cmake_backend`.

## Fix

Add a `skip_cpp` boolean input to the Runtime Image Build workflow. When true, `CPP_EXTRA` is forced to empty — only the pure Python `flag_gems` wheel is installed.

Default: `false` (unchanged behavior).

## Usage

```bash
# Build runtime v2 with pure Python flag_gems only (no cpp extensions)
gh workflow run "Runtime Image Build (manual)" -f backend="nvidia-cuda12.8" -f push="true" -f skip_cpp="true"
```

The Containerfile already handles `CPP_EXTRA=\"\"` gracefully — when empty, the entire cpp install block is skipped. No Containerfile changes needed.

This PR was written in part with the assistance of generative AI.