### PR TITLE
feat: add skip_cpp input to flaggems-release.yml

### DIFF
--- a/.github/workflows/flaggems-release.yml
+++ b/.github/workflows/flaggems-release.yml
@@ -29,6 +29,10 @@ on:
         description: 'FlagGems tag/ref to build (e.g. "v5.3.1")'
         type: string
         required: true
+      skip_cpp:
+        description: 'skip cpp operator wheel build + upload (step 5b)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -70,6 +74,7 @@ jobs:
   # ── 5b: cpp operator wheels, inside runtime:v1 ───────────────────────────
   cpp-matrix:
     needs: python-wheel
+    if: ${{ !inputs.skip_cpp }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.m.outputs.matrix }}
@@ -86,6 +91,7 @@ jobs:
 
   cpp-wheels:
     needs: [python-wheel, cpp-matrix]
+    if: ${{ !inputs.skip_cpp && needs.cpp-matrix.result == 'success' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.cpp-matrix.outputs.matrix) }}


### PR DESCRIPTION
Add a `skip_cpp` input to flaggems-release.yml so the pure-Python flag_gems wheel can be built and uploaded to all vendor PyPIs without triggering cpp wheel builds.

### Changes
- **`skip_cpp`** input (bool, default false): skips cpp-matrix + cpp-wheels jobs
- When cpp is skipped, `update-config` naturally won't fire (its condition requires `cpp-wheels.result == 'success'`)

### Usage
```
workflow_dispatch:
  flaggems_ref: v5.3.2
  skip_cpp: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)