### PR TITLE
flaggems-builder: build wheel in isolated venv (PEP 668 fix)

### DIFF
--- a/flaggems-builder/build.sh
+++ b/flaggems-builder/build.sh
@@ -92,7 +92,10 @@ echo ">>> daily version: $SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLAG_GEMS"
 
 echo ">>> building pure-Python wheel"
 mkdir -p "$OUTDIR"
-python3 -m pip wheel "$src" --no-deps -w "$OUTDIR"
+# Build in an isolated venv: on Ubuntu 24.04 (Python 3.12) the system
+# interpreter is PEP 668 externally-managed and pip refuses to run against it.
+python3 -m venv "$workdir/venv"
+"$workdir/venv/bin/pip" wheel "$src" --no-deps -w "$OUTDIR"
 
 wheel="$(ls -t "$OUTDIR"/flag_gems-*.whl 2>/dev/null | head -1)"
 if [ -z "$wheel" ]; then


### PR DESCRIPTION
Ubuntu 24.04 runners ship Python 3.12 whose system interpreter is externally-managed (PEP 668); 'python3 -m pip wheel' aborts with error: externally-managed-environment. Build in a throwaway venv under the existing mktemp workdir instead.