### PR TITLE
feat: add tsingmicro-tsm260610 backend

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -50,6 +50,7 @@ runners:
     mthreads-musa5.2.0: [self-hosted, musa520]
     sunrise-tangrt1.2.0: [self-hosted, sunrise]
     tsingmicro-tsm260604: [self-hosted, tsingmicro]
+    tsingmicro-tsm260610: [self-hosted, tsingmicro]
 
 # `docker run` flags needed to expose each vendor's accelerator to a container.
 # Used by the docs to render a concrete run command per image. Vendors not

--- a/base/tsingmicro-tsm260610
+++ b/base/tsingmicro-tsm260610
@@ -1,0 +1,88 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ============================================================
+# Base image for TsingMicro TSM 260610164501 on Ubuntu 24.04
+# ============================================================
+# History:
+# - 20260608: Initial version
+# - 20260716: Bump base OS 22.04 -> 24.04
+# - 20260730: New backend for SDK 260610164501 (host driver upgraded ahead of 260604)
+
+FROM ubuntu:24.04
+
+LABEL org.opencontainers.image.authors="FlagOS contributors"
+
+ARG PYTHON_VERSION=3.10
+ARG SDK_RELEASE=260610164501
+
+# ── Build arguments ────────────────────────────────────────────
+ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/tsingmicro
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# libunwind8, libopenmpi3 are depdencies for torch_txda;
+# clang is dependency from triton;
+# libfmt8 (22.04) — torch_txda links libfmt.so.8; 24.04 ships libfmt.so.9;
+# sudo is hardcoded dependency from TSM installers.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl git vim ca-certificates \
+      gcc g++ build-essential cmake clang \
+      libopenmpi3 sudo \
+      libunwind8 \
+      libpython3-dev \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# torch_txda links libfmt.so.8; Ubuntu 24.04 only ships libfmt.so.9.
+# Install the 22.04 package from filestore (59K, no conflict with libfmt9).
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /tmp/libfmt8.deb ${FILE_STORE}/libfmt8_8.1.1+ds1-2_amd64.deb \
+    && dpkg -i /tmp/libfmt8.deb \
+    && rm /tmp/libfmt8.deb
+
+# ── TsingMicro Runtime packages ───────────────────────────────────
+ENV PACKAGE_NAME="Tsm_validation_suite Tsm_runtime Tsm_ccl Tsm_profiler"
+
+RUN set -eux ; \
+  for pkg in ${PACKAGE_NAME}; do \
+    fn="${pkg}_${SDK_RELEASE}_x86_64_installer.run"; \
+    curl --retry 5 --retry-delay 5 --retry-all-errors -o "${fn}" "${FILE_STORE}/${fn}"; \
+    chmod +x "${fn}"; \
+    ./"${fn}"; \
+    rm -f "${fn}"; \
+  done
+
+# ── TsingMicro Compiler depdendencies ─────────────────────────────
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/tx8.tar.gz \
+      ${FILE_STORE}/tx8_depends_dev_20260507_104051.tar.gz \
+    && tar xf /tmp/tx8.tar.gz -C /usr/local \
+    && rm /tmp/tx8.tar.gz
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/llvm.tar.gz \
+      ${FILE_STORE}/llvm-22-ubuntu-x64.tgz \
+    && mkdir -p /usr/local/llvm \
+    && tar xf /tmp/llvm.tar.gz -C /usr/local/llvm \
+    && rm /tmp/llvm.tar.gz
+ 
+ENV KUIPER_PATH="/usr/local/kuiper" \
+    TX8_DEPS_ROOT="/usr/local/tx8_deps" \
+    LLVM_SYSPATH="/usr/local/llvm"
+
+ENV PATH="${KUIPER_PATH}/bin:${PATH}" \
+    LLVM_BINARY_DIR="${LLVM_SYSPATH}/bin" \
+    PYTHONPATH="${LLVM_SYSPATH}/python_packages/mlir_core" \
+    LD_LIBRARY_PATH="${TX8_DEPS_ROOT}/lib:${KUIPER_PATH}/lib:${KUIPER_PATH}/tsm8-profiler/lib"
+
+ENV USE_TORCH_XLA="0" \
+    TORCH_COMPILE_DISABLE="1"

