### PR TITLE
ci: gate manual workflow triggers via shared authorize action

### DIFF
--- a/.github/actions/check-trigger-author/action.yml
+++ b/.github/actions/check-trigger-author/action.yml
@@ -1,0 +1,40 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check trigger author
+description: |-
+  Fail the workflow if github.triggering_actor is not listed in
+  .github/builders.txt. Enforced only for manual workflow_dispatch
+  triggers; other event types (push, schedule, workflow_run,
+  workflow_call) are not gated.
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repo
+      uses: actions/checkout@v7
+
+    - name: Check trigger author
+      shell: bash
+      run: |
+        if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+          echo "Not a manual dispatch (${{ github.event_name }}) — skipping authorization"
+          exit 0
+        fi
+        actor="${{ github.triggering_actor }}"
+        if ! grep -Fxq "$actor" .github/builders.txt; then
+          echo "::error::$actor is not authorized to trigger this workflow"
+          exit 1
+        fi
+        echo "Authorized triggerer: $actor"

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -33,21 +33,11 @@ on:
 
 jobs:
   authorize:
-    # Only accounts listed in .github/builders.txt may trigger this workflow.
-    # workflow_dispatch is already restricted to users with write access;
-    # this narrows it further to the maintainers who actually run image builds.
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   set-matrix:
     needs: authorize

--- a/.github/workflows/flaggems-release.yml
+++ b/.github/workflows/flaggems-release.yml
@@ -44,21 +44,11 @@ defaults:
 
 jobs:
   authorize:
-    # Only accounts listed in .github/builders.txt may trigger this workflow.
-    # workflow_dispatch is already restricted to users with write access;
-    # this narrows it further to the maintainers who run releases.
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   # ── 5a: pure-Python wheel, all vendor PyPIs ──────────────────────────────
   python-wheel:

--- a/.github/workflows/flaggems-release.yml
+++ b/.github/workflows/flaggems-release.yml
@@ -43,8 +43,26 @@ defaults:
     shell: bash
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow.
+    # workflow_dispatch is already restricted to users with write access;
+    # this narrows it further to the maintainers who run releases.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   # ── 5a: pure-Python wheel, all vendor PyPIs ──────────────────────────────
   python-wheel:
+    needs: authorize
     # Self-hosted runner for fast upload — pushing a 5.4 MB wheel to 14
     # vendor Nexus repositories over the public internet (GitHub runner) has
     # been observed at ~60 kB/s. An internal self-hosted runner saturates

--- a/.github/workflows/flaggems-wheel.yml
+++ b/.github/workflows/flaggems-wheel.yml
@@ -44,21 +44,10 @@ defaults:
 jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
-    # manually. The scheduled daily build is not gated — the check step only
-    # runs on workflow_dispatch.
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   build:
     needs: authorize

--- a/.github/workflows/flaggems-wheel.yml
+++ b/.github/workflows/flaggems-wheel.yml
@@ -42,7 +42,26 @@ defaults:
     shell: bash
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually. The scheduled daily build is not gated — the check step only
+    # runs on workflow_dispatch.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   build:
+    needs: authorize
     runs-on: ubuntu-latest
     env:
       FLAGGEMS_REPO: https://github.com/flagos-ai/FlagGems.git

--- a/.github/workflows/gendoc-base.yaml
+++ b/.github/workflows/gendoc-base.yaml
@@ -60,21 +60,10 @@ defaults:
 jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
-    # manually. The workflow_run follow-up (after a base image build) is not
-    # gated — the check step only runs on workflow_dispatch.
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   set-matrix:
     needs: authorize

--- a/.github/workflows/gendoc-base.yaml
+++ b/.github/workflows/gendoc-base.yaml
@@ -58,7 +58,26 @@ defaults:
     shell: bash
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually. The workflow_run follow-up (after a base image build) is not
+    # gated — the check step only runs on workflow_dispatch.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   set-matrix:
+    needs: authorize
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/gendoc-runtime.yaml
+++ b/.github/workflows/gendoc-runtime.yaml
@@ -31,7 +31,25 @@ permissions:
   pull-requests: write
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow.
+    # workflow_dispatch is already restricted to users with write access;
+    # this narrows it further to the maintainers who generate docs.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   finalize:
+    needs: authorize
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/gendoc-runtime.yaml
+++ b/.github/workflows/gendoc-runtime.yaml
@@ -32,21 +32,11 @@ permissions:
 
 jobs:
   authorize:
