### PR TITLE
flaggems-builder: version from git state, drop FLAGGEMS_VERSION

### DIFF
--- a/flaggems-builder/build.sh
+++ b/flaggems-builder/build.sh
@@ -46,37 +46,26 @@ git clone --quiet "$FLAGGEMS_REPO" "$src"
 git -C "$src" fetch --quiet --tags --force origin || true
 git -C "$src" checkout --quiet "$FLAGGEMS_REF"
 
-echo ">>> version: $(git -C "$src" describe --tags 2>/dev/null || echo '(no tag)')"
-
-# Daily builds get a date-stamped version instead of the scm default
-# (e.g. 5.4.0.dev580+gb89e0aeb8), whose leading token is a commit *count* —
-# opaque about when the wheel was built. We swap the count for the build date:
+# The version is a pure function of git state, letting setuptools_scm read the
+# tags in this clone. Two cases:
 #
-#   5.3.5.dev20260809
-#   \______/ \______/
-#    base     build date
+#   * HEAD is on an exact tag (release, ref=v5.3.4): the wheel is that tag,
+#     clean — 5.3.4. This is what the release workflow means: you named a tag,
+#     you get that exact wheel.
+#   * HEAD is past the last tag (daily off master): date-stamp the next release
+#     so builds are human-sortable and `pip install --pre` picks the newest —
+#     5.3.5.dev20260809.
 #
-# The date makes builds human-sortable and lets `pip install --pre` always pick
-# the newest (PEP 440 orders by version, and version order == chronological
-# order here). One scheduled build per day, so a bare date never collides on
-# the index; a manual same-day rebuild should pass FLAGGEMS_VERSION to override.
-#
-# We apply this version by creating a throwaway LOCAL git tag on HEAD rather
-# than the SETUPTOOLS_SCM_PRETEND_VERSION env var. The env var makes scm skip
-# git entirely, leaving __commit_id__ = None in _version.py. Tagging keeps scm
-# reading git, so the generated flag_gems/_version.py carries BOTH the date
-# version and the real commit: a tester can recover the commit at runtime via
+# We pin the daily version with a throwaway LOCAL tag on HEAD (never pushed,
+# dies with the clone) rather than SETUPTOOLS_SCM_PRETEND_VERSION, which would
+# make scm skip git and drop __commit_id__. The tag keeps scm reading git, so
+# flag_gems/_version.py carries BOTH the date version and the real commit:
 #
 #   python -c "import flag_gems._version as v; print(v.version, v.commit_id)"
-#
-# The tag lives only in this throwaway clone (never pushed) and dies with it.
-#
-# Set FLAGGEMS_VERSION to override the computed version (e.g. a pinned build).
-if [ -z "${FLAGGEMS_VERSION:-}" ]; then
-  "$py" -m pip install --quiet "setuptools-scm>=8,<10"
-  # guess-next-dev bumps to the next release after the latest tag (dist>0), so
-  # once v5.3.4 is tagged and any commit lands the base becomes 5.3.5. Strip the
-  # trailing .devN/.postN scm appends, leaving a bare base for our date stamp.
+"$py" -m pip install --quiet "setuptools-scm>=8,<10"
+if ! git -C "$src" describe --tags --exact-match >/dev/null 2>&1; then
+  # guess-next-dev bumps to the next release after the latest tag (dist>0).
+  # Strip the trailing .devN/.postN scm appends, leaving a bare base to stamp.
   base="$("$py" -c "
 import setuptools_scm
 v = setuptools_scm.get_version(
@@ -86,15 +75,9 @@ v = setuptools_scm.get_version(
 )
 print(v.split('.dev')[0].split('.post')[0])
 ")"
-  FLAGGEMS_VERSION="${base}.dev$(date +%Y%m%d)"
+  git -C "$src" tag -f "${base}.dev$(date +%Y%m%d)" >/dev/null
 fi
-# Local, unpushed tag on HEAD: scm reads it as the exact version while still
-# recording the commit. -f so a re-run in a reused clone overwrites cleanly.
-git -C "$src" tag -f "$FLAGGEMS_VERSION" >/dev/null
-echo ">>> daily version: ${FLAGGEMS_VERSION}  (commit $(git -C "$src" rev-parse --short=9 HEAD))"
-# Scoped to the flag_gems dist so it can only ever override this project.
-export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLAG_GEMS="$FLAGGEMS_VERSION"
-echo ">>> daily version: $SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLAG_GEMS"
+echo ">>> version: $(git -C "$src" describe --tags)  (commit $(git -C "$src" rev-parse --short=9 HEAD))"
 
 echo ">>> building pure-Python wheel"
 mkdir -p "$OUTDIR"


### PR DESCRIPTION
## Problem

Building an exact tag via **FlagGems Release Wheels** (`flaggems_ref=v5.3.4`) produced `flag_gems-5.3.4.dev20260809` instead of a clean `5.3.4`. The date-stamp block (#340, for the daily wheel) ran unconditionally, so it also fired on the release path and re-stamped the clean tag version as a pre-release.

## Fix

Version is now a pure function of git state — no `FLAGGEMS_VERSION` override:

| HEAD | version |
|---|---|
| on an exact tag (release, `v5.3.4`) | `5.3.4` |
| past the last tag (daily off `master`) | `5.3.5.dev<date>` |

Naming a tag in the release workflow means: build and push that exact wheel. Daily builds past the tag stay date-stamped; a daily build with no commit since the tag yields the clean version, which is fine.

## Verified — real builds from this branch

```
ref=v5.3.4            -> flag_gems-5.3.4-py3-none-any.whl
master + 1 commit     -> flag_gems-5.3.5.dev20260809-py3-none-any.whl
```

Follow-up to #342 / #343 (PEP 668).