### PR TITLE
release: upload tagged wheel to daily PyPI index too

### DIFF
--- a/scripts/release_flaggems.py
+++ b/scripts/release_flaggems.py
@@ -87,9 +87,18 @@ def cmd_build_python(args: argparse.Namespace) -> str:
 
 
 def cmd_upload_python(args: argparse.Namespace) -> None:
-    """Push the same py3-none-any wheel to every vendor PyPI in parallel."""
+    """Push the same py3-none-any wheel to every vendor PyPI in parallel.
+
+    The tagged release wheel also goes to the daily index (flagos-pypi-daily):
+    when master sits on a freshly-pushed tag, the daily build produces a clean
+    release version rather than a .dev stamp, so the daily index would otherwise
+    lack that exact version until the next commit lands.
+    """
     cfg = _load_configs()
     urls = _pypi_urls(cfg)
+    daily = cfg.get("pypi_daily")
+    if daily:
+        urls["daily"] = daily
     wheel = Path(args.wheel)
 
     if args.dry_run:


### PR DESCRIPTION
## Problem

When `master` sits on a freshly-pushed tag, the daily build produces a clean release version (e.g. `5.3.4`, per #344) rather than a `.dev` stamp. So the daily index (`flagos-pypi-daily`) can lack that exact tagged version until the next commit lands on master.

## Fix

`cmd_upload_python` now includes `flagos-pypi-daily` (from the existing `pypi_daily` key in configs.yaml) in the upload set, alongside the vendor PyPIs. A tagged release therefore always lands a copy on the daily index.

## Verified

Dry-run lists the daily target alongside all 14 vendor PyPIs.

Follow-up to #344.