### PR TITLE
feat: base image drift detection — flat tags + status CLI + last-updated descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ All self-hosted: default is `[self-hosted, h20]` (x86_64). Ascend backends overr
 
 ## Conventions
 
-- **Version from configs.yaml.** `configs.yaml` `version:` is the single stack-wide release version. `scripts/version.py` computes per-backend versions as `X.Y.Z-n` where n = commits to `base/<name>` since tag vX.Y.Z. At release: bump `version:` and `flaggems:` in one place → `git tag vX.Y.Z`.
+- **Version from configs.yaml.** `configs.yaml` `version:` is the single stack-wide release version; all images share it as their flat tag. At release: bump `version:` and `flaggems:` in one place → `git tag vX.Y.Z`.
 - **FlagGems version from configs.yaml.** `configs.yaml` `flaggems:` sets the wheel version for runtime builds. Override with `--flaggems` CLI flag when needed.
 - **Per-vendor PyPI indexes.** Each vendor has a separate index: `flagos-pypi-{vendor}`. This isolates vendor-specific packages so there is no cross-vendor package confusion.
 - **No extras for runtime deps.** `configs.yaml deps:` lists explicit packages passed to `uv pip install` — extras (`.[nvidia-cuda128]`) can't resolve correctly across vendor indexes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,14 +58,14 @@ configs.yaml + base/ Containerfiles + build-config.yml
 
 ### Image naming
 
-- **Base:** `flagos-base-{vendor}-{backend}:{version}-{n}` — version from Containerfile `LABEL org.opencontainers.image.version` (repo tag), n = per-backend git revision count since that tag. Only Containerfile changes bump n.
+- **Base:** `flagos-base-{vendor}-{backend}:{version}` — version from configs.yaml `version:`. All backends share the same flat tag during a release cycle; rebuilt images overwrite it. (A per-backend `-N` commit-count affix was tried and dropped as confusing.)
 - **Runtime:** `flagos-runtime-{vendor}-{backend}:{version}` — version from configs.yaml `version:` (same as base)
 - Registry: `harbor.baai.ac.cn/{prefix}/` (prefix from `build-config.yml` registry.prefixes)
 - `base/<name>` Containerfile names match the `{vendor}-{backend}` key (e.g. `base/nvidia-cuda12.8`)
 
-### Base image version (per-backend, not global)
+### Base image version (flat, stack-wide)
 
-`configs.yaml` declares `version: "X.Y.Z"` — the single stack-wide release version. `scripts/version.py` counts git commits to each `base/<name>` since tag `vX.Y.Z`, producing `X.Y.Z-n` per backend. The repo tag anchors all backends at the same baseline; n diverges as Containerfiles evolve independently. The version is stamped onto the image at build time as an OCI label — Containerfiles do not hardcode it.
+`configs.yaml` declares `version: "X.Y.Z"` — the single stack-wide release version. Every base image carries the same flat `X.Y.Z` tag, stamped as an OCI label at build time (Containerfiles do not hardcode it). Because rebuilt images overwrite the same tag, whether a pushed image is stale is answered by `scripts/base_image_status.py` — it reads the `revision`/`version` OCI labels off the pushed image and diffs the corresponding `base/<name>` Containerfile since that commit.
 
 ### Runtime Containerfile (multi-stage, dual-compiler)
 

--- a/configs.yaml
+++ b/configs.yaml
@@ -22,13 +22,16 @@
 #   flaggems: FlagGems wheel version for runtime builds — override with --flaggems.
 #
 # Base image naming convention:
-#   {base_image_prefix}-{vendor}-{backend}:{version}-{n}
-#   e.g. flagos-base-nvidia-cuda12.8:2.1.1-0
-#   {n} = commits to base/{vendor}-{backend} since tag v{version}.
+#   {base_image_prefix}-{vendor}-{backend}:{version}
+#   e.g. flagos-base-nvidia-cuda12.8:2.1.2
+# All backends share the same flat tag during a release cycle; rebuilt
+# images overwrite it. Whether a pushed image is stale is answered by
+# scripts/base_image_status.py (OCI labels vs base/<name> Containerfile),
+# not by a per-tag commit-count affix.
 #
 # Runtime image naming convention:
 #   flagos-runtime-{vendor}-{backend}:{version}
