### PR TITLE
Optimize Cambricon 4.4.3 base image

### DIFF
--- a/base/cambricon-neuware4.4.3
+++ b/base/cambricon-neuware4.4.3
@@ -39,29 +39,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # ── Install Neuware ────────────────────────────────────────────────
-ENV PKGS="cnlicense_1.2.0-1.ubuntu22.04_amd64.deb \
-  cndev_6.5.25-1.ubuntu22.04_amd64.deb \
-  cnbin_2.4.2-1.ubuntu22.04_amd64.deb \
-  cndrv_3.4.3-1.ubuntu22.04_amd64.deb \
-  cndev-compat_6.5.25-1.ubuntu22.04_amd64.deb \
-  cnrt_7.4.0-1.ubuntu22.04_amd64.deb \
-  cnas_5.4.3-1.ubuntu22.04_amd64.deb \
-  cnpx_1.6.0-1.ubuntu22.04_amd64.deb \
-  cnpapi_4.4.2-1.ubuntu22.04_amd64.deb \
-  cnperf_6.4.3-1.ubuntu22.04_amd64.deb \
-  cngdb_4.4.2-1.ubuntu22.04_amd64.deb \
-  cncc_5.4.3-1.ubuntu22.04_amd64.deb \
-  cnrtc_0.7.4-1.ubuntu22.04_amd64.deb \
-  cnjpeg_0.5.1-1.ubuntu22.04_amd64.deb \
-  cncodec3_2.4.1-1.ubuntu22.04_amd64.deb \
-  cnsanitizer_0.12.3-1.ubuntu22.04_amd64.deb \
+ENV PKGS="
   cntoolkit_4.4.3-1.ubuntu22.04_amd64.deb \
   cnnl_2.1.829-20251127_150207-v2.1.12-0.rc0-3-g54aaee8.ubuntu22.04_amd64.deb \
   cnnlextra_2.2.7-1.ubuntu22.04_amd64.deb \
   mluops_1.8.1-1.ubuntu22.04_amd64.deb \
   cncl_1.29.4-1.ubuntu22.04_amd64.deb \
-  cnstudio_1.2.1-1.ubuntu22.04_amd64.deb \
-  cntoolkit-cloud_4.4.3-1.ubuntu22.04_amd64.deb \
   cnclep_1.1.1-1.ubuntu22.04_amd64.deb"
 
 RUN set -eux ; \


### PR DESCRIPTION
It turned out that the cntoolkit debian package is a wrapper of a lot of other packages. We actually don't need to install those sub-packages at all.