### PR TITLE
ci: fix gendoc retry loop — correct workflow ref + bot exemption

### DIFF
--- a/.github/actions/check-trigger-author/action.yml
+++ b/.github/actions/check-trigger-author/action.yml
@@ -17,7 +17,9 @@ description: |-
   Fail the workflow if github.triggering_actor is not listed in
   .github/builders.txt. Enforced only for manual workflow_dispatch
   triggers; other event types (push, schedule, workflow_run,
-  workflow_call) are not gated.
+  workflow_call) are not gated. The repository's own automation
+  (github-actions[bot], i.e. a dispatch authenticated as the repo
+  GITHUB_TOKEN) is allowed so self-healing re-dispatch loops work.
 
 runs:
   using: composite
@@ -33,6 +35,13 @@ runs:
           exit 0
         fi
         actor="${{ github.triggering_actor }}"
+        # gendoc-base.yaml re-dispatches itself (via gh workflow run with the
+        # repo GITHUB_TOKEN) to retry failed backends. Exempt that identity —
+        # the bot token is only usable by workflows running in this repo.
+        if [[ "$actor" == "github-actions[bot]" ]]; then
+          echo "Repo automation (github-actions[bot]) — skipping authorization"
+          exit 0
+        fi
         if ! grep -Fxq "$actor" .github/builders.txt; then
           echo "::error::$actor is not authorized to trigger this workflow"
           exit 1

--- a/scripts/finalize_descriptions.py
+++ b/scripts/finalize_descriptions.py
@@ -24,7 +24,7 @@ Two modes, dispatched by ``--done``:
     ``main``. Clean up state + per-backend extract branches when done.
 
 **done=false (retry)**
-    Self-trigger the ``base-descriptions.yml`` workflow with only the missing
+    Self-trigger the ``gendoc-base.yaml`` workflow with only the missing
     backends (or exit with a warning if there are none). Clean up the
     per-backend extract branches that were already collected so they don't
     interfere with the next retry. If the retry cap is hit, exit with error.
@@ -231,8 +231,11 @@ def _retry(args) -> None:
 
     next_retry = retry + 1
     print(f"Self-triggering retry {next_retry}/{max_retries} for: {missing}")
+    # Reference the workflow by its file name, not its display name — the
+    # display name ("Generate docs for base images") has changed before and
+    # silently broke the retry loop.
     subprocess.run(
-        ["gh", "workflow", "run", "Base image descriptions",
+        ["gh", "workflow", "run", "gendoc-base.yaml",
          "-f", f"backend={missing}", "-f", f"retry_count={next_retry}"],
         check=True, cwd=REPO_ROOT,
     )


### PR DESCRIPTION
## What

Fixes the broken self-healing retry loop in `gendoc-base.yaml` — two bugs, one root cause each:

1. **Wrong workflow reference.** `scripts/finalize_descriptions.py` `_retry()` dispatches `gendoc-base.yaml` via `gh workflow run "Base image descriptions"` — but no workflow has that display name (the file is "Generate docs for base images"). `gh workflow run` silently fails, so the retry loop has never worked. Fix: reference the workflow by its **file name** (`gendoc-base.yaml`), which is stable against display-name changes (the docstring said `base-descriptions.yml`, a third name — also corrected).

2. **The allowlist gate (#311/#313) would block the retry.** The re-dispatch is authenticated as the repo `GITHUB_TOKEN`, so `github.triggering_actor` is `github-actions[bot]` — not in `.github/builders.txt`. Fix: exempt `github-actions[bot]` in the shared authorize action. The bot token is only usable by workflows already running in this repo, so the human-only restriction (maintainers `tengqm` + `shiptux` via the UI) is unchanged — this only lets the workflow's own automation re-dispatch itself.

## Verify

- `python3 -m py_compile scripts/finalize_descriptions.py` — OK
- Authorize logic simulated: bot passes, `tengqm`/`shiptux` pass, strangers fail, `dependabot[bot]` and prefix matches fail (thanks to `grep -Fx`)
- `gh workflow list` confirms `gendoc-base.yaml` resolves to "Generate docs for base images"

## Notes

- `pr_prefix: "auto/base-descriptions"` in the script is a git **branch** prefix, not a workflow name — left untouched.
- Exempting the bot means any workflow merged into this repo could re-dispatch a gated workflow. Same caveat as the gate itself: as strong as branch protection on `main`.

This PR was written in part with the assistance of generative AI.
