### PR TITLE
fix: run gen_data.py before gen_descriptions.py in finalize

### DIFF
--- a/scripts/finalize_descriptions.py
+++ b/scripts/finalize_descriptions.py
@@ -128,9 +128,15 @@ def _finalize(args) -> None:
     _git("config", "user.name", "flagos-ci", check=False)
     _git("config", "user.email", "noreply@flagos.net", check=False)
 
-    # gen_descriptions reads TSV files from VERSIONS_DIR.
+    # gen_descriptions reads TSV files from VERSIONS_DIR and requires
+    # docs/data/images.yaml (produced by gen_data.py) to be up to date.
     env = _git_env()
     env["VERSIONS_DIR"] = str(REPO_ROOT / "versions")
+
+    subprocess.run(
+        [sys.executable, str(REPO_ROOT / "docs" / "gen_data.py")],
+        check=True, cwd=REPO_ROOT, env=env,
+    )
 
     subprocess.run(
         [sys.executable, str(REPO_ROOT / "docs" / "gen_descriptions.py")],


### PR DESCRIPTION
finalize_descriptions.py calls gen_descriptions.py which reads
docs/data/images.yaml, but gen_data.py was not re-run before it.
On retries the file was missing entirely (FileNotFoundError),
crashing the descriptions pipeline.

### Fix
Run `docs/gen_data.py` immediately before `docs/gen_descriptions.py`
in the `_finalize()` function, ensuring images.yaml is always
regenerated from the latest configs.yaml + Containerfiles.

### Impact
This was the root cause of PR #252 missing version numbers for
libncurses5, libtinfo5 (cambricon) and libnuma1 (hygon) — the
TSV data was correct, but gen_descriptions.py couldn't read
images.yaml and crashed, leaving the PR in a stale state from a
previous run.