### PR TITLE
runtime: fix compiler status to distinguish flagtree vs triton

### DIFF
--- a/runtime/compiler.sh
+++ b/runtime/compiler.sh
@@ -122,7 +122,7 @@ compiler() {
         echo "active compiler:"
         local active
         if active=$(_compiler_active_dir); then
-            python3 -c "import os, triton; print(' ', os.path.basename(os.path.dirname(triton.__file__)), '-', triton.__version__)"
+            python3 -c "import os, triton; print(' ', os.path.basename(os.path.dirname(os.path.dirname(triton.__file__))), '-', triton.__version__)"
         else
             echo "  (no compiler side dir on PYTHONPATH)"
         fi


### PR DESCRIPTION
## Fix

`compiler()` status reported the active compiler as **"triton"** even when FlagTree was the active compiler.

**Root cause:** the label used `os.path.basename(os.path.dirname(triton.__file__))`. For both side dirs, `triton.__file__` is `<side>/triton/__init__.py`, so `dirname` → `<side>/triton` and `basename` → `triton` in both cases — indistinguishable.

**Fix:** use `dirname(dirname(triton.__file__))` → the side dir (`/opt/flagtree` vs `/opt/triton`), whose basename correctly labels the active compiler.

Verified in a container from the rebuilt image: `compiler` now shows `flagtree` on FlagTree and `triton` on vendor Triton.
