### PR TITLE
feat(runtime): publish runtime image descriptions to Harbor

### DIFF
--- a/.github/workflows/gendoc-base.yaml
+++ b/.github/workflows/gendoc-base.yaml
@@ -146,6 +146,7 @@ jobs:
 
       - name: Harbor login (for image pull)
         env:
+          HARBOR_USER: ${{ secrets.HARBOR_USER }}
           HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
           # Harbor is internal — bypass any HTTP_PROXY/HTTPS_PROXY the runner
           # may have set for GitHub access, otherwise docker login routes
@@ -158,7 +159,7 @@ jobs:
         run: |
           host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
           for i in 1 2 3; do
-            if printf '%s' "$HARBOR_PW" | docker login "$host" -u tengqm --password-stdin; then
+            if printf '%s' "$HARBOR_PW" | docker login "$host" -u "$HARBOR_USER" --password-stdin; then
               exit 0
             fi
             echo "Harbor login attempt $i failed, retrying in 30s..."

--- a/.github/workflows/gendoc-runtime.yaml
+++ b/.github/workflows/gendoc-runtime.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Runtime Image Descriptions
+name: Generate docs for runtime images
 
 # Post-build: generate runtime image description markdown (single source for the
 # docs site, the in-repo runtime/<name>.md file, and the Harbor repository

--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Log in to the Container registry
         if: ${{ inputs.push }}
         env:
+          HARBOR_USER: ${{ secrets.HARBOR_USER }}
           HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
           # Harbor is internal — bypass any HTTP_PROXY/HTTPS_PROXY the runner
           # may have set for GitHub access.
@@ -66,7 +67,7 @@ jobs:
           # registry host = build-config.yml registry.host
           host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
           for i in 1 2 3; do
-            if printf '%s' "${HARBOR_PW}" | docker login "${host}" -u tengqm --password-stdin; then
+            if printf '%s' "${HARBOR_PW}" | docker login "${host}" -u "${HARBOR_USER}" --password-stdin; then
               exit 0
             fi
             echo "Harbor login attempt $i failed, retrying in 30s..."

--- a/.github/workflows/pubdoc-runtime.yaml
+++ b/.github/workflows/pubdoc-runtime.yaml
@@ -12,24 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Publish documentation for base images
+name: Publish documentation for runtime images
 
 # Publication is gated on review+merge: when reviewed per-image descriptions
-# land on main (a base-descriptions PR merged), push them to the Harbor repository.
-# Nothing goes live until the version diff — the checkpoint for catching
-# a disruptive change (e.g. a toolchain gcc bump) — has been reviewed and merged.
+# land on main (a runtime-descriptions PR merged), push them to the Harbor
+# repository. Nothing goes live until the description diff has been reviewed
+# and merged. Mirrors pubdoc-base.yaml for the runtime layer.
 
 on:
-  # This whenever the base image description is changed (usually a followup
-  # to the base image rebuild), the image repository description is supposed
-  # to be automatically updated.
+  # Whenever a runtime image description changes on main (usually a followup
+  # to the runtime image rebuild), the image repository description is
+  # automatically updated.
   push:
     branches: [main]
     paths:
-      - 'base/*.md'
+      - 'runtime/*.md'
 
-  # This is for the occasional github failure when the changes on 'base/*.md'
-  # files fail to trigger this workflow.
+  # For the occasional github failure when changes on 'runtime/*.md' files
+  # fail to trigger this workflow.
   workflow_dispatch:
 
 defaults:
@@ -41,8 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HARBOR_HOST: harbor.baai.ac.cn
-      HARBOR_USER: ${{ secrets.HARBOR_USER }}
-      HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
+      HARBOR_USER: flagos21
+      HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS21 }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -51,11 +51,11 @@ jobs:
       - name: Build the image list
         run: python3 docs/gen_data.py
       - name: Upload descriptions to Harbor
-        run: python3 docs/upload_descriptions.py
+        run: python3 docs/upload_descriptions.py --layer runtime
 
       - name: Clean up description branch
         if: always()
         run: |
           label=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 'unknown')
-          git push origin --delete "auto/base-descriptions-${label}" 2>/dev/null || true
-          echo "Cleaned up auto/base-descriptions-${label}"
+          git push origin --delete "auto/runtime-descriptions-${label}" 2>/dev/null || true
+          echo "Cleaned up auto/runtime-descriptions-${label}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,8 @@ Two stages: **builder** (installs uv, venv, deps, compilers, FlagGems wheel) →
 - **`trigger.yml`** — Base Image Build (manual). `workflow_dispatch` with backend + push inputs. Generates matrix via `generate_matrix.py`, calls reusable `imagebuild.yml` per backend.
 - **`runtime.yml`** — Runtime Image Build (manual). Same pattern, additionally checks out FlagGems repo for version derivation.
 - **`flaggems-wheel.yml`** — Daily (01:17 UTC) + manual FlagGems wheel build + upload to `flagos-pypi-daily` via twine.
