### PR TITLE
runtime: raise pip download-resume limit for large wheels

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -111,6 +111,18 @@ ENV VIRTUAL_ENV=/flagos \
 # ── Upgrade pip in the venv ──────────────────────────────────────
 RUN pip install --no-cache-dir --upgrade pip
 
+# ── Raise pip's download-resume limit ─────────────────────────────
+# pip resumes an interrupted download in place, but its built-in ceiling
+# is 5 resume attempts (6 tries total). On CN runners the link to the
+# vendor index (resource.flagos.net) drops mid-stream every ~50-130 MB, so
+# large wheels can exhaust that ceiling before completing — the mthreads
+# `triton` wheel is 580 MB and reproducibly dies part-way (e.g. 434/580 MB)
+# after 6 tries. PIP_RESUME_RETRIES is the env form of --resume-retries
+# (pip >= 25.1, hence set AFTER the upgrade above); it is a ceiling, so a
+# download that finishes early simply stops resuming. Applies to every pip
+# download in this build (DEPS, FlagTree, Triton, FlagGems).
+ENV PIP_RESUME_RETRIES=100
+
 # ── Install vendor dependencies (explicit, no extras) ──────────
 # Dependencies come from configs.yaml deps: — explicit, no resolver ambiguity.
 # Each vendor has exactly one primary index (FLAGOS_PYPI); EXTRA_PYPI serves as


### PR DESCRIPTION
Fixes the mthreads-musa4.3.6 runtime build failures on CN runners.

## Problem

The mthreads `triton` wheel is **580 MB**. On CN runners the link to `resource.flagos.net` drops mid-stream every ~50-130 MB. pip's built-in resume ceiling is **5 resume attempts** (6 tries total), which is exhausted before the file completes — the download dies part-way (e.g. 434/580 MB) after 6 tries, then our 3× shell retry loop also exhausts, failing the whole build after ~2h.

- **v1** mthreads-musa4.3.6 (no flag_gems): succeeded on retry after 3 prior failures (a healthier link window — luck, not reliable)
- **v2** mthreads-musa4.3.6 (with flag_gems): failed 2× on the same download

## Solution

Set `PIP_RESUME_RETRIES=100` (env form of `--resume-retries`, pip >= 25.1, so placed after the pip upgrade). It is a ceiling, so smaller wheels that finish in one shot simply stop resuming.

Applies to every pip download in the build (DEPS, FlagTree, Triton, FlagGems) — several showed resume warnings, not just Triton.

## References

- pip 25.1 introduced resumable downloads and `--resume-retries` with a default of 5 resume attempts.
- Failed v2 build log: run 31341799455 job 93316725779 (died at 434/580 MB on the first shell cycle, 449/580 MB on the second, 74/580 MB on the third).
