### PR TITLE
fix: handle env=None in configs.yaml

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -143,7 +143,6 @@ vendors:
       cmake_backend: NPU
       triton: triton-ascend==3.2.0
       flagtree: flagtree==0.6.0+ascend3.2
-      env:
       deps:
         - torch==2.9.0+cpu
         - torch-npu==2.9.0
@@ -162,7 +161,6 @@ vendors:
       flagtree: flagtree==0.6.0+ascend3.5
       triton_post_install:
         - triton_ascend==3.2.1
-      env:
       deps:
         - torch==2.10.0+cpu
         - torch-npu==2.10.0
@@ -286,7 +284,6 @@ vendors:
       python: "3.10"
       triton: triton==3.3.0+das.opt1.dtk2604.torch290
       flagtree: flagtree==0.5.1+hcu3.1
-      env:
       deps:
         - torch==2.9.0+das.opt1.dtk2604
         - numpy==2.2.6
@@ -501,7 +498,6 @@ vendors:
       hardware: ["T-Head ZW810E"]
       python: "3.12"
       triton: triton==3.5.0+ppu2.0.0.oe
-      env:
       deps:
         - torch==2.9.0+ppu2.0.0.oe
         - numpy==2.3.5

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -196,7 +196,7 @@ def resolve_build_args(
     triton = backend_info.get("triton", "")
     triton_post = backend_info.get("triton_post_install", [])
     triton_extra = " ".join(triton_post) if isinstance(triton_post, list) else ""
-    runtime_env = backend_info.get("env", {}).get("runtime", {})
+    runtime_env = (backend_info.get("env") or {}).get("runtime", {})
     runtime_env_lines = "\n".join(
         f"{k}={v}" for k, v in (runtime_env or {}).items()
     )

--- a/scripts/generate_matrix.py
+++ b/scripts/generate_matrix.py
@@ -114,7 +114,7 @@ def _runtime_matrix(configs: dict, runners: dict, repo_root: Path, selected: lis
         cpp_extra = f"cpp-{cpp_backend}" if cpp_backend else ""
 
         # Per-backend runtime env vars — serialized as "KEY=value\nKEY2=value2"
-        runtime_env = backend_info.get("env", {}).get("runtime", {})
+        runtime_env = (backend_info.get("env") or {}).get("runtime", {})
         runtime_env_lines = "\n".join(
             f"{k}={v}" for k, v in (runtime_env or {}).items()
         )


### PR DESCRIPTION
When `env:` is null in configs.yaml, `backend_info.get('env', {})` returns `None` (key exists, value is null), not the default `{}`. Subsequent `.get('runtime', {})` crashes with AttributeError.

Affects ascend, enflame, hygon backends which have `env:` as null/empty.

### Fix
```python
# Before
runtime_env = backend_info.get("env", {}).get("runtime", {})
# After  
runtime_env = (backend_info.get("env") or {}).get("runtime", {})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)