### PR TITLE
fix: remove VISIBLE_DEVICES from env.runtime

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -106,9 +106,6 @@ vendors:
         base:
           PATH: /usr/local/cuda/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
-        runtime:
-          NVIDIA_VISIBLE_DEVICES: "all"
-          NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
       deps:
         - torch==2.10.0+cu128
         - torchaudio==2.10.0+cu128
@@ -129,9 +126,6 @@ vendors:
         base:
           PATH: /usr/local/cuda/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
-        runtime:
-          NVIDIA_VISIBLE_DEVICES: "all"
-          NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
       deps:
         - torch==2.11.0+cu130
         - torchaudio==2.11.0+cu130
@@ -428,7 +422,6 @@ vendors:
           PATH: /usr/local/musa/bin:${PATH}
           LD_LIBRARY_PATH: /usr/local/musa/lib
         runtime:
-          MTHREADS_VISIBLE_DEVICES: "all"
           LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
       deps:
         - torch==2.9.0+musa.4.3.6
@@ -454,7 +447,6 @@ vendors:
           PATH: /usr/local/musa/bin:${PATH}
           LD_LIBRARY_PATH: /usr/local/musa/lib
         runtime:
-          MTHREADS_VISIBLE_DEVICES: "all"
           LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
       deps:
         - torch==2.9.1+musa5.2.0


### PR DESCRIPTION
## Problem

`NVIDIA_VISIBLE_DEVICES`, `MTHREADS_VISIBLE_DEVICES` etc. are container-toolkit variables read at container start — setting them in the image is a no-op and misleading. Users override them via `docker run -e`.

Same for `NVIDIA_DRIVER_CAPABILITIES`.

## Fix

Remove from `env.runtime`:
- nvidia-cuda12.8: `NVIDIA_VISIBLE_DEVICES`, `NVIDIA_DRIVER_CAPABILITIES`
- nvidia-cuda13.3: `NVIDIA_VISIBLE_DEVICES`, `NVIDIA_DRIVER_CAPABILITIES`
- mthreads-musa4.3.6: `MTHREADS_VISIBLE_DEVICES`
- mthreads-musa5.2.0: `MTHREADS_VISIBLE_DEVICES`

Kept:
- mthreads `LD_LIBRARY_PATH` — MKL .so path, needed at runtime
- tsingmicro `USE_TORCH_XLA`, `TORCH_COMPILE_DISABLE` — behavior flags

After this, only 3 backends have `env.runtime` (down from 5).

This PR was written in part with the assistance of generative AI.