--- a/configs.yaml
+++ b/configs.yaml
@@ -544,3 +544,44 @@ vendors:
         - TSM Profiler 260604163331          # Tsm_profiler_260604163331_x86_64_installer.run
         - TX8 Compiler Dependencies 20260507 # tx8_depends_dev_20260507_104051.tar.gz
         - LLVM a66376b0                      # llvm-a66376b0-ubuntu-x64.tgz
+
+    tsm260610:
+      extras: tsingmicro
+      hardware: ["Tsingmicro TX8110"]
+      driver: "260610164501.01"
+      python: "3.10"
+      triton: triton==3.3.0+gitfe2a28fa
+      flagtree: flagtree==0.5.0.post20260612+git705a4064
+      system_dpkg:
+        # libfmt8 is a system-level dependency for torch_txda (links
+        # libfmt.so.8). Ubuntu 24.04 ships libfmt9, so we install the
+        # 22.04 .deb via dpkg. It is NOT an SDK component.
+        - libfmt8
+      env:
+        base:
+          KUIPER_PATH: /usr/local/kuiper
+          TX8_DEPS_ROOT: /usr/local/tx8_deps
+          LLVM_SYSPATH: /usr/local/llvm
+          PATH: /usr/local/kuiper/bin:${PATH}
+          LLVM_BINARY_DIR: /usr/local/llvm/bin
+          PYTHONPATH: /usr/local/llvm/python_packages/mlir_core
+          LD_LIBRARY_PATH: /usr/local/tx8_deps/lib:/usr/local/kuiper/lib:/usr/local/kuiper/tsm8-profiler/lib
+          USE_TORCH_XLA: "0"
+          TORCH_COMPILE_DISABLE: "1"
+        runtime:
+          USE_TORCH_XLA: "0"
+          TORCH_COMPILE_DISABLE: "1"
+      deps:
+        - torch==2.7.0+cpu
+        - torchvision==0.22.0+cpu
+        - torchaudio==2.7.0+cpu
+        - torch_txda==0.1.0+20260615.37ba6bbd
+        - txops==0.1.0+20260508.60287151
+        - numpy==2.2.6
+      sdk:
+        - TSM Runtime 260610164501           # Tsm_runtime_260610164501_x86_64_installer.run
+        - TSM Validation Suite 260610164501  # Tsm_validation_suite_260610164501_x86_64_installer.run
+        - TSM CCL 260610164501               # Tsm_ccl_260610164501_x86_64_installer.run
+        - TSM Profiler 260610164501          # Tsm_profiler_260610164501_x86_64_installer.run
+        - TX8 Compiler Dependencies 20260507 # tx8_depends_dev_20260507_104051.tar.gz
+        - LLVM a66376b0                      # llvm-a66376b0-ubuntu-x64.tgz


### PR DESCRIPTION
## Summary

Add new backend `tsingmicro-tsm260610` for TsingMicro SDK 260610164501.

## Background

The tsm node host driver was upgraded to 260610164501.01 ahead of the pinned SDK in `tsm260604` (260604163331). This caused runtime verification failures — `tsm_smi` returned "library expects V260604163331, kernel module reports 260610164501".

## Changes

| File | Change |
|------|--------|
| `base/tsingmicro-tsm260610` | New Containerfile, identical to tsm260604 except `SDK_RELEASE=260610164501` |
| `configs.yaml` | New `vendors.tsingmicro.tsm260610` block with updated driver and SDK versions |
| `.github/build-config.yml` | Add `tsingmicro-tsm260610: [self-hosted, tsingmicro]` runner override |

## Verification

- [x] Base image builds successfully on tsm node
- [x] `tsm_smi` inside container detects all 32 chips (8× TX8110-256-00)
- [x] SDK version matches host driver: `V260610164501.01`

## Notes

- Four SDK installer files (`Tsm_*_260610164501_x86_64_installer.run`) were uploaded to the filestore prior to this PR.
- `tsm260604` is retained for hosts still on the older driver.

---

This PR was written in part with the assistance of generative AI.