### PR TITLE
Bump compiler versions for Sunrise

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -503,8 +503,8 @@ vendors:
       hardware: ["Sunrise SR-SUN-S2-X1"]
       driver: "0.24.0"
       python: "3.10"
-      triton: triton==3.4.0.6+gite4f6d6e4
-      # flagtree==0.4.0+sunrise3.4 — requires GLIBC_2.39, unavailable on current system
+      triton: triton==3.6.0.1+git0a5cfb35
+      flagtree: flagtree==0.6.0+sunrise3.6
       env:
         base:
           TANGRT_ROOT: /usr/local/tangrt


### PR DESCRIPTION
The PR bumps the compiler version for Sunrise backend.

- The new triton version `3.6.0.1+git0a5cfb35` will be used for the coming 2.2.0 FlagOS release; and
- The FlagTree version is updated to `0.6.0+sunrise3.6` and enabled because we are using Ubuntu 24.04 as the base operating system.