### PR TITLE
fix(hygon): add missing runtime libs for torch + DCU detection

### DIFF
--- a/base/hygon-dtk26.04
+++ b/base/hygon-dtk26.04
@@ -38,6 +38,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git vim ca-certificates curl \
         libnuma1 \
+        libgfortran5 libdrm-amdgpu1 libdw1 libelf1 libpciaccess0 \
         gcc g++ build-essential cmake \
         pciutils \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

The `hygon-dtk26.04` runtime image fails verification: `import torch` raises `ImportError: libgfortran.so.5: cannot open shared object file`. Even past that, the DCU is undetected (`torch.cuda.is_available() == False`, `device_count() == 0`, "load library error").

Root cause: `base/hygon-dtk26.04` installs `libnuma1` but is missing five system libraries the DTK HIP torch stack links against.

| Missing `.so` | Ubuntu 24.04 package | Impact |
|---|---|---|
| `libgfortran.so.5` | `libgfortran5` | blocks `import torch` — HIP torch 2.9.0 (`hip 6.3.26045`) links Fortran BLAS/LAPACK |
| `libdrm_amdgpu.so.1` | `libdrm-amdgpu1` | torch imports but no DCU |
| `libdw.so.1` | `libdw1` | ″ |
| `libelf.so.1` | `libelf1` | ″ |
| `libpciaccess.so.0` | `libpciaccess0` | ″ |

## Fix

Add the five packages to the base Containerfile's apt list (one line).

## Verification

Reproduced on a hygon node (8× healthy DCU, `hy-smi` OK). Confirmed via `ldd | grep "not found"` across `torch/lib`, `/opt/dtk-26.04/lib*`, and `/opt/hyhal/lib` that these are the **complete** set of missing libs. With all five present in the `2.1.1` image:

```
torch.cuda.is_available()  -> True
torch.cuda.device_count()  -> 8
torch.cuda.get_device_name(0) -> "BW"
```

This is a base-image change — it requires a base rebuild + runtime rebuild to take effect.

Note: a separate, non-fatal NumPy 2.2.6 vs torch-built-against-1.x `_ARRAY_API not found` warning remains; that's tracked separately and out of scope here.

This PR was written in part with the assistance of generative AI.
