### PR TITLE
fix(verify): stream docker output to terminal instead of capturing

### DIFF
--- a/.github/workflows/verify-runtime.yml
+++ b/.github/workflows/verify-runtime.yml
@@ -70,6 +70,10 @@ jobs:
           python3 -c "import yaml" 2>/dev/null \
             || python3 -m pip install --user --break-system-packages pyyaml
 
+      # images.yaml is .gitignore'd but needed by verify_runtime.py.
+      - name: Generate images.yaml
+        run: python3 docs/gen_data.py
+
       - name: Verify ${{ matrix.name }}
         run: python3 scripts/verify_runtime.py "${{ matrix.name }}"
 

--- a/scripts/verify_runtime.py
+++ b/scripts/verify_runtime.py
@@ -112,23 +112,24 @@ def main() -> None:
         flags_str = run_cfg.get("toolkit", "") or run_cfg.get("raw", "")
         flags = shlex.split(flags_str) if flags_str else []
 
-        # Pull + verify.
+        # Pull + verify.  Stream output directly to the terminal so
+        # self-hosted runners capture it in the job log — capture_output
+        # can drop it when GitHub API connectivity is unreliable.
         print(f"::group::{name} — verify runtime v2 ({image})")
-        subprocess.run(["docker", "pull", image], check=True, capture_output=True)
+        print(f"  Pulling {image}...")
+        pr = subprocess.run(["docker", "pull", image])
+        if pr.returncode != 0:
+            print(f"  ❌ docker pull failed (exit {pr.returncode})")
+            print("::endgroup::")
+            failed.append(name)
+            continue
 
         # Pipe the verification script via bash heredoc so multi-line
         # try/except blocks work (python3 -c can't do that on one line).
         cmd = ["docker", "run"] + flags + ["--rm", image,
                "bash", "-c", f"python3 << 'PYEOF'\n{VERIFY_SCRIPT}\nPYEOF"]
-        r = subprocess.run(cmd, capture_output=True, text=True)
-        if r.stdout:
-            for line in r.stdout.strip().splitlines():
-                if "FAIL" in line:
-                    print(f"  ❌ {line}")
-                else:
-                    print(f"  ✅ {line}")
-        if r.stderr:
-            sys.stderr.write(r.stderr)
+        print(f"  Verifying...")
+        r = subprocess.run(cmd)
         print("::endgroup::")
 
         if r.returncode != 0:


### PR DESCRIPTION
## Problem

First run (#30424576422) on nvidia-cuda12.8 failed with no visible output — the verify step logs were empty.

Two issues:
1. `capture_output=True` in `subprocess.run()` — self-hosted runners with unstable GitHub connectivity drop captured output
2. Missing `gen_data.py` step — `images.yaml` is `.gitignore`'d and may not exist on a fresh checkout

## Fix

- `verify_runtime.py`: remove `capture_output=True` — let `docker pull` and `docker run` stream directly to the terminal. Exit code still determines pass/fail.
- `verify-runtime.yml`: add `python3 docs/gen_data.py` step before verify

This PR was written in part with the assistance of generative AI.