### PR TITLE
runtime: isolate FlagTree and Triton into side dirs

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -65,7 +65,7 @@
 #
 # At release: bump both fields → git tag v<VERSION> → done.
 version: "2.1.2"
-flaggems: "5.3.2"
+flaggems: "5.3.3"
 
 # Versions of build tools needed to compile the cpp operator wheel inside the
 # runtime:v1 container.  Pinned so a future pip install won't silently pull an

--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -37,10 +37,10 @@ ARG RUNTIME_PREREQS=""
 # CPP_EXTRA: cpp-cuda / cpp-musa / cpp-npu / cpp-gcu / cpp-ix, or empty
 ARG DEPS=""
 ARG CPP_EXTRA=""
-# Compiler packages — each may be empty (no-op). When both are set, FlagTree
-# is the default (installed to /flagos) and Triton is installed to /opt/triton
-# (side dir, switched via PYTHONPATH). When only Triton is set, it goes to
-# /flagos (backward compat).
+# Compiler packages — each may be empty (no-op). FlagTree is installed to
+# /opt/flagtree and Triton to /opt/triton; when both are set, FlagTree is
+# the default compiler. Neither lands in site-packages — compiler() toggles
+# them via PYTHONPATH.
 ARG FLAGTREE_PKG=""
 ARG TRITON_PKG=""
 ARG TRITON_EXTRA_PKGS=""
@@ -136,13 +136,19 @@ RUN if [ -n "${RUNTIME_PREREQS}" ]; then \
     fi
 
 # ── Install FlagTree (default compiler, if configured) ──────────
-# FlagTree installs to site-packages/triton/ — it's the default import.
+# FlagTree installs to /opt/flagtree — a side dir, symmetric with /opt/triton.
+# Keeping both compilers out of site-packages isolates their dist-infos, so
+# compiler() can switch between them cleanly via PYTHONPATH. If FlagTree is
+# present it remains the default; 'compiler triton' toggles to the vendor
+# triton in /opt/triton.
+RUN mkdir -p /opt/flagtree
 RUN if [ -n "${FLAGTREE_PKG}" ]; then \
       _installed=1; \
       for i in 1 2 3; do \
         if PIP_INDEX_URL="${FLAGOS_PYPI}" \
            PIP_EXTRA_INDEX_URL="${EXTRA_PYPI}" \
-           pip install --no-cache-dir ${FLAGTREE_PKG}; then \
+           pip install --no-cache-dir --target /opt/flagtree \
+          ${FLAGTREE_PKG}; then \
           _installed=0; break; \
         fi; \
         echo "FlagTree install attempt $i failed, retrying..."; \
@@ -151,19 +157,17 @@ RUN if [ -n "${FLAGTREE_PKG}" ]; then \
     fi
 
 # ── Install Triton (if configured) ──────────────────────────────
-# When both compilers are present: install Triton to /opt/triton (side dir).
-# The compiler() shell function toggles it by prepending /opt/triton to
-# PYTHONPATH. When FlagTree is absent: install Triton to /flagos normally.
-# Always create /opt/triton so the runtime COPY doesn't fail on missing source.
+# Triton installs to /opt/triton (side dir, symmetric with /opt/flagtree).
+# The compiler() shell function toggles by prepending /opt/triton to
+# PYTHONPATH. Always create /opt/triton so the runtime COPY doesn't fail
+# on missing source.
 RUN mkdir -p /opt/triton
 RUN if [ -n "${TRITON_PKG}" ]; then \
-      if [ -n "${FLAGTREE_PKG}" ]; then target_flag="--target /opt/triton"; \
-      else target_flag=""; fi; \
       _installed=1; \
       for i in 1 2 3; do \
         if PIP_INDEX_URL="${FLAGOS_PYPI}" \
            PIP_EXTRA_INDEX_URL="${EXTRA_PYPI}" \
-           pip install --no-cache-dir ${target_flag} \
+           pip install --no-cache-dir --target /opt/triton \
           ${TRITON_PKG}; then \
           _installed=0; break; \
         fi; \
@@ -175,7 +179,7 @@ RUN if [ -n "${TRITON_PKG}" ]; then \
         for i in 1 2 3; do \
           if PIP_INDEX_URL="${FLAGOS_PYPI}" \
              PIP_EXTRA_INDEX_URL="${EXTRA_PYPI}" \
-             pip install --no-cache-dir ${target_flag} \
+             pip install --no-cache-dir --target /opt/triton \
             ${TRITON_EXTRA_PKGS}; then \
             _installed=0; break; \
           fi; \