-    # Only accounts listed in .github/builders.txt may trigger this workflow.
-    # workflow_dispatch is already restricted to users with write access;
-    # this narrows it further to the maintainers who generate docs.
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   finalize:
     needs: authorize

--- a/.github/workflows/hugo-site.yaml
+++ b/.github/workflows/hugo-site.yaml
@@ -42,21 +42,10 @@ defaults:
 jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
-    # manually. The push trigger (docs/** merged to main) is not gated — the
-    # check step only runs on workflow_dispatch.
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   build-and-deploy:
     needs: authorize

--- a/.github/workflows/hugo-site.yaml
+++ b/.github/workflows/hugo-site.yaml
@@ -40,7 +40,26 @@ defaults:
     shell: bash
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually. The push trigger (docs/** merged to main) is not gated — the
+    # check step only runs on workflow_dispatch.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   build-and-deploy:
+    needs: authorize
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.157.0

--- a/.github/workflows/pubdoc-base.yaml
+++ b/.github/workflows/pubdoc-base.yaml
@@ -39,21 +39,10 @@ defaults:
 jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
-    # manually. The push trigger (base/*.md merged to main) is not gated —
-    # the check step only runs on workflow_dispatch.
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   publish:
     needs: authorize

--- a/.github/workflows/pubdoc-base.yaml
+++ b/.github/workflows/pubdoc-base.yaml
@@ -37,7 +37,26 @@ defaults:
     shell: bash
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually. The push trigger (base/*.md merged to main) is not gated —
+    # the check step only runs on workflow_dispatch.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   publish:
+    needs: authorize
     runs-on: ubuntu-latest
     env:
       HARBOR_HOST: harbor.baai.ac.cn

--- a/.github/workflows/pubdoc-runtime.yaml
+++ b/.github/workflows/pubdoc-runtime.yaml
@@ -39,21 +39,10 @@ defaults:
 jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
-    # manually. The push trigger (runtime/*.md merged to main) is not gated —
-    # the check step only runs on workflow_dispatch.
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   publish:
     needs: authorize

--- a/.github/workflows/pubdoc-runtime.yaml
+++ b/.github/workflows/pubdoc-runtime.yaml
@@ -37,7 +37,26 @@ defaults:
     shell: bash
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually. The push trigger (runtime/*.md merged to main) is not gated —
+    # the check step only runs on workflow_dispatch.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   publish:
+    needs: authorize
     runs-on: ubuntu-latest
     env:
       HARBOR_HOST: harbor.baai.ac.cn

--- a/.github/workflows/runtime-image.yaml
+++ b/.github/workflows/runtime-image.yaml
@@ -48,21 +48,11 @@ on:
 
 jobs:
   authorize:
-    # Only accounts listed in .github/builders.txt may trigger this workflow.
-    # workflow_dispatch is already restricted to users with write access;
-    # this narrows it further to the maintainers who actually run image builds.
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   set-matrix:
     needs: authorize

--- a/.github/workflows/sync-to-remote.yaml
+++ b/.github/workflows/sync-to-remote.yaml
@@ -58,7 +58,26 @@ permissions:
   contents: read
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually. Callers via workflow_call are not gated — the check step only
+    # runs on workflow_dispatch.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   sync:
+    needs: authorize
     runs-on: ubuntu-latest
     env:
       REMOTE: ${{ inputs.remote }}

--- a/.github/workflows/sync-to-remote.yaml
+++ b/.github/workflows/sync-to-remote.yaml
@@ -60,21 +60,10 @@ permissions:
 jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
-    # manually. Callers via workflow_call are not gated — the check step only
-    # runs on workflow_dispatch.
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   sync:
     needs: authorize

--- a/.github/workflows/verify-cpp-fixes.yml
+++ b/.github/workflows/verify-cpp-fixes.yml
@@ -22,21 +22,11 @@ on:
 
 jobs:
   authorize:
-    # Only accounts listed in .github/builders.txt may trigger this workflow.
-    # workflow_dispatch is already restricted to users with write access;
-    # this narrows it further to the maintainers who run verifications.
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   verify-nvidia-cuda128:
     needs: authorize

--- a/.github/workflows/verify-cpp-fixes.yml
+++ b/.github/workflows/verify-cpp-fixes.yml
@@ -21,7 +21,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow.
+    # workflow_dispatch is already restricted to users with write access;
+    # this narrows it further to the maintainers who run verifications.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   verify-nvidia-cuda128:
+    needs: authorize
     runs-on: [self-hosted, h20]
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/verify-runtime.yml
+++ b/.github/workflows/verify-runtime.yml
@@ -37,21 +37,11 @@ defaults:
 
 jobs:
   authorize:
-    # Only accounts listed in .github/builders.txt may trigger this workflow.
-    # workflow_dispatch is already restricted to users with write access;
-    # this narrows it further to the maintainers who run verifications.
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Check trigger author
-        run: |
-          actor="${{ github.triggering_actor }}"
-          if ! grep -qx "$actor" .github/builders.txt; then
-            echo "::error::$actor is not authorized to trigger this workflow"
-            exit 1
-          fi
+      - uses: ./.github/actions/check-trigger-author
 
   set-matrix:
     needs: authorize

--- a/.github/workflows/verify-runtime.yml
+++ b/.github/workflows/verify-runtime.yml
@@ -36,7 +36,25 @@ defaults:
     shell: bash
 
 jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow.
+    # workflow_dispatch is already restricted to users with write access;
+    # this narrows it further to the maintainers who run verifications.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Check trigger author
+        run: |
+          actor="${{ github.triggering_actor }}"
+          if ! grep -qx "$actor" .github/builders.txt; then
+            echo "::error::$actor is not authorized to trigger this workflow"
+            exit 1
+          fi
+
   set-matrix:
+    needs: authorize
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.m.outputs.matrix }}


### PR DESCRIPTION
## What

Restrict manual (`workflow_dispatch`) triggering of every workflow to the maintainers listed in `.github/builders.txt`, via a single shared composite action instead of copy-pasted job code.

## How

New composite action **`.github/actions/check-trigger-author/action.yml`**:
- Checks out the repo, reads `.github/builders.txt`, and fails the run if `github.triggering_actor` is not listed (`::error::<actor> is not authorized...`).
- **Only enforces on `workflow_dispatch`** — push, schedule, `workflow_run`, and `workflow_call` triggers pass through untouched, so all existing automation keeps working.
- Uses `grep -Fx` (fixed-string match) so bot names like `dependabot[bot]` match literally.

Every workflow with a manual trigger now has a 5-line `authorize` job wrapping the action, gating its entry job via `needs: authorize`:

```yaml
  authorize:
    runs-on: ubuntu-latest
    steps:
      - uses: ./.github/actions/check-trigger-author
```

Workflows covered (12 total, all with `workflow_dispatch`):
`base-image.yaml` · `runtime-image.yaml` · `flaggems-release.yml` · `flaggems-wheel.yml` (schedule) · `gendoc-base.yaml` (workflow_run) · `gendoc-runtime.yaml` · `hugo-site.yaml` (push) · `pubdoc-base.yaml` (push) · `pubdoc-runtime.yaml` (push) · `sync-to-remote.yaml` (workflow_call) · `verify-cpp-fixes.yml` · `verify-runtime.yml`

The two image builds already gated in #311 are refactored onto the shared action for consistency (net -126 lines of duplicated YAML).

## Why

Any user with write access (~19 collaborators) could manually trigger these — several push to Harbor, upload wheels to vendor PyPIs, deploy the docs site, or run workloads on self-hosted hardware. This narrows manual triggering to `tengqm` + `shiptux` and removes the ~18-line inline job that was starting to be copy-pasted into every workflow.

## Notes

- **Automated triggers untouched** — only the human-clicked manual path is gated.
- **Pre-existing bug found (not fixed here):** `scripts/finalize_descriptions.py` self-retries the docs workflow via `gh workflow run "Base image descriptions"`, but no workflow has that name (file is `Generate docs for base images`). The self-healing retry loop is currently broken regardless of this change; worth a follow-up.
- Gate is only as strong as branch protection on `main`.

This PR was written in part with the assistance of generative AI.