-- **`base-descriptions.yml`** — Triggered on base image build completion. Extracts system package versions from built images (`dpkg-query`), runs `gen_data.py` + `gen_descriptions.py`, opens a **review-gated PR** with the version diff. Publication to Harbor (`base-descriptions-publish.yml`) only happens when that PR lands on `main`.
+- **`gendoc-base.yaml`** — Triggered on base image build completion. Extracts system package versions from built images (`dpkg-query`), runs `gen_data.py` + `gen_descriptions.py`, opens a **review-gated PR** with the version diff. Publication to Harbor (`pubdoc-base.yaml`) only happens when that PR lands on `main` (push to `base/*.md`).
+- **`gendoc-runtime.yaml`** — Runtime twin of `gendoc-base.yaml` (manual trigger; runtime images rebuild often during FlagGems testing, so no auto `workflow_run`). Opens a review-gated PR with `runtime/*.md`. Publication to Harbor (`pubdoc-runtime.yaml`) happens when that PR lands on `main` (push to `runtime/*.md`).
 - **`hugo-site.yaml`** — Builds + deploys docs site to GitHub Pages (triggered on push to `main` when `docs/**`, `configs.yaml`, or `base/**` changes).
 
 ### Runners

--- a/docs/upload_descriptions.py
+++ b/docs/upload_descriptions.py
@@ -14,16 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Push each generated base-image description to Harbor as the repository
+"""Push each generated image description to Harbor as the repository
 description. Harbor renders the description as markdown and shows the repository
 name as the top heading, so the H2-based body reads correctly on its own.
 
-Reads the plain-flavor markdown from base/<name>.md (the same file that serves
+Reads the plain-flavor markdown from <layer>/<name>.md (the same file that serves
 as the in-repo image readme) for every backend in docs/data/images.yaml. The
-repository is flagos-base-<name> under the project taken from the image ref.
+repository is flagos-<layer>-<name> under the project taken from the image ref.
+
+The layer (base or runtime) selects both the markdown directory and which image
+ref in images.yaml supplies the Harbor project.
 
 Env: HARBOR_HOST, HARBOR_USER, HARBOR_PW (basic auth).
-Usage: python docs/upload_descriptions.py [--dry-run]
+Usage: python docs/upload_descriptions.py [--layer base|runtime] [--dry-run]
 """
 
 import base64
@@ -51,7 +54,14 @@ def project_of(image_ref: str) -> str:
 
 
 def main():
-    dry = "--dry-run" in sys.argv[1:]
+    args = sys.argv[1:]
+    dry = "--dry-run" in args
+    layer = "base"
+    if "--layer" in args:
+        layer = args[args.index("--layer") + 1]
+    if layer not in ("base", "runtime"):
+        sys.exit(f"invalid --layer {layer!r}: expected 'base' or 'runtime'")
+
     host = os.environ["HARBOR_HOST"]
     user = os.environ.get("HARBOR_USER", "")
     pw = os.environ.get("HARBOR_PW", "")
@@ -59,18 +69,18 @@ def main():
 
     root = Path(__file__).resolve().parent.parent
     images = yaml.safe_load((root / "docs" / "data" / "images.yaml").read_text())
-    base_dir = root / "base"
+    md_dir = root / layer
 
     failures = 0
     for entry in images.get("backends", []):
         name = entry["name"]
-        md_path = base_dir / f"{name}.md"
+        md_path = md_dir / f"{name}.md"
         if not md_path.is_file():
             print(f"skip {name}: no description md")
             continue
         desc = strip_front_matter(md_path.read_text())
-        project = project_of(entry["base"]["image"])
-        repo = f"flagos-base-{name}"
+        project = project_of(entry[layer]["image"])
+        repo = f"flagos-{layer}-{name}"
         url = f"https://{host}/api/v2.0/projects/{project}/repositories/{repo}"
         if dry:
             print(f"[dry-run] PUT {url}  ({len(desc)} chars)")


### PR DESCRIPTION
## Summary

Adds the **publish** half of the runtime docs pipeline, mirroring the base layer. The generate side already opened a review-gated PR with `runtime/*.md`, but nothing pushed those descriptions to Harbor once merged.

## Changes

- **`docs/upload_descriptions.py`** — generalized from base-only to both layers via `--layer base|runtime` (default `base`, so existing base usage is unchanged). Reads `<layer>/<name>.md` and pushes to `flagos-<layer>-<name>` under the project from that layer's image ref.
- **`.github/workflows/pubdoc-runtime.yaml`** (new) — runtime twin of `pubdoc-base.yaml`. Triggers on push to `main` touching `runtime/*.md` (plus `workflow_dispatch`); logs in as `flagos21` / `HARBOR_AC_FLAGOS21` (the `flagos-runtime` project account).
- **Renamed** `runtime-descriptions.yml` → `gendoc-runtime.yaml` for symmetry with the base `gendoc-*`/`pubdoc-*` pair.
- **De-hardcoded the base-side Harbor username** — `secrets.HARBOR_USER` in place of `tengqm` in `imagebuild.yml`, `gendoc-base.yaml`, `pubdoc-base.yaml`. (Runtime keeps `flagos21`; non-Harbor `tengqm` references left untouched.)
- **`CLAUDE.md`** — corrected stale workflow filenames, documented the runtime pair.

## Notes

- Requires repo secret **`HARBOR_USER`** (added).
- Confirm `HARBOR_AC_FLAGOS21`'s account has push-description permission on the `flagos-runtime` Harbor project — it pushes images today, but the description PUT hits a different API endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)