### PR TITLE
Remove mthreads environment variables for runtime images

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -421,8 +421,8 @@ vendors:
           MUSA_HOME: /usr/local/musa
           PATH: /usr/local/musa/bin:${PATH}
           LD_LIBRARY_PATH: /usr/local/musa/lib
-        runtime:
-          LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
+        # runtime:
+        #  LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
       deps:
         - torch==2.9.0+musa.4.3.6
         - torch_musa==2.9.0
@@ -446,8 +446,8 @@ vendors:
           MUSA_HOME: /usr/local/musa
           PATH: /usr/local/musa/bin:${PATH}
           LD_LIBRARY_PATH: /usr/local/musa/lib
-        runtime:
-          LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
+        # runtime:
+        # LD_LIBRARY_PATH: "${VIRTUAL_ENV}/lib:${LD_LIBRARY_PATH}"
       deps:
         - torch==2.9.1+musa5.2.0
         - torch_musa==2.9.1


### PR DESCRIPTION
Let's try using patched libtorch.so for mthreads.