### PR TITLE
fix(runtime): COPY compiler.sh from context root — build context is runtime/

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -276,7 +276,7 @@ RUN if [ -n "${RUNTIME_ENV}" ]; then \
 # the default compiler (FlagTree at /opt/flagtree, else Triton at
 # /opt/triton) is active in every shell, and 'compiler flagtree|triton'
 # toggles between the side dirs.
-COPY runtime/compiler.sh /etc/profile.d/compiler.sh
+COPY compiler.sh /etc/profile.d/compiler.sh
 
 # ── Bash plumbing — make profile.d/*.sh available everywhere ─────
 #   /etc/profile         → profile.d/*.sh   (login shells, native)


### PR DESCRIPTION
## Problem

Every `runtime-*` job in the Runtime Image Build workflow fails at the **Build runtime image** step:

```
#24 [runtime  9/11] COPY runtime/compiler.sh /etc/profile.d/compiler.sh
#24 ERROR: failed to calculate checksum ... "/runtime/compiler.sh": not found
Containerfile:279
```

Introduced by #332 (`runtime: isolate FlagTree and Triton into side dirs`), which added `COPY runtime/compiler.sh` to the Containerfile. But the build context is **already** `runtime/` — both `.github/workflows/runtime.yml` and `scripts/build_runtime.py` invoke `docker build -f runtime/Containerfile runtime/`. Docker therefore resolves the source as `runtime/runtime/compiler.sh`, which doesn't exist.

Affects every backend (nvidia-cuda12.8, nvidia-cuda13.3, cambricon, enflame, kunlunxin, metax, sunrise all failed in run 31177235809) and the local `python scripts/build_runtime.py <backend>` path identically.

## Fix

```diff
-COPY runtime/compiler.sh /etc/profile.d/compiler.sh
+COPY compiler.sh /etc/profile.d/compiler.sh
```

All other COPYs in the file are `COPY --from=builder`, so this is the only context-relative source and the only one affected.

## Verification

- `python scripts/build_runtime.py nvidia-cuda12.8 --dry-run` → context confirmed as `runtime/`, source `runtime/compiler.sh` present.
- Remaining pre-existing warnings (`InvalidDefaultArgInFrom` on `FROM ${BASE_IMAGE}`) are unrelated — they already appeared in passing builds; `BASE_IMAGE` is always supplied as a build arg.
