### PR TITLE
fix: revert cambricon base to ubuntu:22.04

### DIFF
--- a/base/cambricon-neuware4.4.3
+++ b/base/cambricon-neuware4.4.3
@@ -13,17 +13,12 @@
 # limitations under the License.
 
 # ============================================================
-# Base image for Cambricon Neuware 4.4.3 Ubuntu 24.04
+# Base image for Cambricon Neuware 4.4.3 Ubuntu 22.04
 # ============================================================
 # History:
 # - 20260624: Initial version
-# - 20260716: Bump base OS 22.04 -> 24.04 for fleet uniformity (cambricon is
-#   triton-only, so this is not needed for flagtree, but keeps all bases on one
-#   OS). Neuware .debs are ubuntu22.04-tagged; their 22.04-built binaries run on
-#   24.04 (forward-compatible). noble dropped libncurses5/libtinfo5 (.so.5) —
-#   use libncurses6/libtinfo6 instead.
-
-FROM ubuntu:24.04
+# - 20260716: Bumped to 24.04 but cnperf fails (libncurses5 dropped), reverted
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
@@ -38,7 +33,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
   && apt-get install -f -y pciutils curl git vim ca-certificates unzip\
     gcc g++ gdb build-essential cmake make \
-    libncurses6 libtinfo6 libc6-dev-i386 \
+    libncurses5 libtinfo5 libc6-dev-i386 \
   && ln -fs /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
@@ -75,7 +70,7 @@ RUN set -eux ; \
     dpkg -i ${pkg}; \
     rm -f ${pkg}; \
   done \
-  && apt-get install -yf 2>/dev/null || true \
+  && apt-get install -yf \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/base/hygon-dtk26.04
+++ b/base/hygon-dtk26.04
@@ -37,6 +37,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # RUN sed -i 's|URIs: http://archive.ubuntu.com/ubuntu|URIs: https://mirrors.aliyun.com/ubuntu|g; s|URIs: http://security.ubuntu.com/ubuntu|URIs: https://mirrors.aliyun.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources \
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git vim ca-certificates curl \
+        libnuma1 \
         gcc g++ build-essential cmake \
         pciutils \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### cambricon-neuware4.4.3
cnperf deb depends on libncurses5/libtinfo5 which were dropped
in noble (24.04). `dpkg -i` silently failed, masked by the
`2>/dev/null || true` fallback on the apt-get -yf line.

- `FROM ubuntu:24.04` → `ubuntu:22.04`
- `libncurses6 libtinfo6` → `libncurses5 libtinfo5`
- Stop swallowing `apt-get -yf` errors

### hygon-dtk26.04
Hygon's torch links against libnuma.so.1 but the base image
didn't install it. `import torch._C` fails with:
  ImportError: libnuma.so.1: cannot open shared object file

- Add `libnuma1` to apt packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)