### PR TITLE
Fix python environment for cambricon 4.7.2 backend

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -191,37 +191,36 @@ vendors:
         - numpy==2.2.6
       sdk:
         - cnmon 6.2.15         # cnmon-6.2.15-x86_64.zip
-        - cntoolkit 4.4.3        # cntoolkit_4.4.3-1.ubuntu22.04_amd64.deb
-        - cncl 1.29.4            # cncl_1.29.4-1.ubuntu22.04_amd64.deb
-        - cnclep 1.1.1.          # cnclep_1.1.1-1.ubuntu22.04_amd64.deb
-        - cnnl+extra 2.1.829     # cnnl_2.1.829-20251127_150207-v2.1.12-0.rc0-3-g54aaee8.ubuntu22.04_amd64.deb
-                                 # cnnlextra_2.2.7-1.ubuntu22.04_amd64.deb
-        - mluops 1.8.1           # mluops_1.8.1-1.ubuntu22.04_amd64.deb
+        - cntoolkit 4.4.3      # cntoolkit_4.4.3-1.ubuntu22.04_amd64.deb
+        - cncl 1.29.4          # cncl_1.29.4-1.ubuntu22.04_amd64.deb
+        - cnclep 1.1.1.        # cnclep_1.1.1-1.ubuntu22.04_amd64.deb
+        - cnnl 2.1.829         # cnnl_2.1.829-20251127_150207-v2.1.12-0.rc0-3-g54aaee8.ubuntu22.04_amd64.deb
+        - cnnlextra 2.2.7      # cnnlextra_2.2.7-1.ubuntu22.04_amd64.deb
+        - mluops 1.8.1         # mluops_1.8.1-1.ubuntu22.04_amd64.deb
 
     neuware4.7.2:
       extras: cambricon
       hardware: ["Cambricon MLU590"]
       driver: "6.5.48"
       python: "3.12"
-      triton: triton==3.2.0+mlu1.7.2
+      triton: triton==3.4.0+mlu2.1.1
       env:
         base:
           NEUWARE_HOME: /usr/local/neuware
           PATH: /usr/local/neuware/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/neuware/lib64
       deps:
-        - cambricon_dali==0.13.0
-        - torch==2.7.1+cpu
-        - torch-mlu==1.29.2+torch2.7.1
-        - torch-mlu-ops==1.8.0+torch2.7.1
+        - torch==2.11.0+cpu
+        - torch-mlu==1.33.1+torch2.11.0
+        - torch-mlu-ops==1.12.1+torch2.11.0
         - numpy==2.2.6
       sdk:
         - cnmon 6.5.48           # cnmon-6.5.48-x86_64.zip
         - cntoolkit 4.7.2        # cntoolkit_4.7.2-1.ubuntu24.04_amd64.deb
         - cncl 1.30.8            # cncl_1.30.8-1.ubuntu24.04_amd64.deb
         - cnclep 1.4.0           # cnclep_1.4.0-1.ubuntu24.04_amd64.deb
-        - cnnl+extra 2.1.829     # cnnl_2.2.14-1.ubuntu24.04_amd64.deb
-                                 # cnnlextra_2.4.0-1.ubuntu24.04_amd64.deb
+        - cnnl 2.2.14            # cnnl_2.2.14-1.ubuntu24.04_amd64.deb
+        - cnnlextra 2.4.0        # cnnlextra_2.4.0-1.ubuntu24.04_amd64.deb
         - mluops 1.12.0          # mluops_1.12.0-1.ubuntu24.04_amd64.deb
 
   enflame:


### PR DESCRIPTION
This PR adjusts the python package version requirements for the Cambricon Neuware 4.7.2 backend.