### PR TITLE
Bump topsaten library version for tops-1.10.6

### DIFF
--- a/base/enflame-tops1.10.6
+++ b/base/enflame-tops1.10.6
@@ -50,7 +50,7 @@ RUN curl -fsSL -O ${FILE_STORE}/topsruntime_1.10.6-1_amd64.deb \
       -O ${FILE_STORE}/topsfile_1.10.6-1_amd64.deb \
       -O ${FILE_STORE}/topsprof_1.10.6-1_amd64.deb \
       -O ${FILE_STORE}/efml_1.10.6-1_amd64.deb \
-      -O ${FILE_STORE}/topsaten_3.7.20260602-1_amd64.deb \
+      -O ${FILE_STORE}/topsaten_3.8.20260710-1_amd64.deb \
       -O ${FILE_STORE}/eccl_3.6.3.11-1_amd64.deb \
       -O ${FILE_STORE}/eccl-tests_3.6.3.11-1_amd64.deb \
       -O ${FILE_STORE}/triton-gcu_3.6.0+1.0.20260722.cc.1.10.6-1_amd64.deb \


### PR DESCRIPTION
The PR bumps the version of the topsaten library for the tops-1.10.6 backend.