### PR TITLE
feat(vllm-repack): strip setuptools build-leak from vllm 0.20.2

### DIFF
--- a/vllm-repack/build-and-repack.sh
+++ b/vllm-repack/build-and-repack.sh
@@ -129,9 +129,14 @@ docker run -d --name "$CONTAINER" --network host \
 
 # ── Build + repack ──────────────────────────────────────────────────────
 
-# Ensure build deps — remove once build images include setuptools-scm
+# Ensure build deps — remove once build images ship these.
+# With --no-build-isolation, pip uses the venv's own setuptools, ignoring
+# vllm's build-system.requires. Newer vllm (>=0.20) declares PEP 639
+# `license = "Apache-2.0"` + `license-files`, which setuptools <77 rejects,
+# so pin setuptools to vllm's own required range.
 docker exec "$CONTAINER" bash -c "
-    pip install -i https://mirrors.aliyun.com/pypi/simple 'setuptools-scm>=8,<10' \
+    pip install -i https://mirrors.aliyun.com/pypi/simple \
+        'setuptools>=77.0.3,<81.0.0' 'setuptools-scm>=8,<10' \
         > /dev/null 2>&1
 "
 

--- a/vllm-repack/config.yaml
+++ b/vllm-repack/config.yaml
@@ -16,7 +16,7 @@
 # Each key is a set of *package names* (no version, case-insensitive).
 #
 # Top-level rules (applied to vllm's own METADATA):
-#   remove_torch_chain, remove_cuda_only, remove_orphaned
+#   remove_torch_chain, remove_cuda_only, remove_orphaned, remove_build_leak
 #
 # Indirect-dep rules (applied to retained deps that declare torch/triton
 # in their own METADATA — discovered automatically by repack_recursive):
@@ -49,6 +49,18 @@ remove_cuda_only:
 # Packages whose only consumer was stripped above (no other consumers left).
 remove_orphaned:
   - apache-tvm-ffi
+
+# Build-only tools that leak into runtime Requires-Dist.  vllm >=0.20 declares
+# `setuptools<81.0.0,>=77.0.3; python_version > "3.11"` — the build-system pin
+# mirrored into runtime deps.  On Python 3.12 backends the marker is active, so
+# installing vllm would force setuptools>=77 into the runtime venv.  That both
+# conflicts with vendor torch pins (e.g. torch-gcu pins setuptools==69.5.1) and
+# defeats the FlagOS `setuptools<77` guard (>=77 stamps Metadata-Version 2.4,
+# which Nexus rejects — see configs.yaml flaggems_cpp_build_deps).  setuptools is
+# not a genuine runtime import need here (the venv already ships a working one),
+# so strip it from vllm's own Requires-Dist.
+remove_build_leak:
+  - setuptools
 
 # ── Indirect dependency stripping rules ───────────────────────────────
 # When repack_recursive() finds a retained dep whose own METADATA

--- a/vllm-repack/repack.py
+++ b/vllm-repack/repack.py
@@ -296,7 +296,7 @@ def _pin_requires_dist(meta_text: str, dep_name: str, pinned_version: str) -> tu
 
 
 def classify(rd: dict, config: dict):
-    """Return one of: 'torch_chain', 'cuda_only', 'orphaned', 'keep'."""
+    """Return one of: 'torch_chain', 'cuda_only', 'orphaned', 'build_leak', 'keep'."""
     nn = _normalize(rd["name"])
     for item in config.get("remove_torch_chain", []):
         if _normalize(item) == nn:
@@ -307,6 +307,9 @@ def classify(rd: dict, config: dict):
     for item in config.get("remove_orphaned", []):
         if _normalize(item) == nn:
             return "orphaned"
+    for item in config.get("remove_build_leak", []):
+        if _normalize(item) == nn:
+            return "build_leak"
     return "keep"
 
 
