### PR TITLE
chore: bump version to 2.1.2

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -61,7 +61,7 @@
 # Runtime images also pull the corresponding FlagGems wheel version below.
 #
 # At release: bump both fields → git tag v<VERSION> → done.
-version: "2.1.1"
+version: "2.1.2"
 flaggems: "5.3.2"
 
 # Versions of build tools needed to compile the cpp operator wheel inside the


### PR DESCRIPTION
## What

Start the 2.1.2 release cycle: bump `configs.yaml` `version:` from `2.1.1` → `2.1.2`.

## Why

This seeds all base image tags (`flagos-base-*-*:2.1.2-N`) and the runtime image tags (`flagos-runtime-*-*:2.1.2`) for the release. RELEASE.md step 1.

## Notes

- `flaggems:` stays at `5.3.2` — it will be backfilled by the FlagGems Release Wheels workflow (RELEASE.md step 5c) once the new FlagGems version is tagged. The intermediate steps (base images, runtime:v1) don't consume it.
- No tag yet — per RELEASE.md, the tag comes only after the full stack is verified (step 9).

This PR was written in part with the assistance of generative AI.
