### PR TITLE
feat: add runtime v2 verification script and CI workflow

### DIFF
--- a/.github/workflows/verify-runtime.yml
+++ b/.github/workflows/verify-runtime.yml
@@ -1,0 +1,82 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Verify Runtime Images
+
+# Verify runtime v2 images on actual hardware: import torch, triton, flag_gems,
+# and run flag_gems.use_gems() with a simple add operator.
+#
+# Each backend runs on its own self-hosted runner (matching hardware) and
+# reports pass/fail independently via GHA step summary.
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: 'Backend to verify (e.g. nvidia-cuda12.8), or "all"'
+        type: string
+        default: all
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - run: python3 -m pip install --user pyyaml
+      - id: m
+        env:
+          BACKEND: ${{ inputs.backend }}
+        run: |
+          if [[ "${BACKEND}" == "all" ]]; then
+            python3 scripts/generate_matrix.py > matrix.json
+          else
+            python3 scripts/generate_matrix.py ${BACKEND} > matrix.json
+          fi
+          echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+  verify:
+    needs: set-matrix
+    # Verification is best-effort on each self-hosted runner.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    runs-on: ${{ fromJSON(matrix.runson) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install dependencies
+        run: |
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages pyyaml
+
+      - name: Verify ${{ matrix.name }}
+        run: python3 scripts/verify_runtime.py "${{ matrix.name }}"
+
+      - name: Report success (${{ matrix.name }})
+        if: success()
+        run: echo "✅ ${{ matrix.name }} — passed" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report failure (${{ matrix.name }})
+        if: failure()
+        run: echo "❌ ${{ matrix.name }} — failed (see log)" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/verify_runtime.py
+++ b/scripts/verify_runtime.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify a runtime v2 image: import torch, triton, flag_gems, and run
+flag_gems.use_gems() with a simple add operator.
+
+Pulls the image from Harbor and runs the verification command inside it
+with the appropriate per-vendor docker run flags.  Designed primarily
+for interactive use on self-hosted runner nodes.
+
+Usage: python scripts/verify_runtime.py <backend-name>
+       python scripts/verify_runtime.py nvidia-cuda12.8
+       python scripts/verify_runtime.py all         # every backend listed in images.yaml
+"""
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Verification script run inside the container via bash heredoc.
+# Checks: import torch, import triton, import flag_gems, use_gems + add op.
+# Each step is independently try/except'd; failures are collected.
+VERIFY_SCRIPT = r'''import sys
+tests = []
+# 1. import torch
+try:
+    import torch
+    tests.append('torch OK ' + torch.__version__)
+except Exception as e:
+    tests.append('torch FAIL: ' + str(e))
+
+# 2. import triton
+try:
+    import triton
+    tests.append('triton OK ' + str(getattr(triton, '__version__', '?')))
+except Exception as e:
+    tests.append('triton FAIL: ' + str(e))
+
+# 3. import flag_gems
+try:
+    import flag_gems
+    tests.append('flag_gems OK ' + flag_gems.__version__)
+except Exception as e:
+    tests.append('flag_gems FAIL: ' + str(e))
+
+# 4. use_gems + add op
+try:
+    flag_gems.use_gems()
+    a = torch.randn(2, 3)
+    b = a + a
+    tests.append('use_gems+add OK shape=' + str(list(b.shape)))
+except Exception as e:
+    tests.append('use_gems+add FAIL: ' + str(e))
+
+for t in tests:
+    print(t)
+if any('FAIL' in t for t in tests):
+    sys.exit(1)
+'''
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: verify_runtime.py <backend-name> | all")
+
+    images = yaml.safe_load(
+        (REPO_ROOT / "docs" / "data" / "images.yaml").read_text()
+    )
+    build_cfg = yaml.safe_load(
+        (REPO_ROOT / ".github" / "build-config.yml").read_text()
+    )
+
+    # Resolve backend names.
+    target = sys.argv[1]
+    all_names = [b["name"] for b in images.get("backends", [])]
+    if target == "all":
+        names = all_names
+        print(f"Verifying all {len(names)} runtime v2 backends...")
+    else:
+        names = [target] if target in all_names else []
+        if not names:
+            sys.exit(f"'{target}' not in images.yaml")
+
+    failed = []
+    for name in names:
+        entry = next(b for b in images.get("backends", []) if b["name"] == name)
+        image = entry["runtime"]["image"]
+        vendor = name.split("-")[0]
+
+        # Per-vendor docker run flags.
+        run_cfg = (
+            (build_cfg.get("run") or {}).get("vendors") or {}
+        ).get(vendor) or {}
+        flags_str = run_cfg.get("toolkit", "") or run_cfg.get("raw", "")
+        flags = shlex.split(flags_str) if flags_str else []
+
+        # Pull + verify.
+        print(f"::group::{name} — verify runtime v2 ({image})")
+        subprocess.run(["docker", "pull", image], check=True, capture_output=True)
+
+        # Pipe the verification script via bash heredoc so multi-line
+        # try/except blocks work (python3 -c can't do that on one line).
+        cmd = ["docker", "run"] + flags + ["--rm", image,
+               "bash", "-c", f"python3 << 'PYEOF'\n{VERIFY_SCRIPT}\nPYEOF"]
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.stdout:
+            for line in r.stdout.strip().splitlines():
+                if "FAIL" in line:
+                    print(f"  ❌ {line}")
+                else:
+                    print(f"  ✅ {line}")
+        if r.stderr:
+            sys.stderr.write(r.stderr)
+        print("::endgroup::")
+
+        if r.returncode != 0:
+            print(f"  ❌ {name}: verification FAILED (exit {r.returncode})")
+            failed.append(name)
+        else:
+            print(f"  ✅ {name}: ALL 4 checks passed")
+
+    if failed:
+        print(f"\n{len(failed)} FAILED: {' '.join(failed)}")
+        sys.exit(1)
+    print(f"\nAll {len(names)} backends passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a verification script and CI workflow for runtime v2 (`:{version}`) images — step 7 of the release runbook.

### `scripts/verify_runtime.py`

Runs inside each runtime v2 container via `bash` heredoc:

| # | Check | Expected |
|---|---|---|
| 1 | `import torch` | prints version |
| 2 | `import triton` | prints version |
| 3 | `import flag_gems` | prints version |
| 4 | `flag_gems.use_gems()` + `torch.randn(2,3) + torch.randn(2,3)` | shape output |

Reads `images.yaml` for image refs and `build-config.yml` for per-vendor docker run flags.

### `.github/workflows/verify-runtime.yml`

Manual trigger (`workflow_dispatch`) with `backend` filter (default `all`). Fans out across self-hosted runners via matrix — each backend gets verified on its own hardware. `continue-on-error: true` so failures are non-blocking. Each job reports pass/fail in the GHA step summary.

## Files

- `scripts/verify_runtime.py` — new: verification script
- `.github/workflows/verify-runtime.yml` — new: CI workflow

This PR was written in part with the assistance of generative AI.