@@ -570,7 +573,7 @@ def resolve_dep_versions(meta_text: str, extra_indexes: list[str]) -> dict[str, 
     config = load_config()
     all_rd = parse_requires_dist(meta_text)
     exclude = set()
-    for cat in ("remove_torch_chain", "remove_cuda_only", "remove_orphaned"):
+    for cat in ("remove_torch_chain", "remove_cuda_only", "remove_orphaned", "remove_build_leak"):
         for item in config.get(cat, []):
             exclude.add(_normalize(item))
 
@@ -917,18 +920,18 @@ def repack_top_level(whl_path: Path, extra_indexes: list[str], recurse: bool = T
     all_rd = parse_requires_dist(meta_text)
 
     # 2. Classify every Requires-Dist
-    removed: dict[str, list[str]] = {"torch_chain": [], "cuda_only": [], "orphaned": []}
+    removed: dict[str, list[str]] = {"torch_chain": [], "cuda_only": [], "orphaned": [], "build_leak": []}
     retained: list[str] = []
 
     for rd in all_rd:
         cat = classify(rd, config)
-        if cat in ("torch_chain", "cuda_only", "orphaned"):
+        if cat in ("torch_chain", "cuda_only", "orphaned", "build_leak"):
             removed[cat].append(rd["raw"])
         else:
             retained.append(rd["raw"])
 
     print(f"  keep:     {len(retained)}")
-    for cat in ("torch_chain", "cuda_only", "orphaned"):
+    for cat in ("torch_chain", "cuda_only", "orphaned", "build_leak"):
         if removed[cat]:
             print(f"  {cat}: {len(removed[cat])}")
 
@@ -945,7 +948,7 @@ def repack_top_level(whl_path: Path, extra_indexes: list[str], recurse: bool = T
 
     # 4. Strip & rewrite top-level wheel
     names_to_remove: set[str] = set()
-    for cat in ("torch_chain", "cuda_only", "orphaned"):
+    for cat in ("torch_chain", "cuda_only", "orphaned", "build_leak"):
         for rd_raw in removed.get(cat, []):
             nm = _NAME_RE.match(rd_raw)
             if nm:


### PR DESCRIPTION
## Problem

vllm 0.20.2 adopted the **PEP 639** license form (`license = "Apache-2.0"` + `license-files = ["LICENSE"]`), which only **setuptools >=77.0.3** can parse. It also mirrors that pin into runtime metadata:

```
Requires-Dist: setuptools<81.0.0,>=77.0.3; python_version > "3.11"
```

This surfaced building the **enflame tops1.9.10** runtime image (Python 3.12), and breaks in two places:

1. **Build:** `pip wheel --no-build-isolation VLLM_TARGET_DEVICE=empty` uses the venv's own setuptools (ignoring vllm's `build-system.requires`). `torch-gcu` hard-pins `setuptools==69.5.1` into the venv, causing a PEP 639 parse error: `configuration error: project.license must be valid exactly by one definition`.
2. **Install:** on Python 3.12 the `> "3.11"` marker is active, so installing the repacked vllm forces `setuptools>=77` into the runtime venv — conflicting with vendor torch pins and **defeating the `configs.yaml setuptools<77` guard** (>=77 stamps Metadata-Version 2.4, which Nexus rejects for the in-runtime FlagGems C++ wheel build).

## Fix

- **`build-and-repack.sh`** — install `setuptools>=77.0.3,<81.0.0` into the *ephemeral* empty-build venv (vllm's own required range). Build emits Metadata-Version 2.4; `repack.py._downgrade_metadata_version` already rewrites that to 2.2. Confined to the build; never touches the runtime image's `<77` flag_gems step.
- **`config.yaml` / `repack.py`** — new top-level removal category `remove_build_leak` strips `setuptools` from vllm's own `Requires-Dist`. setuptools is not a genuine runtime import need (the venv already ships a working one); the >=77 floor is just the build-system pin leaking into runtime deps.

The `> "3.11"` marker means the leak is inert on the Python 3.10 backends (metax/mthreads/hygon/...) and only bites Python 3.12 (enflame) — the same 3.12-uniqueness that required the full in-image build+repack there.

## Verification

Repacked `vllm-0.20.2+flagos` wheel on enflame: Metadata-Version **2.2**, License Apache-2.0, torch stripped, and (with this change) no `setuptools` line. E2E install/serve on enflame GCU tracked separately.

This PR was written in part with the assistance of generative AI.
