### PR TITLE
docs: move 'last updated' to footer of base descriptions; verify message fixes

### DIFF
--- a/docs/gen_descriptions.py
+++ b/docs/gen_descriptions.py
@@ -336,16 +336,6 @@ def render(entry: dict, versions: dict, lang: str = "en", flavor: str = "web", m
         lines += COPYRIGHT
         _ = lines.append("")
 
-    # ── Last updated (from the image's OCI labels at build time) ──
-    meta = meta or {}
-    if meta.get("last_updated") or meta.get("revision"):
-        parts = []
-        if meta.get("last_updated"):
-            parts.append(human_date(meta["last_updated"]))
-        if meta.get("revision"):
-            parts.append(f"`{meta['revision'][:12]}`")
-        lines += [f"*{s['last_updated']}: {' · '.join(parts)}*", ""]
-
     # ── Prerequisites (shared with runtime) ──
     lines += _prerequisites(entry, s, web)
 
@@ -382,6 +372,16 @@ def render(entry: dict, versions: dict, lang: str = "en", flavor: str = "web", m
 
     # ── Verify (shared with runtime) ──
     lines += _verify(entry, s)
+
+    # ── Last updated (from the image's OCI labels at build time) — footer ──
+    meta = meta or {}
+    if meta.get("last_updated") or meta.get("revision"):
+        parts = []
+        if meta.get("last_updated"):
+            parts.append(human_date(meta["last_updated"]))
+        if meta.get("revision"):
+            parts.append(f"`{meta['revision'][:12]}`")
+        lines.append(f"*{s['last_updated']}: {' · '.join(parts)}*")
 
     return "\n".join(lines).rstrip() + "\n"
 

--- a/scripts/verify_base.py
+++ b/scripts/verify_base.py
@@ -56,6 +56,7 @@ def main() -> None:
         (REPO_ROOT / ".github" / "build-config.yml").read_text()
     )
     vendor = name.split("-")[0]
+    backend = name.split("-")[1]
     verify_cmd = (
         (build_cfg.get("verify") or {}).get("vendors") or {}
     ).get(vendor, "")
@@ -81,22 +82,23 @@ def main() -> None:
 
     if r.returncode == 0:
         # Print a GHA workflow command so the log stands out.
-        print(f"::notice title=Verify::{vendor}: verify OK — {verify_cmd}")
+        print(f"::notice title=Verify::{backend}: verify OK — {verify_cmd}")
         return
 
     # Non-zero exit. Collapse into "skip" or "fail" based on signal.
     rc = r.returncode
     if rc == 137:
         # SIGKILL (OOM) — real error, not missing hardware.
-        sys.exit(f"{vendor}: verify command was OOM-killed (exit {rc})")
+        sys.exit(f"{backend}: verify command was OOM-killed (exit {rc})")
     if rc == 139:
         # SIGSEGV — real error.
-        sys.exit(f"{vendor}: verify command segfaulted (exit {rc})")
+        sys.exit(f"{backend}: verify command segfaulted (exit {rc})")
 
     # Any other non-zero: likely missing device / driver — skip.
     print(
-        f"::warning title=Verify::{vendor}: verify exited {rc} "
-        f"— runner likely lacks {vendor} hardware → SKIP"
+        f"::warning title=Verify::{backend}: verify exited {rc} "
+        f"— runner likely lacks {vendor} hardware? "
+        f"({flags_str})"
     )
 
 


### PR DESCRIPTION
## What

Two changes on `main` (fbafbf2):

1. **Move "Last updated" to the footer** of base image descriptions (`docs/gen_descriptions.py`). The build-provenance line was placed above Prerequisites; it belongs at the end of the description — the top is a stable surface (front matter, title), while the footer records when the image content was last rebuilt.

2. **`scripts/verify_base.py` message fixes** — the GHA notices/errors now key on the **backend** name (`cuda12.8`) instead of the vendor (`nvidia`), which is ambiguous when a vendor has multiple backends; and the skip warning now appends the `docker run` flags used, so the failing invocation is reproducible.

## Notes

- The "Last updated" line renders as the final line in both flavors (web/plain, en/zh):
  ```
  *Last updated: 2026-08-05 13:59:11 · `abcd1234`*
  ```
- The descriptions change regenerates via the normal gendoc path; no new transport.

This PR was written in part with the assistance of generative AI.
