### PR TITLE
Bump torch family verions again for enflame 1.9.10 backend

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -240,12 +240,11 @@ vendors:
           ENABLE_I64_CHECK: "1"
       deps:
         - pyefml==1.9.10
-        - torch==2.9.1+cpu
-        - torchaudio==2.9.1+cpu
-        - torchvision==0.24.1+cpu
-        - torch-gcu==2.9.1+3.7.1
-        - flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323
-        - numpy==2.3.5
+        - torch==2.10.0+cpu
+        - torchaudio==2.10.0+cpu
+        - torchvision==0.25.0+cpu
+        - torch-gcu==2.10.0+3.7.20260408
+        - flash-attn==2.7.2+torch.2.10.0.gcu.3.4.20260506
       sdk:
         - Enflame driver 1.9.10   # enflame-x86_64-gcc-1.9.10-20260520104313.run
         - TOPS Runtime 1.9.10     # topsruntime_1.9.10-1_amd64.deb


### PR DESCRIPTION
Bump torch versions back for 1.9.10 backend.
Removed numpy from the version requirements.