### PR TITLE
fix: apply configs.yaml env.runtime to runtime Containerfile

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -158,6 +158,7 @@ jobs:
             --build-arg "TRITON_EXTRA_PKGS=${{ matrix.triton_extra_pkgs }}" \
             --build-arg "INCLUDE_TESTS=false" \
             --build-arg "FLAGGEMS_VERSION=${flaggems_ver}" \
+            --build-arg "RUNTIME_ENV=${{ matrix.runtime_env }}" \
             ${no_flaggems_arg} \
             -t "${image_tag}" \
             -f runtime/Containerfile runtime/

--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -50,6 +50,10 @@ ARG FLAGGEMS_VERSION=0.0.0
 # When non-empty, skip the flag_gems install entirely — produces the
 # build-platform image for step 5 (no flag_gems, just torch + deps + compilers).
 ARG NO_FLAGGEMS=""
+# Per-backend runtime env vars from configs.yaml env.runtime, serialized
+# as "KEY=value\nKEY2=value2". Written to /etc/profile.d/runtime_env.sh in
+# the runtime stage so they are active in every shell.
+ARG RUNTIME_ENV=""
 
 
 # ════════════════════════════════════════════════════════════════
@@ -247,6 +251,14 @@ COPY --from=builder /app /app
 
 ENV VIRTUAL_ENV=/flagos \
     PATH="/flagos/bin:${PATH}"
+
+# ── Per-backend runtime env vars from configs.yaml env.runtime ──
+# Written to profile.d so they are sourced in every shell (login,
+# non-login interactive, and bash -c via BASH_ENV).
+ARG RUNTIME_ENV
+RUN if [ -n "${RUNTIME_ENV}" ]; then \
+      printf '%s\n' "${RUNTIME_ENV}" > /etc/profile.d/runtime_env.sh; \
+    fi
 
 # C++ operator extensions are opt-in — set USE_C_EXTENSION=1 at runtime
 # AFTER installing the flag-gems-cpp-<vendor> wheel. The env is NOT set

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -196,6 +196,10 @@ def resolve_build_args(
     triton = backend_info.get("triton", "")
     triton_post = backend_info.get("triton_post_install", [])
     triton_extra = " ".join(triton_post) if isinstance(triton_post, list) else ""
+    runtime_env = backend_info.get("env", {}).get("runtime", {})
+    runtime_env_lines = "\n".join(
+        f"{k}={v}" for k, v in (runtime_env or {}).items()
+    )
 
     args = {
         "BASE_IMAGE": base_image_override
@@ -211,6 +215,7 @@ def resolve_build_args(
         "TRITON_PKG": triton,
         "TRITON_EXTRA_PKGS": triton_extra,
         "INCLUDE_TESTS": include_tests_override or "false",
+        "RUNTIME_ENV": runtime_env_lines,
     }
 
     return args

--- a/scripts/generate_matrix.py
+++ b/scripts/generate_matrix.py
@@ -113,6 +113,12 @@ def _runtime_matrix(configs: dict, runners: dict, repo_root: Path, selected: lis
         cpp_backend = str(backend_info.get("cmake_backend", "")).lower()
         cpp_extra = f"cpp-{cpp_backend}" if cpp_backend else ""
 
+        # Per-backend runtime env vars — serialized as "KEY=value\nKEY2=value2"
+        runtime_env = backend_info.get("env", {}).get("runtime", {})
+        runtime_env_lines = "\n".join(
+            f"{k}={v}" for k, v in (runtime_env or {}).items()
+        )
+
         include.append({
             "name": name,
             "runson": runson_for(name, runners),
@@ -130,6 +136,7 @@ def _runtime_matrix(configs: dict, runners: dict, repo_root: Path, selected: lis
             "triton_extra_pkgs": " ".join(
                 backend_info.get("triton_post_install", [])
             ) if isinstance(backend_info.get("triton_post_install"), list) else "",
+            "runtime_env": runtime_env_lines,
         })
 
     return {"include": include}


### PR DESCRIPTION
## Problem

`env.runtime` was configured in `configs.yaml` (e.g. mthreads backends set `LD_LIBRARY_PATH=${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}` for MKL), but was **never applied** in the runtime Containerfile. 

This caused `mthreads-musa4.3.6` to crash on `import torch`:
```
libmkl_intel_lp64.so.2: cannot open shared object file: No such file or directory
```

`mkl==2024.0.0` is installed and its .so files are at `/flagos/lib/`, but `LD_LIBRARY_PATH` only has the base image's `/usr/local/musa/lib`.

`mthreads-musa5.2.0` passed only because its torch doesn't link against MKL — it was luck, not correctness.

## Fix

| File | Change |
|---|---|
| `generate_matrix.py` | Serialize `env.runtime` as `KEY=value\\n…` into `matrix.runtime_env` |
| `runtime/Containerfile` | Accept `ARG RUNTIME_ENV`, write to `/etc/profile.d/runtime_env.sh` (sourced via `BASH_ENV`) |
| `runtime.yml` | Pass `--build-arg RUNTIME_ENV=${{ matrix.runtime_env }}` |
| `build_runtime.py` | Include `RUNTIME_ENV` in resolved build args |

Env vars are now active in all shells (login, interactive, `bash -c`) via the existing `BASH_ENV` → `profile.d/*.sh` plumbing.

This PR was written in part with the assistance of generative AI.