### PR TITLE
fix(hygon): pin numpy==1.26.4 to match vendor torch ABI

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -296,7 +296,12 @@ vendors:
       flagtree: flagtree==0.5.1+hcu3.1
       deps:
         - torch==2.9.0+das.opt1.dtk2604
-        - numpy==2.2.6
+        # torch built against the numpy 1.x C ABI — numpy 2.x breaks it
+        # ("Numpy is not available"). opencv-python-headless declares numpy>=2
+        # but that is a packaging declaration only (its wheel is runtime
+        # backward-compatible with numpy>=1.19), so 1.26.4 is safe. See
+        # vllm-repack/E2E-REPORT.md §2.4 / §1.7.
+        - numpy==1.26.4
       sdk:
         - Hygon DTK 26.04      # DTK-26.04-Ubuntu22.04-x86_64.tar.gz
 


### PR DESCRIPTION
## Summary

Pins `numpy==1.26.4` for `hygon-dtk26.04` in `configs.yaml` (was `2.2.6`).

The runtime image ships torch `2.9.0+das.opt1.dtk2604`, which is compiled against the **numpy 1.x C ABI**. Under the current `numpy==2.2.6` pin, torch fails at runtime — `Failed to initialize NumPy: _ARRAY_API not found` → `RuntimeError: Numpy is not available` — which blocks all inference. This is a pre-existing image issue, not caused by vllm.

## Verification (hygon25, 8× BW1000)

- Bisected: `numpy==1.26.4` → `torch.Tensor.numpy()` works; `numpy==2.2.6` → broken.
- The opencv objection is a **non-issue**: `opencv-python-headless 5.0.0.93` declares `numpy>=2; python_version >= "3.9"`, but that is a *packaging declaration*, not a runtime ABI floor. Its wheel is numpy-2.x-built and backward-compatible with numpy≥1.19. Verified with a full cv2 C-API roundtrip under numpy 1.26.4 (cvtColor, imencode/imdecode PNG lossless max_err=0, float64 resize) — all pass. So pinning 1.26.4 has no opencv side effect.

## Scope

Only `hygon-dtk26.04` is changed. The numpy floor is a per-vendor-torch-build property:
- **iluvatar-corex4.4.0** is already `1.26.4` (same 1.x-ABI torch class) — no change.
- **mthreads-musa5.2.0** (also py3.10) is confirmed working on `2.2.6` — not touched.
- All other backends left as-is — no evidence they need a change; downgrading a working backend risks breaking a numpy-2.x-built torch.

## Follow-up required

**The `hygon-dtk26.04` runtime image must be rebuilt** to bake in numpy 1.26.4 (the pin only takes effect on rebuild).

Context: vllm-repack/E2E-REPORT.md §2.4 / §1.7 (PR #284).

Generated with Claude Code.