### PR TITLE
Fix build config where cambricon 4.7.2 is missing

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -39,6 +39,7 @@ runners:
     ascend-cann8.5.0: [self-hosted, cann850]
     ascend-cann9.0.0: [self-hosted, cann9]
     cambricon-neuware4.4.3: [self-hosted, cambricon]
+    cambricon-neuware4.7.2: [self-hosted, cambricon]
     enflame-tops1.9.10: [self-hosted, enflame]
     enflame-tops1.9.17: [self-hosted, enflame]
     hygon-dtk26.04: [self-hosted, hygon]


### PR DESCRIPTION
We need a proper runner mapping for cambricon.