@@ -243,7 +247,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /root/.local/share/uv /root/.local/share/uv
 COPY --from=builder /flagos /flagos
-# Triton side dir — only exists for dual-compiler backends.
+# Compiler side dirs — FlagTree at /opt/flagtree, Triton at /opt/triton.
+# Both only exist when the corresponding compiler is configured; COPY is
+# a no-op for missing sources.
+COPY --from=builder /opt/flagtree /opt/flagtree
 COPY --from=builder /opt/triton /opt/triton
 
 # ── Copy tests and benchmarks ─────────────────────────────────
@@ -265,79 +272,11 @@ RUN if [ -n "${RUNTIME_ENV}" ]; then \
 # here as a default because runtime:v1 (NO_FLAGGEMS) has no cpp wheel and
 # setting it prematurely causes FlagGems to crash on import.
 #
-# The default compiler is FlagTree (installed to /flagos); use
-# 'compiler triton' or 'compiler flagtree' to switch.
-
-# ── Compiler switching function ────────────────────────────────
-# Written to /etc/profile.d/compiler.sh; available in login shells (via
-# /etc/profile), non-login interactive (via bash.bashrc → profile.d/*.sh),
-# and non-interactive (via BASH_ENV → profile.d/*.sh).
-#
-#   compiler            — show active compiler and what's available
-#   compiler flagtree   — switch to FlagTree (default)
-#   compiler triton     — switch to Triton (prepends /opt/triton to PYTHONPATH)
-RUN printf '\n\
-compiler() {\n\
-  _strip_opt_triton() {\n\
-    local cleaned=""\n\
-    IFS=":"\n\
-    for p in $PYTHONPATH; do\n\
-      [ "$p" != "/opt/triton" ] && [ -n "$cleaned" ] && cleaned="${cleaned}:${p}"\n\
-      [ "$p" != "/opt/triton" ] && [ -z "$cleaned" ] && cleaned="$p"\n\
-    done\n\
-    printf "%%s" "$cleaned"\n\
-  }\n\
-\n\
-  case "${1:-}" in\n\
-    flagtree)\n\
-      cleaned=$(_strip_opt_triton)\n\
-      if [ -n "$cleaned" ]; then\n\
-        export PYTHONPATH="$cleaned"\n\
-      else\n\
-        unset PYTHONPATH\n\
-      fi\n\
-      python3 -c "import triton; print(\"flagtree (active) -\", triton.__version__)"\n\
-      ;;\n\
-    triton)\n\
-      if [ ! -d /opt/triton/triton ]; then\n\
-        echo "triton: not available on this backend" >&2\n\
-        return 1\n\
-      fi\n\
-      cleaned=$(_strip_opt_triton)\n\
-      if [ -n "$cleaned" ]; then\n\
-        export PYTHONPATH="/opt/triton:${cleaned}"\n\
-      else\n\
-        export PYTHONPATH="/opt/triton"\n\
-      fi\n\
-      python3 -c "import triton; print(\"triton (active) -\", triton.__version__)"\n\
-      ;;\n\
-    ""|status|help)\n\
-      echo "available compilers:"\n\
-      if python3 -c "import importlib.metadata; importlib.metadata.version(\"flagtree\")" 2>/dev/null; then\n\
-        ft_ver=$(python3 -c "import importlib.metadata; print(importlib.metadata.version(\"flagtree\"))")\n\
-        echo "  flagtree  ${ft_ver}  (default)"\n\
-      fi\n\
-      if [ -d /opt/triton/triton ]; then\n\
-        tr_ver=$(PYTHONPATH="/opt/triton${PYTHONPATH:+:}${PYTHONPATH:-}" python3 -c "import triton; print(triton.__version__)")\n\
-        echo "  triton    ${tr_ver}"\n\
-      elif python3 -c "import triton" 2>/dev/null; then\n\
-        tr_ver=$(python3 -c "import triton; print(triton.__version__)")\n\
-        echo "  triton    ${tr_ver}  (default)"\n\
-      fi\n\
-      echo\n\
-      echo "active compiler:"\n\
-      python3 -c "import os, triton; print(\" \", \"flagtree\" if \"/opt/triton\" not in os.path.dirname(triton.__file__) else \"triton\", \"-\", triton.__version__)"\n\
-      ;;\n\
-    *)\n\
-      echo "Usage: compiler [flagtree|triton]" >&2\n\
-      echo "  compiler           show status" >&2\n\
-      echo "  compiler flagtree  switch to FlagTree (default)" >&2\n\
-      echo "  compiler triton    switch to Triton" >&2\n\
-      return 1\n\
-      ;;\n\
-  esac\n\
-}\n\
-' > /etc/profile.d/compiler.sh
+# Compiler switching: see runtime/compiler.sh — baked to /etc/profile.d so
+# the default compiler (FlagTree at /opt/flagtree, else Triton at
+# /opt/triton) is active in every shell, and 'compiler flagtree|triton'
+# toggles between the side dirs.
+COPY runtime/compiler.sh /etc/profile.d/compiler.sh
 
 # ── Bash plumbing — make profile.d/*.sh available everywhere ─────
 #   /etc/profile         → profile.d/*.sh   (login shells, native)

