### PR TITLE
ci: checkout repo before running local authorize action

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -35,8 +35,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   set-matrix:

--- a/.github/workflows/flaggems-release.yml
+++ b/.github/workflows/flaggems-release.yml
@@ -46,8 +46,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   # ── 5a: pure-Python wheel, all vendor PyPIs ──────────────────────────────

--- a/.github/workflows/flaggems-wheel.yml
+++ b/.github/workflows/flaggems-wheel.yml
@@ -45,8 +45,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   build:

--- a/.github/workflows/gendoc-base.yaml
+++ b/.github/workflows/gendoc-base.yaml
@@ -61,8 +61,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   set-matrix:

--- a/.github/workflows/gendoc-runtime.yaml
+++ b/.github/workflows/gendoc-runtime.yaml
@@ -34,8 +34,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   finalize:

--- a/.github/workflows/hugo-site.yaml
+++ b/.github/workflows/hugo-site.yaml
@@ -43,8 +43,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   build-and-deploy:

--- a/.github/workflows/pubdoc-base.yaml
+++ b/.github/workflows/pubdoc-base.yaml
@@ -40,8 +40,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   publish:

--- a/.github/workflows/pubdoc-runtime.yaml
+++ b/.github/workflows/pubdoc-runtime.yaml
@@ -40,8 +40,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   publish:

--- a/.github/workflows/runtime-image.yaml
+++ b/.github/workflows/runtime-image.yaml
@@ -50,8 +50,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   set-matrix:

--- a/.github/workflows/sync-to-remote.yaml
+++ b/.github/workflows/sync-to-remote.yaml
@@ -61,8 +61,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   sync:

--- a/.github/workflows/verify-cpp-fixes.yml
+++ b/.github/workflows/verify-cpp-fixes.yml
@@ -24,8 +24,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   verify-nvidia-cuda128:

--- a/.github/workflows/verify-runtime.yml
+++ b/.github/workflows/verify-runtime.yml
@@ -39,8 +39,11 @@ jobs:
   authorize:
     # Only accounts listed in .github/builders.txt may trigger this workflow
     # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
   set-matrix:


### PR DESCRIPTION
## What

Fixes the `authorize` job in all 12 gated workflows: add `actions/checkout@v7` before the local composite action, so the repo exists in the workspace before the action is resolved.

## Why

The failed run [30978342521](https://github.com/flagos-ai/build-infra/actions/runs/30978342521) (Docs site, push trigger) shows:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'.../.github/actions/check-trigger-author'. Did you forget to run
actions/checkout before running your local action?
```

Local composite actions (`./.github/actions/...`) are resolved from the runner workspace **before any step executes** — the action's own internal checkout comes too late. The image builds (#311) had the checkout in the inline `authorize` job; consolidating onto the shared action (#313) dropped it.

## Change

Each workflow's `authorize` job now runs checkout first:

```yaml
  authorize:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v7
      - uses: ./.github/actions/check-trigger-author
```

12 workflows updated, +36 lines (one line + 2-line comment each). Validated: every `authorize` job parses, and `actions/checkout@v7` is the first step before the action in all 12.

## Test

`gh workflow run "Docs site"` (or any push to `docs/**`) — the `authorize` job should now pass and proceed to `build-and-deploy`. I can trigger it after merge if you'd like.

This PR was written in part with the assistance of generative AI.
