### PR TITLE
Fix base image for mthreads

### DIFF
--- a/base/mthreads-musa4.3.6
+++ b/base/mthreads-musa4.3.6
@@ -20,12 +20,14 @@
 #   MUSA/MCCL/muDNN packages carry no OS tag and are unchanged: their 22.04-built
 #   binaries link older glibc/libstdc++ and run on 24.04's newer libs
 #   (forward-compatible), while the 24.04 base satisfies flagtree's GLIBCXX floor.
-FROM ubuntu:24.04
+# - 20260801: Downgrad base OS to 22.04, add driver package.
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/mthreads
+ENV DRIVER=musa_3.3.6-server_amd64.deb
 ENV TOOLKIT_PKG=musa_toolkits_rc4.3.6.tar.gz
 ENV MCCL_PKG=mccl_rc2.1.6.PH1.tar.gz
 ENV MUDNN_PKG=mudnn_rc3.1.6.PH1.tar.gz
@@ -38,6 +40,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc g++ build-essential cmake \
         libelf1 libnuma-dev libgfortran5 libpython3-dev \
         libopenmpi-dev openmpi-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Driver
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /driver.deb ${FILE_STORE}/${DRIVER} \
+    && apt-get update \
+    && apt-get install -fy /driver.deb \
+    && rm /driver.deb \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Toolkit

--- a/base/mthreads-musa5.2.0
+++ b/base/mthreads-musa5.2.0
@@ -20,12 +20,14 @@
 #   MUSA/MCCL/muDNN packages carry no OS tag and are unchanged: their 22.04-built
 #   binaries link older glibc/libstdc++ and run on 24.04's newer libs
 #   (forward-compatible), while the 24.04 base satisfies flagtree's GLIBCXX floor.
-FROM ubuntu:24.04
+# - 20260801: Downgrade base OS to 22.04 and add driver package install.
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.authors="FlagOS contributors"
 
 # ── Build arguments ────────────────────────────────────────────
 ENV FILE_STORE=https://resource.flagos.net/repository/flagos-filestore/mthreads
+ENV DRIVER=musa_5.2.0-server_amd64.deb
 ENV TOOLKIT_PKG=musa_toolkits_5.2.0.tar.gz
 ENV MCCL_PKG=mccl.2.4.0.PH1.tar.gz
 ENV MUDNN_PKG=mudnn.3.4.0.PH1.tar.gz
@@ -38,6 +40,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc g++ build-essential cmake \
         libelf1 libnuma-dev libgfortran5 libpython3-dev \
         libopenmpi-dev openmpi-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Driver
+RUN curl --retry 5 --retry-delay 5 --retry-all-errors -o /driver.deb ${FILE_STORE}/${DRIVER} \
+    && apt-get update \
+    && apt-get install -fy /driver.deb \
+    && rm /driver.deb \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Toolkit


### PR DESCRIPTION
It turned out that the driver package has to be installed into the container as well, or else the 'libmusa.so.1' library would be missing. And it will mean that torch is completely not usable.