### PR TITLE
runtime: rename compiler.sh → zz-compiler.sh so it sorts last in profile.d

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -272,11 +272,17 @@ RUN if [ -n "${RUNTIME_ENV}" ]; then \
 # here as a default because runtime:v1 (NO_FLAGGEMS) has no cpp wheel and
 # setting it prematurely causes FlagGems to crash on import.
 #
-# Compiler switching: see runtime/compiler.sh — baked to /etc/profile.d so
+# Compiler switching: see runtime/zz-compiler.sh — baked to /etc/profile.d so
 # the default compiler (FlagTree at /opt/flagtree, else Triton at
 # /opt/triton) is active in every shell, and 'compiler flagtree|triton'
 # toggles between the side dirs.
-COPY compiler.sh /etc/profile.d/compiler.sh
+#
+# The zz- prefix forces it to sort LAST among /etc/profile.d/*.sh (which are
+# sourced alphabetically). Some base images ship a vendor.sh (captured from
+# the SDK's set_env.sh) that exports PYTHONPATH absolutely — ascend's does —
+# which would clobber the compiler dir if compiler.sh sorted before it. Sorting
+# last means the compiler's PYTHONPATH export wins and triton stays importable.
+COPY zz-compiler.sh /etc/profile.d/zz-compiler.sh
 
 # ── Bash plumbing — make profile.d/*.sh available everywhere ─────
 #   /etc/profile         → profile.d/*.sh   (login shells, native)

--- a/runtime/zz-compiler.sh
+++ b/runtime/zz-compiler.sh
@@ -14,7 +14,12 @@
 # limitations under the License.
 
 # ============================================================================
-# compiler.sh — runtime compiler switcher, baked into every runtime image.
+# zz-compiler.sh — runtime compiler switcher, baked into every runtime image.
+#
+# The zz- prefix forces this to sort LAST in /etc/profile.d/*.sh (sourced
+# alphabetically). It must run after any vendor.sh that exports PYTHONPATH
+# absolutely (ascend's set_env.sh capture does), otherwise that vendor.sh
+# clobbers the compiler side dir off PYTHONPATH and triton stops importing.
 #
 # FlagTree (default, when present) lives in /opt/flagtree and the vendor
 # Triton lives in /opt/triton.  Neither is in site-packages, so their


### PR DESCRIPTION
## Summary

Fixes `import triton` failing in both **ascend** runtime images (`No module named 'triton'`) in the 2.1.2 verify run ([31314448646](https://github.com/flagos-ai/build-infra/actions/runs/31314448646)).

The compilers install to `/opt/flagtree` and `/opt/triton` via `pip --target` (not site-packages); `compiler.sh` in `/etc/profile.d` puts the active one on `PYTHONPATH`. But `/etc/profile.d/*.sh` is sourced **alphabetically**:

```
compiler.sh   (c)  -> PYTHONPATH=/opt/flagtree:...
...
vendor.sh     (v)  -> export PYTHONPATH="<CANN paths>"   <- clobbers, runs later
```

Ascend's `vendor.sh` is captured from the CANN `set_env.sh`, which exports `PYTHONPATH` **absolutely** (see the note in `base/ascend-*`: *"set_env.sh puts them on PYTHONPATH"*). Because it sorts after `compiler.sh`, it overwrites the compiler dir off `PYTHONPATH`, so triton is no longer importable in a plain `python3` (which is exactly how `verify_runtime.py` imports it).

## Fix

Rename `compiler.sh` -> `zz-compiler.sh` so it sorts **last** in `profile.d`, after any `vendor.sh`. The compiler's `PYTHONPATH` export then wins and triton stays importable.

- Only affects backends whose base ships a `PYTHONPATH`-rewriting `vendor.sh` (ascend today). No behavior change elsewhere.
- `git mv` preserves history; `COPY` line + header comment updated.

## Testing

Static verification only (ordering + that `verify_runtime.py`'s `bash -c` path sources `profile.d` via `BASH_ENV`). **Needs an ascend runtime rebuild to confirm end-to-end** — the last runtime build predates this. Does not touch the Class-2 libdevice-symbol failures (cambricon-4.4.3 / sunrise), which are an upstream FlagGems fallback gap.
