### PR TITLE
runtime: route uv seed packages to CN mirror

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -84,6 +84,17 @@ RUN curl -LsSf "https://resource.flagos.net/repository/flagos-filestore/utils/uv
 # instead of GitHub (much faster from CN runners).
 ENV UV_PYTHON_INSTALL_MIRROR=https://resource.flagos.net/repository/flagos-filestore/uv-python
 
+# ── uv package index — routes `uv venv --seed` (pip/setuptools/wheel)
+# to the CN mirror instead of PyPI.org. This is uv's ONLY package-index
+# operation in this file (CPython uses UV_PYTHON_INSTALL_MIRROR above;
+# every pip install uses PIP_INDEX_URL below), so before this the seed
+# fetch was the one step still crossing the international link — the
+# deterministic failure point on CN runners (esp. aarch64 Ascend nodes).
+# UV_DEFAULT_INDEX is the current (non-deprecated) name as of uv 0.11.30.
+# Timeout raised from uv's 30s default; the mirror can be slow to first byte.
+ENV UV_DEFAULT_INDEX=${EXTRA_PYPI} \
+    UV_HTTP_TIMEOUT=120
+
 # ── Install managed CPython (always from filestore mirror) ─────
 # --python-preference only-managed guarantees uv downloads its own
 # CPython build regardless of what the base image ships. Base image


### PR DESCRIPTION
## Problem

`uv venv --seed` downloads pip/setuptools/wheel from PyPI.org by default. On CN runners, especially aarch64 Ascend nodes, this international fetch is the deterministic failure point when the network link is flaky (transient timeouts / connection resets at `uv venv --seed`). Every other network step in the Containerfile is already CN-local:
- uv binary + CPython ��� resource.flagos.net filestore
- Every `pip install` → FLAGOS_PYPI/EXTRA_PYPI (resource.flagos.net / aliyun mirror)

The seed was the leak.

## Solution

Set `UV_DEFAULT_INDEX` (current, non-deprecated as of uv 0.11.30) to the same aliyun mirror pip already uses, and raise `UV_HTTP_TIMEOUT` from uv's 30s default. The seed step resolves against the default index like every other uv package operation, so this routes it CN-locally.

The agent that researched uv 0.11.30 behavior confirmed:
1. Seed packages are NOT vendored into the uv binary—they are fetched over the network from an index at runtime (proof: fresh PyPI releases alter seeding behavior).
2. `UV_DEFAULT_INDEX` is the correct, current variable (added 0.4.23); `UV_INDEX_URL` is deprecated but still honored.
3. No seed-specific index var exists—the seed uses the general default-index configuration.

## Impact

Turns ascend runner `uv venv --seed` from an international PyPI.org fetch (flaky) into an aliyun CN-local fetch (same mirror pip already uses). Should eliminate the deterministic `uv venv --seed` transient failures on firewalled CN runners.

���� Generated with [Claude Code](https://claude.com/claude-code)