### PR TITLE
ci(runtime): self-label dispatch runs with run-name

### DIFF
--- a/.github/workflows/runtime-image.yaml
+++ b/.github/workflows/runtime-image.yaml
@@ -14,6 +14,15 @@
 
 name: Builid Runtime Image (manual)
 
+# The run title self-labels each dispatch so v1 (build, no flag_gems) and v2
+# (full, with flag_gems) are told apart at a glance in the Actions run list —
+# the two produce identical job names, so without this they are indistinguishable.
+# Shows: layer (v1/v2) · backend · push/no-push · no-cache · pinned flaggems ver.
+run-name: >-
+  ${{ inputs.no_flaggems && 'v1 build' || 'v2 flag_gems' }}
+  · ${{ inputs.backend }}
+  · ${{ inputs.push && 'push' || 'no-push' }}${{ inputs.no_cache && ' · no-cache' || '' }}${{ inputs.flaggems != '' && format(' · fg={0}', inputs.flaggems) || '' }}
+
 # Runtime images are built on demand, not on every push/PR. They layer
 # FlagGems (pure Python + optional C++ extension) on top of a base image
 # via wheel install. Trigger this manually to build a backend (or all).


### PR DESCRIPTION
## What

Add a top-level `run-name:` to the runtime build workflow so each dispatch self-labels in the Actions run list.

## Why

The workflow's job names are `runtime-<backend>` regardless of inputs, so **v1** (build, no flag_gems) and **v2** (full, with flag_gems) runs look identical in the run list. GitHub does not expose `workflow_dispatch` input values on a completed run, so once dispatched there is no way to tell which run was which. This forced two concurrent dispatches to both be cancelled because neither could be identified.

## What the label shows

`layer (v1/v2) · backend · push/no-push · no-cache · pinned flaggems ver`

Examples:
- `v1 build · all · push`
- `v2 flag_gems · all · push · no-cache`
- `v2 flag_gems · nvidia-cuda12.8 · no-push · fg=5.3.2`

## Testing

- `yaml.safe_load` parses the workflow with `run-name` present.
- No behavior change to the build itself — title-only.