-#   e.g. flagos-runtime-nvidia-cuda12.8:2.1.1
+#   e.g. flagos-runtime-nvidia-cuda12.8:2.1.2
 #
 # The PyPI index URL is auto-generated: pypi_base.format(vendor=<vendor>).
 # Override per-backend with an explicit "index:" field if needed.

--- a/docs/extract_versions.py
+++ b/docs/extract_versions.py
@@ -32,6 +32,30 @@ from pathlib import Path
 import yaml
 
 
+def image_labels(image: str) -> dict:
+    """Read the last-updated + revision OCI labels via docker inspect.
+
+    The docs pipeline renders these as a "Last updated" line in the base
+    description; the values come from build_base.py (git committer time +
+    build commit). A missing label prints ``<no value>`` — treat as absent.
+    """
+    fmt = ('{{index .Config.Labels "last-updated"}}'
+           '|{{index .Config.Labels "org.opencontainers.image.revision"}}')
+    r = subprocess.run(
+        ["docker", "inspect", image, "--format", fmt],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        return {}
+    ts, _, rev = r.stdout.partition("|")
+    out = {}
+    if ts and ts != "<no value>":
+        out["last_updated"] = ts.strip()
+    if rev and rev != "<no value>":
+        out["revision"] = rev.strip()
+    return out
+
+
 def main():
     if len(sys.argv) != 3:
         sys.exit("usage: extract_versions.py <backend-name> <out-dir>")
@@ -47,14 +71,21 @@ def main():
     out_dir.mkdir(parents=True, exist_ok=True)
     out = out_dir / f"{name}.tsv"
 
+    # Always pull the latest image; docker run --rm uses the local copy but
+    # the runner may have a stale cache from a previous build cycle.
+    subprocess.run(["docker", "pull", image], check=True, capture_output=True)
+
+    # Record the build provenance labels (written by upload_version_tsv.py
+    # into the TSV headers, then rendered by gen_descriptions.py).
+    labels = image_labels(image)
+    (out_dir / f"{name}.labels").write_text(
+        "".join(f"{k}={v}\n" for k, v in labels.items())
+    )
+
     if not pkgs:
         out.write_text("")
         print(f"{name}: no explicit system packages")
         return
-
-    # Always pull the latest image; docker run --rm uses the local copy but
-    # the runner may have a stale cache from a previous build cycle.
-    subprocess.run(["docker", "pull", image], check=True, capture_output=True)
 
     # dpkg-query prints the found packages even when some are absent (it exits
     # non-zero then) — capture stdout regardless.

--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -269,7 +269,7 @@ def main():
             sdk_blob = " ".join(sdk).lower()
             arch = "aarch64" if ("aarch64" in sdk_blob or "arm64" in sdk_blob) else "x86_64"
 
-            ver = image_version(repo_root, name) or _git_describe(repo_root)
+            ver = image_version(repo_root) or _git_describe(repo_root)
 
             # Merge dpkg-installed system-level packages (e.g. libfmt8 for
             # tsingmicro) — these are exceptions declared in configs.yaml, not

--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -53,6 +53,7 @@ Usage:
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -69,6 +70,7 @@ LANGS = ("en", "zh-cn")
 STRINGS = {
     "en": {
         "prerequisites": "Prerequisites",
+        "last_updated": "Last updated",
         "architecture": "Architecture",
         "chip_models": "Chip models",
         "host_driver": "Host driver",
@@ -98,6 +100,7 @@ STRINGS = {
     },
     "zh-cn": {
         "prerequisites": "前置条件",
+        "last_updated": "更新时间",
         "architecture": "架构",
         "chip_models": "芯片型号",
         "host_driver": "宿主机驱动",
@@ -183,6 +186,35 @@ def load_versions(versions_dir: Path | None, name: str) -> dict:
             pkg, ver = line.split("\t", 1)
             out[pkg.strip()] = clean_version(ver.strip())
     return out
+
+
+def load_meta(versions_dir: Path | None, name: str) -> dict:
+    """Build provenance from the ``# header`` lines of <name>.tsv.
+
+    upload_version_tsv.py prepends ``# run:``, ``# verify:`` and, when
+    present, ``# last_updated:`` / ``# revision:`` (from the image's OCI
+    labels, via extract_versions.py). Returns the last two, which the
+    description renders as a "Last updated" line.
+    """
+    if not versions_dir:
+        return {}
+    f = versions_dir / f"{name}.tsv"
+    if not f.is_file():
+        return {}
+    meta = {}
+    for line in f.read_text().splitlines():
+        if not line.startswith("# "):
+            break  # headers are contiguous at the top
+        key, _, val = line[2:].partition(": ")
+        if key.strip() in ("last_updated", "revision") and val.strip():
+            meta[key.strip()] = val.strip()
+    return meta
+
+
+def human_date(ts: str) -> str:
+    """RFC3339 -> display form: '2026-08-05T13:59:11+08:00' -> '2026-08-05 13:59:11'."""
+    m = re.match(r"(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})", ts)
+    return f"{m.group(1)} {m.group(2)}" if m else ts
 
 
 def wrap_cmd(cmd: str, width: int = 84) -> str:
@@ -273,7 +305,7 @@ def _verify(entry: dict, s: dict) -> list[str]:
     return lines
 
 
-def render(entry: dict, versions: dict, lang: str = "en", flavor: str = "web") -> str:
+def render(entry: dict, versions: dict, lang: str = "en", flavor: str = "web", meta: dict | None = None) -> str:
     """Compose the description markdown for one backend in `lang`.
 
     Only prose/headers are localized (from STRINGS); every technical value —
@@ -303,6 +335,16 @@ def render(entry: dict, versions: dict, lang: str = "en", flavor: str = "web") -
         # Apache 2.0 copyright header (only for web — Harbor can't parse HTML comments).
         lines += COPYRIGHT
         _ = lines.append("")
+
+    # ── Last updated (from the image's OCI labels at build time) ──
+    meta = meta or {}
+    if meta.get("last_updated") or meta.get("revision"):
+        parts = []
+        if meta.get("last_updated"):
+            parts.append(human_date(meta["last_updated"]))
+        if meta.get("revision"):
+            parts.append(f"`{meta['revision'][:12]}`")
+        lines += [f"*{s['last_updated']}: {' · '.join(parts)}*", ""]
 
     # ── Prerequisites (shared with runtime) ──
     lines += _prerequisites(entry, s, web)
@@ -453,7 +495,7 @@ def main():
                     print(f"Warning: '{name}' not in images.yaml — skipping", file=sys.stderr)
                     continue
                 versions = load_versions(versions_dir, name)
-                md = render(backends[name], versions, lang, "web")
+                md = render(backends[name], versions, lang, "web", load_meta(versions_dir, name))
                 (out_dir / f"{name}.md").write_text(md)
                 total += 1
             print(f"Wrote {len(requested)} {lang} base web pages to {out_dir}")
@@ -463,7 +505,7 @@ def main():
             if name not in backends:
                 continue
             versions = load_versions(versions_dir, name)
-            md = render(backends[name], versions, "en", "plain")
+            md = render(backends[name], versions, "en", "plain", load_meta(versions_dir, name))
             (base_dir / f"{name}.md").write_text(md)
         print(f"Wrote {len(requested)} base plain readmes to {base_dir}")
 
@@ -509,7 +551,7 @@ def main():
         out_dir = root / "docs" / "content" / lang / "base"
         out_dir.mkdir(parents=True, exist_ok=True)
         for name, entry in backends.items():
-            md = render(entry, load_versions(versions_dir, name), lang, "web")
+            md = render(entry, load_versions(versions_dir, name), lang, "web", load_meta(versions_dir, name))
             (out_dir / f"{name}.md").write_text(md)
             total += 1
         print(f"Wrote {len(backends)} {lang} base web pages to {out_dir}")
@@ -517,7 +559,7 @@ def main():
     # Base plain flavor: base/<name>.md (Harbor-bound)
     base_dir = root / "base"
     for name, entry in backends.items():
-        md = render(entry, load_versions(versions_dir, name), "en", "plain")
+        md = render(entry, load_versions(versions_dir, name), "en", "plain", load_meta(versions_dir, name))
         (base_dir / f"{name}.md").write_text(md)
     print(f"Wrote {len(backends)} base plain readmes to {base_dir}")
 

--- a/scripts/base_image_status.py
+++ b/scripts/base_image_status.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report which base images are outdated relative to what is pushed to Harbor.
+
+During a release cycle every backend shares one flat Harbor tag,
+``flagos-base-{name}:{version}`` — rebuilt images overwrite the same tag.
+An earlier ``-N`` affix design was dropped as confusing to users. Instead
+this script answers "is the pushed image behind HEAD?" *without building
+anything*, by reading the OCI labels that ``scripts/build_base.py`` stamps
+onto every image:
+
+    org.opencontainers.image.revision   git commit the image was built from
+    org.opencontainers.image.version    image version tag at build time
+
+A backend is OUTDATED when either:
+
+  - the ``base/<name>`` Containerfile changed since that commit, or
+  - the image's ``version`` label differs from the tag being inspected
+    (normally configs.yaml ``version:`` — the tag changed, so the image
+    must be rebuilt to carry the new tag).
+
+Run this before a manual, selective base rebuild to see which backends
+actually need one.
+
+Status values:
+    UP_TO_DATE  pushed :{tag} reflects HEAD's containerfile and tag
+    OUTDATED    containerfile and/or tag changed since the pushed image
+    NOT_BUILT   no :{tag} tag in Harbor yet — must build
+    UNKNOWN     could not determine (see detail column)
+
+Usage:
+    HARBOR_USER=... HARBOR_PW=... python scripts/base_image_status.py
+    python scripts/base_image_status.py --json
+    python scripts/base_image_status.py nvidia-cuda12.8 cambricon-neuware4.7.2
+    python scripts/base_image_status.py --tag 2.1.2
+
+Requires a checkout with the full history (fetch-depth: 0) so the
+revision stamped on a pushed image is resolvable locally.
+
+Exit code is always 0 — this is an informational overview.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_context() -> tuple[str, str, str, list[str]]:
+    """Return (host, base-project, version, backend names)."""
+    configs = yaml.safe_load((REPO_ROOT / "configs.yaml").read_text()) or {}
+    build = yaml.safe_load((REPO_ROOT / ".github" / "build-config.yml").read_text()) or {}
+    registry = build.get("registry") or {}
+    host = registry.get("host", "")
+    project = (registry.get("prefixes") or {}).get("base", "flagos-base")
+    version = str(configs.get("version", "") or "")
+
+    vendors = configs.get("vendors") or {}
+    names = sorted(f"{v}-{b}" for v, backends in vendors.items() for b in backends)
+    return host, project, version, names
+
+
+def auth_header() -> str:
+    user = os.environ.get("HARBOR_USER", "")
+    pw = os.environ.get("HARBOR_PW", "")
+    if not user or not pw:
+        sys.exit("HARBOR_USER and HARBOR_PW are required (same as docs/upload_descriptions.py)")
+    return "Basic " + base64.b64encode(f"{user}:{pw}".encode()).decode()
+
+
+def image_labels(host: str, repo: str, tag: str, auth: str) -> dict | None:
+    """Return the OCI labels of the pushed image, or None if the tag is absent."""
+    manifest_url = f"https://{host}/v2/{repo}/manifests/{tag}"
+    headers = {
+        "Authorization": auth,
+        "Accept": (
+            "application/vnd.oci.image.manifest.v1+json, "
+            "application/vnd.docker.distribution.manifest.v2+json, "
+            "application/vnd.oci.image.index.v1+json, "
+            "application/vnd.docker.distribution.manifest.list.v2+json"
+        ),
+    }
+    try:
+        with urllib.request.urlopen(urllib.request.Request(manifest_url, headers=headers), timeout=30) as r:
+            manifest = json.load(r)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+    # Plain docker build produces a single-arch manifest with a config digest.
+    # A multi-arch index has no "config"; follow the first entry.
+    if "config" not in manifest and "manifests" in manifest:
+        first = manifest["manifests"][0]["digest"]
+        with urllib.request.urlopen(
+            urllib.request.Request(f"https://{host}/v2/{repo}/manifests/{first}", headers=headers),
+            timeout=30,
+        ) as r:
+            manifest = json.load(r)
+
+    config_digest = manifest.get("config", {}).get("digest")
+    if not config_digest:
+        return {}
+    with urllib.request.urlopen(
+        urllib.request.Request(f"https://{host}/v2/{repo}/blobs/{config_digest}", headers={"Authorization": auth}),
+        timeout=30,
+    ) as r:
+        config = json.load(r)
+    return (config.get("config") or {}).get("labels") or {}
+
+
+def containerfile_changed(revision: str, name: str) -> bool | None:
+    """True if base/<name> changed since `revision`; None if the commit is unknown."""
+    r = subprocess.run(
+        ["git", "diff", "--quiet", f"{revision}..HEAD", "--", f"base/{name}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    if r.returncode == 128:  # revision not present in this clone
+        return None
+    return r.returncode == 1  # 0 = no diff, 1 = diff
+
+
+def containerfile_commits(revision: str, name: str) -> int | None:
+    """Number of commits touching base/<name> since `revision`; None if unknown."""
+    r = subprocess.run(
+        ["git", "rev-list", "--count", f"{revision}..HEAD", "--", f"base/{name}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode != 0:
+        return None
+    return int(r.stdout.strip())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("backends", nargs="*", help="limit to these backends (default: all)")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    ap.add_argument("--tag", help="Harbor tag to inspect (default: configs.yaml version)")
+    args = ap.parse_args()
+
+    host, project, version, names = load_context()
+    if not host:
+        sys.exit("registry.host missing from .github/build-config.yml")
+    if not version:
+        sys.exit("configs.yaml has no version: field")
+    tag = args.tag or version
+    auth = auth_header()
+
+    if args.backends:
+        wanted = set(args.backends)
+        missing = wanted - set(names)
+        if missing:
+            sys.exit(f"unknown backend(s): {', '.join(sorted(missing))}")
+        names = [n for n in names if n in wanted]
+
+    results = []
+    for name in names:
+        repo = f"{project}/flagos-base-{name}"
+        entry = {"name": name, "tag": tag, "built": "", "status": "", "detail": ""}
+        try:
+            labels = image_labels(host, repo, tag, auth)
+        except urllib.error.URLError as e:
+            entry.update(status="UNKNOWN", detail=f"registry unreachable: {e.reason}")
+            results.append(entry)
+            continue
+        except Exception as e:  # noqa: BLE001
+            entry.update(status="UNKNOWN", detail=str(e))
+            results.append(entry)
+            continue
+
+        if labels is None:
+            entry.update(status="NOT_BUILT")
+            results.append(entry)
+            continue
+
+        revision = labels.get("org.opencontainers.image.revision", "")
+        built_version = labels.get("org.opencontainers.image.version", "")
+        entry["built"] = revision[:12]
+        if not revision:
+            entry.update(status="UNKNOWN", detail="image has no revision label")
+            results.append(entry)
+            continue
+
+        changed = containerfile_changed(revision, name)
+        if changed is None:
+            entry.update(
+                status="UNKNOWN",
+                detail=f"commit {revision[:12]} not in local clone (need fetch-depth: 0)",
+            )
+            results.append(entry)
+            continue
+
+        reasons = []
+        if built_version and built_version != tag:
+            reasons.append(f"tag: built as {built_version}, expected {tag}")
+        if changed:
+            n = containerfile_commits(revision, name)
+            count = f" ({n} commit(s))" if n is not None else ""
+            reasons.append(f"containerfile: changed since {revision[:12]}{count}")
+        if not reasons and not built_version:
+            # Image is current tag-wise but carries no version label to verify.
+            reasons.append("no version label on image")
+
+        entry["status"] = "OUTDATED" if reasons else "UP_TO_DATE"
+        entry["detail"] = "; ".join(reasons)
+        results.append(entry)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return
+
+    header = f"{'backend':<28} {'tag':<8} {'built':<13} status"
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        detail = f"  ({r['detail']})" if r.get("detail") else ""
+        print(f"{r['name']:<28} {r['tag']:<8} {r['built']:<13} {r['status']}{detail}")
+    counts = Counter(r["status"] for r in results)
+    summary = ", ".join(f"{n} {s}" for s, n in counts.most_common())
+    print(f"\n{len(results)} backends: {summary}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_base.py
+++ b/scripts/build_base.py
@@ -18,12 +18,12 @@ from __future__ import annotations
 
 """Build FlagOS base container images.
 
-The image version comes from the Containerfile's ``LABEL org.opencontainers.image.version``
-plus a per-backend git revision count since that version's tag — so only
-Containerfile changes bump the version, not unrelated repo edits.
+The image version comes from ``configs.yaml version:`` (see
+``scripts/version.py``) — every backend shares the same flat tag during a
+release cycle and rebuilt images overwrite it.
 
 Image tag convention:
-    flagos-base-{name}:{version}-{n}   (n = commits to base/{name} since v{version})
+    flagos-base-{name}:{version}
 
 Usage:
     python scripts/build_base.py <name> [options]

--- a/scripts/build_base.py
+++ b/scripts/build_base.py
@@ -138,7 +138,7 @@ def main():
             f"Available: {', '.join(available)}"
         )
 
-    version = image_version(repo_root, args.name) or git_version(repo_root)
+    version = image_version(repo_root) or git_version(repo_root)
     commit = git(repo_root, "rev-parse", "HEAD") or ""
     created = git(repo_root, "show", "-s", "--format=%cI", "HEAD") or ""
 
@@ -153,10 +153,14 @@ def main():
         tag = f"{image_name}:{version}"
 
     # OCI provenance stamped onto the built image (git is the source of truth).
+    # last-updated is the committer time of the build commit (RFC3339) — the
+    # moment this image's content was decided; used by the docs pipeline to
+    # render a human "last updated" line into base descriptions.
     labels = {
         "org.opencontainers.image.version": version,
         "org.opencontainers.image.revision": commit,
         "org.opencontainers.image.created": created,
+        "last-updated": created,
         "org.opencontainers.image.source": "https://github.com/flagos-ai/build-infra",
     }
 

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -139,14 +139,13 @@ def resolve_base_image(
 
     {registry}/{prefix}-{vendor}-{backend}:{version}
 
-    The version comes from the base image's Containerfile LABEL +
-    per-backend git revision count (see version.image_version).
-    Falls back to git describe when the Containerfile has no version LABEL.
+    The version comes from configs.yaml ``version:`` (see version.image_version).
+    Falls back to git describe when configs.yaml has no version.
     Falls back to :latest when no git tag is reachable (shallow checkout).
     """
     prefix = configs.get("base_image_prefix", "flagos-base")
     name = f"{vendor}-{backend}"
-    version = image_version(repo_root, name)
+    version = image_version(repo_root)
     if version is None:
         version = git_describe(repo_root)
     if not version:

--- a/scripts/upload_version_tsv.py
+++ b/scripts/upload_version_tsv.py
@@ -21,9 +21,13 @@ Preconditions: the caller records the verify step outcome to
 ``<tsv-dir>/<backend>.verify_outcome`` (contents: ``success``, ``failure``,
 or ``skipped``).  ``GITHUB_RUN_ID`` must be set in the environment.
 
-The script prepends two metadata headers (``# run:``, ``# verify:``) to the
-TSV so the accumulate job can tell whether the data is fresh and whether the
-verify step passed.
+The script prepends metadata headers (``# run:``, ``# verify:``) to the
+TSV so the accumulate job can tell whether the data is fresh and whether
+the verify step passed. If ``<tsv-dir>/<backend>.labels`` exists (written
+by ``docs/extract_versions.py``), its ``last_updated``/``revision`` lines
+are added as ``# last_updated:`` / ``# revision:`` headers too — they
+travel inside the TSV so the descriptions generator can render a "Last
+updated" line.
 
 Before pushing, deletes the remote branch so a failed extract leaves no stale
 branch behind.
@@ -67,9 +71,17 @@ def main() -> None:
     run_id = os.environ.get("GITHUB_RUN_ID", "unknown")
     verify = verify_file.read_text().strip() if verify_file.is_file() else "unknown"
 
+    headers = [f"# run: {run_id}", f"# verify: {verify}"]
+    labels_file = tsv_dir / f"{backend}.labels"
+    if labels_file.is_file():
+        for line in labels_file.read_text().splitlines():
+            key, _, val = line.partition("=")
+            if val:
+                headers.append(f"# {key}: {val}")
+
     # Prepend metadata headers to the TSV content.
     tsv_raw = tsv_file.read_text()
-    payload = f"# run: {run_id}\n# verify: {verify}\n{tsv_raw}"
+    payload = "\n".join(headers) + "\n" + tsv_raw
 
     # Delete any stale branch so a failed extract leaves no trace.
     subprocess.run(

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -12,29 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Per-backend image version from configs.yaml + git.
+"""Image version tag from configs.yaml.
 
 configs.yaml declares the stack version::
 
-    version: "2.1.1"
+    version: "2.1.2"
 
-image_version() counts git commits to ``base/<name>`` since tag
-``v2.1.1``, producing::
+image_version() returns that value verbatim::
 
-    2.1.1        (n=0, no changes since the tag)
-    2.1.1-3      (3 commits to this Containerfile since v2.1.1)
+    2.1.2
+
+During a release cycle every backend shares the same flat tag
+(``flagos-base-{name}:{version}``) and rebuilt images overwrite it. An
+earlier design appended a per-backend ``-N`` affix (commits to
+``base/<name>`` since the release tag) so a stale image was visible from
+its tag alone; that proved confusing to users and was dropped. Whether a
+pushed image reflects HEAD is answered instead by
+``scripts/base_image_status.py``, which reads the OCI labels stamped on
+the image (see build_base.py) and diffs the corresponding containerfile.
 """
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
+
+import yaml
 
 
 def _load_version(repo_root: Path) -> str | None:
     """Read ``version:`` from configs.yaml."""
-    import yaml
-
     cfg = repo_root / "configs.yaml"
     if not cfg.is_file():
         return None
@@ -43,32 +49,9 @@ def _load_version(repo_root: Path) -> str | None:
     return data.get("version") or None
 
 
-def image_version(repo_root: Path, name: str) -> str | None:
-    """Compute the per-backend image version tag.
+def image_version(repo_root: Path) -> str | None:
+    """Return the stack version tag for images, e.g. ``"2.1.2"``.
 
-    ``name`` is the containerfile name (e.g. ``"nvidia-cuda12.8"``).
-
-    Returns ``"X.Y.Z-n"`` when there are *n* commits to ``base/<name>``
-    since tag ``vX.Y.Z``, or just ``"X.Y.Z"`` when n=0.  Returns None
-    when configs.yaml has no version field.
+    Returns None when configs.yaml has no version field.
     """
-    label_ver = _load_version(repo_root)
-    if not label_ver:
-        return None
-
-    tag = f"v{label_ver}"
-    try:
-        r = subprocess.run(
-            ["git", "rev-list", "--count", f"{tag}..HEAD", "--", f"base/{name}"],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-        )
-    except FileNotFoundError:
-        return label_ver
-
-    if r.returncode != 0:
-        return label_ver
-
-    n = int(r.stdout.strip())
-    return f"{label_ver}-{n}" if n else label_ver
+    return _load_version(repo_root)


### PR DESCRIPTION
## What

Base-image drift detection, per the agreed design: flat tags, drift answered by a side-channel tool instead of a `-N` affix, and "last updated" surfaced in the auto-generated descriptions.

## Part 1 — flat tags (drop the `-N` affix)

`scripts/version.py` no longer counts commits per backend; `image_version()` returns the flat configs.yaml version. All backends share `flagos-base-{name}:{version}` during a release cycle; rebuilt images overwrite the same tag.

- Simplifies tags and fixes a latent inconsistency: `build_runtime.resolve_base_image()` computed the base ref via `version.py` (which yielded `-N` once a tag existed) while the CI runtime matrix used the flat version.
- Doc references updated (CLAUDE.md, configs.yaml header, `build_base.py` module docstring, `docs/gen_data.py` caller).

## Part 2 — `scripts/base_image_status.py` (drift CLI)

Run it **before** a manual selective base rebuild to see which pushed images are stale — no build required. Reads the `revision`/`version` OCI labels off `flagos-base-{name}:{version}` via the Docker Registry v2 API (basic auth, same pattern as `docs/upload_descriptions.py`), then:

- **Containerfile drift:** did `base/<name>` change since the stamped commit?
- **Tag drift:** does the image's `version` label match the current configs.yaml `version:`? (A tag change means the image must be rebuilt to carry the new tag.)

```
backend                        tag    built        status
nvidia-cuda12.8                2.1.2  a1b2c3d4e5f6  UP_TO_DATE
cambricon-neuware4.4.3         2.1.2  f7e6d5c4b3a2  OUTDATED  (containerfile: changed since f7e6d5c (1 commit))
ascend-cann8.5.0               2.1.2  3b2a1c0d9e8f  OUTDATED  (tag: built as 2.1.1, expected 2.1.2)
iluvatar-corex4.4.0            2.1.2  -            NOT_BUILT
```

Statuses: `UP_TO_DATE` / `OUTDATED` / `NOT_BUILT` / `UNKNOWN`. `--json`, backend subset, `--tag` override. Exit 0 always (informational). Requires a full clone (`fetch-depth: 0`) and `HARBOR_USER`/`HARBOR_PW`.

## Part 3 — "Last updated" in base descriptions

- `build_base.py` stamps a `last-updated` OCI label (committer time of the build commit, RFC3339).
- `docs/extract_versions.py` reads the `last-updated` + `revision` labels off the built image (docker inspect) into a sidecar.
- `scripts/upload_version_tsv.py` embeds them as `# last_updated:` / `# revision:` TSV headers — they ride the existing version-transport branch mechanism, no new plumbing.
- `docs/gen_descriptions.py` renders `*Last updated: 2026-08-05 13:59:11 · `abcd1234`*` at the top of each base description (en/zh, web/plain).

The gendoc PR diff then shows when each base image was last rebuilt — human-readable date + machine-readable hash.

## Verification

- `py_compile` on all touched scripts; unit tests for `human_date`, `load_meta`, header composition, and the status-decision matrix.
- Drift logic tested against real refs: cambricon 4.4.3/4.7.2 → OUTDATED (env fix #312), nvidia-cuda12.8 → UP_TO_DATE (configs-only changes don't count), metax-maca3.8.1.3 (new) → OUTDATED.
- **Not yet live-tested against Harbor** (needs creds) nor through a real gendoc cycle (needs a rebuilt image carrying the new label) — both are post-merge verification steps.

## Notes

- Runtime drift + runtime label stamping are the agreed follow-up (base-only scope per discussion).
- The status CLI + preflight-in-base-image.yaml integration is the planned follow-up surface (CLI first).

This PR was written in part with the assistance of generative AI.
