### PR TITLE
chore(ci): consolidate Harbor auth to HARBOR_USER + HARBOR_PASSWORD

### DIFF
--- a/.github/workflows/gendoc-base.yaml
+++ b/.github/workflows/gendoc-base.yaml
@@ -147,7 +147,7 @@ jobs:
       - name: Harbor login (for image pull)
         env:
           HARBOR_USER: ${{ secrets.HARBOR_USER }}
-          HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
+          HARBOR_PW: ${{ secrets.HARBOR_PASSWORD }}
           # Harbor is internal — bypass any HTTP_PROXY/HTTPS_PROXY the runner
           # may have set for GitHub access, otherwise docker login routes
           # Harbor traffic through the proxy and fails.

--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -51,7 +51,7 @@ jobs:
         if: ${{ inputs.push }}
         env:
           HARBOR_USER: ${{ secrets.HARBOR_USER }}
-          HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
+          HARBOR_PW: ${{ secrets.HARBOR_PASSWORD }}
           # Harbor is internal — bypass any HTTP_PROXY/HTTPS_PROXY the runner
           # may have set for GitHub access.
           # Only uppercase HTTP_PROXY/HTTPS_PROXY (lowercase clash with runner
@@ -61,7 +61,7 @@ jobs:
           no_proxy: "harbor.baai.ac.cn,.baai.ac.cn"
         run: |
           if [ -z "${HARBOR_PW:-}" ]; then
-            echo "ERROR: secret HARBOR_AC_FLAGOS_BASE is empty or unset" >&2
+            echo "ERROR: secret HARBOR_PASSWORD is empty or unset" >&2
             exit 1
           fi
           # registry host = build-config.yml registry.host

--- a/.github/workflows/pubdoc-base.yaml
+++ b/.github/workflows/pubdoc-base.yaml
@@ -42,7 +42,7 @@ jobs:
     env:
       HARBOR_HOST: harbor.baai.ac.cn
       HARBOR_USER: ${{ secrets.HARBOR_USER }}
-      HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS_BASE }}
+      HARBOR_PW: ${{ secrets.HARBOR_PASSWORD }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/pubdoc-runtime.yaml
+++ b/.github/workflows/pubdoc-runtime.yaml
@@ -41,8 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HARBOR_HOST: harbor.baai.ac.cn
-      HARBOR_USER: flagos21
-      HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS21 }}
+      HARBOR_USER: ${{ secrets.HARBOR_USER }}
+      HARBOR_PW: ${{ secrets.HARBOR_PASSWORD }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/runtime-image.yaml
+++ b/.github/workflows/runtime-image.yaml
@@ -98,11 +98,12 @@ jobs:
       - name: Harbor login (push only)
         if: ${{ inputs.push }}
         env:
-          HARBOR_PW: ${{ secrets.HARBOR_AC_FLAGOS21 }}
+          HARBOR_USER: ${{ secrets.HARBOR_USER }}
+          HARBOR_PW: ${{ secrets.HARBOR_PASSWORD }}
         run: |
           host="${{ needs.set-matrix.outputs.harbor_host }}"
           for i in 1 2 3; do
-            if printf '%s' "$HARBOR_PW" | docker login "$host" -u flagos21 --password-stdin; then
+            if printf '%s' "$HARBOR_PW" | docker login "$host" -u "$HARBOR_USER" --password-stdin; then
               exit 0
             fi
             echo "Harbor login attempt $i failed, retrying..."


### PR DESCRIPTION
## Summary

Collapses Harbor authentication onto a single account across all workflows. Previously the `flagos-runtime` project used `flagos21` / `HARBOR_AC_FLAGOS21` and `flagos-base` used `tengqm` / `HARBOR_AC_FLAGOS_BASE`. Now every workflow logs in via `secrets.HARBOR_USER` + `secrets.HARBOR_PASSWORD`.

## Changes

- **`runtime-image.yaml`, `pubdoc-runtime.yaml`** — drop `flagos21` / `HARBOR_AC_FLAGOS21`; log in with `secrets.HARBOR_USER` + `secrets.HARBOR_PASSWORD`.
- **All five Harbor logins** (`imagebuild.yml`, `runtime-image.yaml`, `gendoc-base.yaml`, `pubdoc-base.yaml`, `pubdoc-runtime.yaml`) — rename secret `HARBOR_AC_FLAGOS_BASE` → `HARBOR_PASSWORD`, including the empty-secret error message in `imagebuild.yml`.

## Notes

- Requires repo secrets **`HARBOR_USER`** and **`HARBOR_PASSWORD`** (added).
- **`HARBOR_AC_FLAGOS21`** and **`HARBOR_AC_FLAGOS_BASE`** are now unused and can be deleted.
- The consolidated account must have push access (image push + repository-description PUT) to both the `flagos-base` and `flagos-runtime` projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)