--- a/runtime/compiler.sh
+++ b/runtime/compiler.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ============================================================================
+# compiler.sh — runtime compiler switcher, baked into every runtime image.
+#
+# FlagTree (default, when present) lives in /opt/flagtree and the vendor
+# Triton lives in /opt/triton.  Neither is in site-packages, so their
+# dist-infos (and the entry points inside them) are only visible to
+# importlib.metadata when that compiler's dir is on PYTHONPATH.  This file
+# is sourced from /etc/profile.d so the default compiler is active in every
+# shell (login, non-login interactive, and bash -c via BASH_ENV), and
+# 'compiler <name>' toggles between the two.
+#
+#   compiler             — show what's available and what's active
+#   compiler flagtree    — switch to FlagTree (default when present)
+#   compiler triton      — switch to the vendor Triton
+# ============================================================================
+
+_compiler_side_dirs="/opt/flagtree /opt/triton"
+
+_compiler_active_dir() {
+    # Return the compiler dir currently on PYTHONPATH, if any.
+    for d in $_compiler_side_dirs; do
+        case ":${PYTHONPATH:-}:" in
+            *":${d}:"*) echo "$d"; return 0 ;;
+        esac
+    done
+    return 1
+}
+
+_compiler_strip_side_dirs() {
+    # Drop the compiler side dirs from PYTHONPATH, keep everything else.
+    local cleaned=""
+    IFS=":"
+    for p in ${PYTHONPATH:-}; do
+        case " $_compiler_side_dirs " in
+            *" $p "*) ;;
+            *) [ -n "$cleaned" ] && cleaned="${cleaned}:${p}" || cleaned="$p" ;;
+        esac
+    done
+    printf '%s' "$cleaned"
+}
+
+_compiler_import_triton() {
+    # Import triton with the given dir first on PYTHONPATH.
+    PYTHONPATH="${1}${PYTHONPATH:+:}${PYTHONPATH:-}" python3 -c \
+        "import triton; print(triton.__version__)"
+}
+
+compiler() {
+    local dir=""
+
+    case "${1:-}" in
+        flagtree)
+            if [ ! -d /opt/flagtree/triton ]; then
+                echo "flagtree: not available on this backend" >&2
+                return 1
+            fi
+            dir="/opt/flagtree"
+            ;;
+        triton)
+            if [ ! -d /opt/triton/triton ]; then
+                echo "triton: not available on this backend" >&2
+                return 1
+            fi
+            dir="/opt/triton"
+            ;;
+        ""|status|help)
+            # Show availability + what's active, and make sure the default
+            # compiler is on PYTHONPATH (idempotent re-export).
+            echo "available compilers:"
+            if [ -d /opt/flagtree/triton ]; then
+                echo "  flagtree  $(_compiler_import_triton /opt/flagtree)  (default)"
+            fi
+            if [ -d /opt/triton/triton ]; then
+                echo "  triton    $(_compiler_import_triton /opt/triton)"
+            fi
+            if ! _compiler_active_dir >/dev/null; then
+                # No side dir on PYTHONPATH — default to flagtree when
+                # present, else triton.  Keeps the image usable with zero
+                # user action and restores the default after an explicit
+                # 'compiler' with no args.
+                if [ -d /opt/flagtree/triton ]; then
+                    dir="/opt/flagtree"
+                elif [ -d /opt/triton/triton ]; then
+                    dir="/opt/triton"
+                fi
+            fi
+            ;;
+        *)
+            echo "Usage: compiler [flagtree|triton]" >&2
+            echo "  compiler           show status" >&2
+            echo "  compiler flagtree  switch to FlagTree (default)" >&2
+            echo "  compiler triton    switch to Triton" >&2
+            return 1
+            ;;
+    esac
+
+    if [ -n "$dir" ]; then
+        local cleaned
+        cleaned=$(_compiler_strip_side_dirs)
+        if [ -n "$cleaned" ]; then
+            export PYTHONPATH="${dir}:${cleaned}"
+        else
+            export PYTHONPATH="${dir}"
+        fi
+        echo "$(basename "$dir") (active) - $(_compiler_import_triton "$dir")"
+    else
+        echo "active compiler:"
+        local active
+        if active=$(_compiler_active_dir); then
+            python3 -c "import os, triton; print(' ', os.path.basename(os.path.dirname(triton.__file__)), '-', triton.__version__)"
+        else
+            echo "  (no compiler side dir on PYTHONPATH)"
+        fi
+    fi
+}
+
+# Keep the default compiler active in every new shell.
+if ! _compiler_active_dir >/dev/null; then
+    if [ -d /opt/flagtree/triton ]; then
+        export PYTHONPATH="/opt/flagtree${PYTHONPATH:+:}${PYTHONPATH:-}"
+    elif [ -d /opt/triton/triton ]; then
+        export PYTHONPATH="/opt/triton${PYTHONPATH:+:}${PYTHONPATH:-}"
+    fi
+fi

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -187,10 +187,12 @@ def resolve_build_args(
     cpp_backend = str(backend_info.get("cmake_backend", "")).lower()
     cpp_extra = f"cpp-{cpp_backend}" if cpp_backend else ""
 
-    # Both compilers are installed (when configured). FlagTree is the default
-    # (installed to /flagos); Triton is installed to /opt/triton (side dir,
-    # switched via PYTHONPATH). When only Triton is configured, it goes to
-    # /flagos as the sole compiler (backward compat).
+    # Both compilers are installed (when configured), each into its own side
+    # dir: FlagTree → /opt/flagtree (default), Triton → /opt/triton. Neither
+    # lives in site-packages, so their dist-infos (entry points) are only
+    # visible when that compiler is active on PYTHONPATH — compiler() toggles
+    # between them. When only one compiler is configured, it goes to its side
+    # dir as the sole compiler and is baked as the default PYTHONPATH.
     flagtree = backend_info.get("flagtree", "")
     triton = backend_info.get("triton", "")
     triton_post = backend_info.get("triton_post_install", [])


### PR DESCRIPTION
## What & why

Fix the dual-compiler layout so the two compilers can't interfere with each other.

**Problem:** FlagTree (the default compiler) was installed into `site-packages/`. Its dist-info carries a `[triton.backends]` entry-point block (`amd/enflame/nvidia`), which `importlib.metadata` scans unconditionally. So even when the vendor Triton was active (`PYTHONPATH=/opt/triton`), a bare `import triton` crashed with `ModuleNotFoundError: triton.backends.enflame` — that module only exists inside FlagTree's own triton. Reproduced on enflame (`compiler triton` broken out of the box).

**Fix:** install both compilers into side dirs outside site-packages —
- FlagTree → `/opt/flagtree` (`pip install --target /opt/flagtree`)
- Triton → `/opt/triton` (always `--target /opt/triton`, no more "sole compiler → site-packages" branch)

Each dist-info is then only on `sys.path` when that compiler is active, so its entry points can't leak into the other compiler. Verified in a hermetic container test: with flagtree at `/opt/flagtree` and vendor triton active, `import triton` / `triton_gcu` registers `gcu` / `flash_attn` / `flag_gems` all work, and `importlib.metadata` reports zero `triton.backends` entry points.

The compiler-switch logic moves from a ~100-line inline `RUN printf` in the Containerfile to a baked **`runtime/compiler.sh`** (`/etc/profile.d/compiler.sh`): `compiler flagtree|triton` toggles `PYTHONPATH`, and sourcing auto-exports the default compiler (FlagTree when present, else Triton) so a bare shell works with no extra knobs. **No new build args.**

## Changes
- `runtime/Containerfile` — install FlagTree/Triton to side dirs, `COPY` both in the runtime stage, drop the inline compiler function (now a file)
- `runtime/compiler.sh` — new; `compiler()` switcher + default auto-export
- `scripts/build_runtime.py` — comment only (compiler args unchanged)

## Testing
- Container simulation on enflame1 (hermetic side-dir layout): flagtree↔triton switching clean, no EP leak, `flash_attn` + `flag_gems` import OK under vendor triton.
- Verified by hand in a live container; a full image build smoke test of one backend is a sensible follow-up before merge if you want it.
