### PR TITLE
fix: scope base-descriptions to only requested backends

### DIFF
--- a/.github/workflows/base-descriptions.yml
+++ b/.github/workflows/base-descriptions.yml
@@ -211,18 +211,27 @@ jobs:
       - run: python3 -m pip install --user pyyaml
 
       - name: Fetch version TSVs from extract jobs
-        run: python3 scripts/fetch_version_tsvs.py versions-remote
+        env:
+          SCOPE: ${{ github.event.inputs.backend || 'all' }}
+        run: |
+          if [[ "${SCOPE}" == "all" ]]; then
+            python3 scripts/fetch_version_tsvs.py versions-remote
+          else
+            python3 scripts/fetch_version_tsvs.py versions-remote --expected "${SCOPE}"
+          fi
 
       # Restore previously-collected TSVs from the state branch so that
       # backends not refreshed this retry retain their data across runs.
       # On retry=0 the state branch doesn't exist yet — that's fine, we
       # start fresh (set-matrix already cleansed stale branches).
+      # For scoped runs, only restore TSVs for the backends being collected.
       - name: Restore state from previous retries
         env:
           GIT_AUTHOR_NAME: flagos-ci
           GIT_AUTHOR_EMAIL: noreply@flagos.net
           GIT_COMMITTER_NAME: flagos-ci
           GIT_COMMITTER_EMAIL: noreply@flagos.net
+          SCOPE: ${{ github.event.inputs.backend || 'all' }}
         run: |
           label="$(git describe --tags --abbrev=0 | sed 's/^v//')"
           state_branch="auto/versions-${label}-state"
@@ -230,7 +239,16 @@ jobs:
             echo "Restoring state from ${state_branch}"
             git fetch origin "${state_branch}"
             mkdir -p versions
-            git checkout FETCH_HEAD -- versions/
+            if [[ "${SCOPE}" == "all" ]]; then
+              git checkout FETCH_HEAD -- versions/
+            else
+              for bk in ${SCOPE}; do
+                f="versions/${bk}.tsv"
+                if git show "FETCH_HEAD:${f}" > "${f}" 2>/dev/null; then
+                  echo "  Restored ${bk}.tsv"
+                fi
+              done
+            fi
           else
             echo "No state branch (${state_branch}) — starting fresh"
             mkdir -p versions

--- a/scripts/fetch_version_tsvs.py
+++ b/scripts/fetch_version_tsvs.py
@@ -49,6 +49,9 @@ def main() -> None:
 
     ap = argparse.ArgumentParser()
     ap.add_argument("out_dir", help="Path to output directory (versions-remote)")
+    ap.add_argument("--expected", default="",
+                    help="Space-separated backend names to fetch. "
+                         "When empty, discover all branches.")
     args = ap.parse_args()
 
     out_dir = Path(args.out_dir)
@@ -69,6 +72,14 @@ def main() -> None:
     if not refs:
         print(f"No extract branches found under {prefix}")
         return
+
+    # When scoped, only fetch backends we're collecting.
+    expected_set = set(args.expected.split()) if args.expected else None
+    if expected_set:
+        refs = [r for r in refs if r[len(prefix):] in expected_set]
+        if not refs:
+            print(f"No extract branches for expected backends: {args.expected}")
+            return
 
     fetched = 0
     for ref in refs:

--- a/scripts/finalize_descriptions.py
+++ b/scripts/finalize_descriptions.py
@@ -138,8 +138,12 @@ def _finalize(args) -> None:
         check=True, cwd=REPO_ROOT, env=env,
     )
 
+    # Only regenerate descriptions for backends that have TSV data
+    # collected in this run — not every backend in images.yaml.
+    versions_dir = REPO_ROOT / "versions"
+    requested = sorted(f.stem for f in versions_dir.glob("*.tsv"))
     subprocess.run(
-        [sys.executable, str(REPO_ROOT / "docs" / "gen_descriptions.py")],
+        [sys.executable, str(REPO_ROOT / "docs" / "gen_descriptions.py")] + requested,
         check=True, cwd=REPO_ROOT, env=env,
     )
 


### PR DESCRIPTION
Three fixes to prevent scoped description runs from touching
unrelated backends:

1. `fetch_version_tsvs.py`: add `--expected` flag to only fetch TSV
   branches for the backends being collected.

2. `base-descriptions.yml`: pass SCOPE to fetch_version_tsvs.py
   so scoped runs only fetch their own data.

3. `finalize_descriptions.py`: only regenerate descriptions for
   backends that have TSV data in `versions/`. Without this,
   a scoped run would still write all 16 backend files because
   `gen_descriptions.py` (no-args) processes every backend in
   `images.yaml`.

### Before (scoped run for cambricon+hygon)
- PR touched all 48 description files (16 backends × 3 flavors)
- Most changes were no-op formatting diffs

### After
- Only regenerates cambricon + hygon description files
- `versions/` contains only the 2 TSVs that were collected