### PR TITLE
ci: label description refresh with configs.yaml version, not git tag

### DIFF
--- a/.github/workflows/gendoc-base.yaml
+++ b/.github/workflows/gendoc-base.yaml
@@ -151,7 +151,7 @@ jobs:
       - name: Delete stale version branch
         if: always()
         run: |
-          label="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 'unknown')"
+          label="$(python3 -c 'import yaml;print(yaml.safe_load(open("configs.yaml"))["version"])' 2>/dev/null || echo 'unknown')"
           git push origin --delete "auto/versions-${label}/${{ matrix.name }}" 2>/dev/null || true
           echo "Cleared auto/versions-${label}/${{ matrix.name }}"
 
@@ -245,7 +245,7 @@ jobs:
           GIT_COMMITTER_EMAIL: noreply@flagos.net
           SCOPE: ${{ github.event.inputs.backend || 'all' }}
         run: |
-          label="$(git describe --tags --abbrev=0 | sed 's/^v//')"
+          label="$(python3 -c 'import yaml;print(yaml.safe_load(open("configs.yaml"))["version"])' 2>/dev/null || echo 'unknown')"
           state_branch="auto/versions-${label}-state"
           if git ls-remote --heads origin "refs/heads/${state_branch}" | grep -q refs; then
             echo "Restoring state from ${state_branch}"
@@ -313,7 +313,7 @@ jobs:
           GIT_COMMITTER_NAME: flagos-ci
           GIT_COMMITTER_EMAIL: noreply@flagos.net
         run: |
-          label="$(git describe --tags --abbrev=0 | sed 's/^v//')"
+          label="$(python3 -c 'import yaml;print(yaml.safe_load(open("configs.yaml"))["version"])' 2>/dev/null || echo 'unknown')"
           state_branch="auto/versions-${label}-state"
 
           if [ ! -d versions ] || [ -z "$(ls -A versions 2>/dev/null)" ]; then

--- a/scripts/collect_version_tsvs.py
+++ b/scripts/collect_version_tsvs.py
@@ -56,12 +56,18 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _label() -> str:
-    r = subprocess.run(
-        ["git", "describe", "--tags", "--abbrev=0"],
-        capture_output=True, text=True, cwd=REPO_ROOT,
-    )
-    if r.returncode == 0 and r.stdout.strip():
-        return r.stdout.strip().lstrip("v")
+    """Version label from configs.yaml ``version:``, e.g. ``2.1.2``.
+
+    Mirrors scripts/version.py so the descriptions PR title/branch and the
+    auto/versions-<label> transport branches track the release's target
+    version rather than the last git tag (which is only cut at release end).
+    """
+    import yaml
+    cfg = REPO_ROOT / "configs.yaml"
+    if cfg.is_file():
+        data = yaml.safe_load(cfg.read_text()) or {}
+        if data.get("version"):
+            return str(data["version"])
     return "unknown"
 
 

--- a/scripts/upload_version_tsv.py
+++ b/scripts/upload_version_tsv.py
@@ -44,13 +44,18 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _label() -> str:
-    """Version label from the latest git tag, e.g. ``2.1.1``."""
-    r = subprocess.run(
-        ["git", "describe", "--tags", "--abbrev=0"],
-        capture_output=True, text=True, cwd=REPO_ROOT,
-    )
-    if r.returncode == 0 and r.stdout.strip():
-        return r.stdout.strip().lstrip("v")
+    """Version label from configs.yaml ``version:``, e.g. ``2.1.2``.
+
+    Mirrors scripts/version.py so the auto/versions-<label>/<backend>
+    transport branches track the release's target version rather than the
+    last git tag (which is only cut at release end).
+    """
+    import yaml
+    cfg = REPO_ROOT / "configs.yaml"
+    if cfg.is_file():
+        data = yaml.safe_load(cfg.read_text()) or {}
+        if data.get("version"):
+            return str(data["version"])
     return "unknown"
 
 


### PR DESCRIPTION
## What

Label the description-refresh pipeline with `configs.yaml version:` instead of the last git tag.

## Why

PR #324 titled itself "refresh image descriptions for **2.1.1**" while we're building 2.1.2. Root cause: `collect_version_tsvs.py` / `upload_version_tsv.py` / `gendoc-base.yaml` derive the cycle label from `git describe --tags`, which stays on the last cut tag (`v2.1.1`) until release end (step 9). That label drives the PR title, PR branch, state branch, and the `auto/versions-<label>/*` transport branches — so every gendoc run mid-cycle claims the previous version.

## Change

- `scripts/collect_version_tsvs.py` + `scripts/upload_version_tsv.py`: `_label()` now reads `configs.yaml version:` (mirroring `scripts/version.py`), falling back to `"unknown"`.
- `.github/workflows/gendoc-base.yaml`: the three shell `label=` lines (extract cleanup, state restore, state save) read configs.yaml directly instead of `git describe`.

Verified: both `_label()` return `2.1.2` today (configs says 2.1.2); workflow YAML parses.

## Notes

- With labels now keyed to the target version, the next gendoc-base run (with 2.1.2 images built) will title itself "refresh image descriptions for 2.1.2".
- The gendoc cleanse step deletes stale `auto/versions*` branches on a fresh run (retry_count=0), so leftover `auto/versions-2.1.1/*` branches from the old cycle get cleaned when the next full run starts.
- Unchanged: the actual release **tag** is still cut only at step 9 (RELEASE.md) — this only fixes the label, not the tag timing.

This PR was written in part with the assistance of generative AI.
