### PR TITLE
base(ascend-cann9.0.0): bake NNAL/ATB env into vendor.sh

### DIFF
--- a/base/ascend-cann9.0.0
+++ b/base/ascend-cann9.0.0
@@ -78,8 +78,16 @@ ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEN
 # Users and downstream Dockerfiles no longer need to source set_env.sh —
 # the vendor env loads automatically in login, non-login interactive,
 # and non-interactive shells (via runtime's profile.d plumbing).
+# We source the CANN toolkit env first, then the NNAL/ATB env (which
+# builds on it) so ATB_HOME_PATH and the ATB lib path are captured too —
+# without them libatb.so fails to load and ATB ops (_npu_reshape_and_cache,
+# _npu_rotary_embedding) crash at inference. The top-level atb/set_env.sh
+# selects the cxx11-ABI (cxx_abi_1) variant, matching torch's ABI.
 RUN env_before=$(env | sort) && \
-    set -a && . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true && set +a && \
+    set -a && \
+    { . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true; } && \
+    { [ -f /usr/local/Ascend/nnal/atb/set_env.sh ] && . /usr/local/Ascend/nnal/atb/set_env.sh > /dev/null 2>&1 || true; } && \
+    set +a && \
     env_after=$(env | sort) && \
     printf '%s\n' "$env_before" > /tmp/_v_before && \
     printf '%s\n' "$env_after" > /tmp/_v_after && \

--- a/vllm-repack/E2E-REPORT.md
+++ b/vllm-repack/E2E-REPORT.md
@@ -1168,6 +1168,79 @@ Inference:    ✅  连贯英语——"What is the capital of France?" → 正确
 
 ---
 
+## 2.8 ascend-cann9.0.0（Ascend 910B4 aarch64：✅ E2E 通过，2026-08-10）
+
+**日期:** 2026-08-10　**平台:** Ascend 910B4（aarch64）　**节点:** `hw25`
+**driver/CANN:** npu-smi 26.0.rc1 / CANN 9.0.0　**镜像:** `flagos-runtime-ascend-cann9.0.0:2.1.2`（Phase B 用其快照 `vllm-phaseb-ascend-snapshot`）
+**容器:** `vllm-phaseb-ascend-cann9.0.0`　**Python:** 3.11.15　**torch/torch_npu:** 2.10.0+cpu / 2.10.0　**triton:** 3.5.1
+**目标:** vllm 0.20.2 (empty) + vllm-plugin-FL，全链路 serve + 推理
+**模型:** Qwen3-4B（`/data/models/Qwen/Qwen3-4B`，modelscope 下载 7.6G）
+**NPU 绑定:** **NPU 1**（NPU 0 有他人 `pytest` 进程占用，故换绑；仅 Python 安装阶段无关设备）
+
+ascend 是此前 flag_gems `j0`/`log2` 缺失致 import 崩溃的两个后端之一，故本次 E2E
+同时是**修复后 5.3.4 wheel 的在硬件确认**。全链路 serve + 推理一次跑通，910B4 上
+Qwen3-4B 贪婪解码输出连贯英语。这也是首个 **aarch64 + Python 3.11** 组合的 repack。
+
+### Repack —— 复用 Phase A 产物（aarch64 / cp311）
+
+Phase A（2026-08-10 于 hw25 build-image 内）产出 4 个 `+flagos` wheel，零泄漏扫描通过，
+平台 tag 正确，用户已上架 `flagos-pypi-ascend`：
+
+```
+vllm:                   0.20.2+flagos     ✅  empty，py3-none-any
+xgrammar:               0.2.4+flagos      ✅  cp311-cp311-manylinux_2_26_aarch64（py3.11+aarch64）
+compressed-tensors:     0.15.0.1+flagos   ✅  纯 py3
+opencv-python-headless: 5.0.0.93+flagos   ✅  cp37-abi3-manylinux_2_28_aarch64（稳定 ABI）
+```
+
+### 安装 —— ✅ 单步 + 插件干净安装
+
+`vllm==0.20.2+flagos` 从 `flagos-pypi-ascend` 单步安装，torch/torch_npu 从镜像保留，
+无公有 torch/cuda/triton 链。`vllm-plugin-FL` 走 `pip install --no-build-isolation -e .`
+（`VLLM_VENDOR` 未设 → 纯 `py3-none-any`，`vllm-plugin-fl 0.0.0+gf4ebc258f`）。
+
+### serve + 推理 —— ✅ 成功（3 处修复）
+
+| # | 症状 | 根因 | 修复 |
+|---|---|---|---|
+| 1 | import 崩溃 `libdevice has no attribute 'j0'` | 镜像烘焙的是 **旧** 5.3.4 wheel（重推前），FlagTree `triton.language.extra.cann.libdevice` 缺 `j0`/`log2`，`_patch_missing_symbols` 无 fallback 可打 | 从 `flagos-pypi-ascend` **强制重装 5.3.4**（重推后 wheel）→ `j0=True log2=True`。**即用户重推 5.3.4 的硬件确认** |
+| 2 | serve 启动崩溃 `coreDim is invalid (value 0)`（EngineCore init） | 模型构造 `register_buffer("_k_scale", torch.tensor(1.0))` 经 `aten::lift_fresh` 被 flag_gems 拦截，标量 tensor 算出零 grid，NPU KernelLaunch coreDim=0 | `dispatch/config/ascend.yaml` `flagos_blacklist` 加 `lift_fresh` / `lift_fresh_copy` / `_to_copy`（纯拷贝，回退 torch_npu 无损） |
+| 3 | 推理崩溃 `OSError: Could not load this library: .../libatb.so`（`_npu_reshape_and_cache` / `_npu_rotary_embedding`） | 基础镜像 `vendor.sh` 仅设 CANN toolkit `LD_LIBRARY_PATH`，**未 source NNAL/ATB `set_env.sh`** → `ATB_HOME_PATH` 空，ATB 后端算子（reshape_and_cache / rotary_embedding）加载失败 | serve 前 `source /usr/local/Ascend/nnal/atb/set_env.sh`（解析到 `cxx_abi_1`，libatb 就位）。**镜像侧缺口**——应烘焙进 base image env（见待办） |
+
+修复后 serve 达 `Application startup complete`（KV cache 2048-token / 50.5x 并发，NPU 1）。
+**首次推理**首 token 延迟高（首请求逐 shape 编译 triton/NPU 内核，60s curl 超时 →
+加长即返回）；rms_norm/rotary/silu_and_mul 均正确 dispatch，全程 0 error。
+
+### Stack 验证（ascend-cann9.0.0，✅ E2E 通过 2026-08-10）
+
+```
+torch/torch_npu: 2.10.0+cpu / 2.10.0  ✅  from 镜像
+triton:       3.5.1                    ✅  （+ triton_ascend）
+vllm:         0.20.2+flagos           ✅  empty，复用 Phase A aarch64 产物
+vllm_fl:      0.0.0+gf4ebc258f        ✅  纯 Python（VLLM_VENDOR 未设）
+flag_gems:    5.3.4（重推后，强制重装）✅  j0/log2 已修；3 op 黑名单（lift_fresh/lift_fresh_copy/_to_copy）
+NPU device:   ✅ NPU 1                 910B4（NPU 0 被他人占用）
+vllm import:  ✅
+vllm serve:   ✅  application startup complete（Qwen3-4B TP=1, max-len 2048, mem-util 0.6, enforce-eager）
+Inference:    ✅  "The capital of France is" → " Paris. The capital of Germany is Berlin.
+                  The capital of Italy is Rome..." 连贯英语；32 token，finish_reason=length，
+                  POST /v1/completions 200 OK，无 coreDim/libatb/dtype 错
+```
+
+### 待办
+
+| 事项 | 状态 | 备注 |
+|------|--------|-------|
+| `lift_fresh`/`lift_fresh_copy`/`_to_copy` 黑名单对齐 Mac 源码并提 PR | ✅ 已提 | **[PR #361](https://github.com/flagos-ai/vllm-plugin-FL/pull/361)**（flagos-ai/vllm-plugin-FL，分支 `ascend-blacklist-lift-fresh`→`main`）：`dispatch/config/ascend.yaml`；coreDim=0 标量崩溃规避，回退 torch_npu 无损。根治方向：flag_gems 标量/极小张量 grid 下限保护 |
+| ATB `set_env.sh` 烘焙进 base image env | ⬜ 待做 | 现须运行时手动 source；应进 `configs.yaml` env.runtime（对应 `base_source` TODO——ascend 已列）。否则每个 ATB 后端算子（reshape_and_cache/rotary_embedding）在裸 shell 崩溃 |
+| flag_gems 5.3.4 重推 v2 镜像刷新 | 🔄 进行中 | 现镜像烘焙旧 wheel，须强制重装才可用；全部 17 个 v2 runtime 镜像重建后消除（run 31365995958，用户驱动） |
+| ascend `+flagos` wheel 上架 | ✅ 已上传 | 4 个 wheel 已上架 `flagos-pypi-ascend`（用户上传） |
+
+**相关提交：** plugin 黑名单已提 **[PR #361](https://github.com/flagos-ai/vllm-plugin-FL/pull/361)**（`ascend-blacklist-lift-fresh`→`main`，commit baeafde）。wheel 复用 Phase A + 用户上传（无落库）；ATB env 1 处在容器内，base image 待对齐。
+
+
+---
+
 # 第 3 部分 · 流程总结与决策
 
 ## 3. 自动化边界

--- a/vllm-repack/E2E-REPORT.md
+++ b/vllm-repack/E2E-REPORT.md
@@ -1232,7 +1232,7 @@ Inference:    ✅  "The capital of France is" → " Paris. The capital of German
 | 事项 | 状态 | 备注 |
 |------|--------|-------|
 | `lift_fresh`/`lift_fresh_copy`/`_to_copy` 黑名单对齐 Mac 源码并提 PR | ✅ 已提 | **[PR #361](https://github.com/flagos-ai/vllm-plugin-FL/pull/361)**（flagos-ai/vllm-plugin-FL，分支 `ascend-blacklist-lift-fresh`→`main`）：`dispatch/config/ascend.yaml`；coreDim=0 标量崩溃规避，回退 torch_npu 无损。根治方向：flag_gems 标量/极小张量 grid 下限保护 |
-| ATB `set_env.sh` 烘焙进 base image env | ⬜ 待做 | 现须运行时手动 source；应进 `configs.yaml` env.runtime（对应 `base_source` TODO——ascend 已列）。否则每个 ATB 后端算子（reshape_and_cache/rotary_embedding）在裸 shell 崩溃 |
+| ATB `set_env.sh` 烘焙进 base image env | ✅ 已提 | **[build-infra PR #353](https://github.com/flagos-ai/build-infra/pull/353)**：`base/ascend-cann9.0.0` 环境捕获块在 CANN 之后追加 source NNAL/ATB `set_env.sh`，`ATB_HOME_PATH` / ATB lib path 进 `vendor.sh`（9.0.0 专属，8.5.0 无 NNAL）。消除运行时手动 source；否则 ATB 后端算子（reshape_and_cache/rotary_embedding）在裸 shell 崩溃 |
 | flag_gems 5.3.4 重推 v2 镜像刷新 | 🔄 进行中 | 现镜像烘焙旧 wheel，须强制重装才可用；全部 17 个 v2 runtime 镜像重建后消除（run 31365995958，用户驱动） |
 | ascend `+flagos` wheel 上架 | ✅ 已上传 | 4 个 wheel 已上架 `flagos-pypi-ascend`（用户上传） |
 


### PR DESCRIPTION
## Problem

On `ascend-cann9.0.0`, the base image env-capture block sourced only the **CANN toolkit** `set_env.sh`. The **NNAL/ATB** `set_env.sh` was never sourced, so `ATB_HOME_PATH` and the ATB lib path never reached `/etc/profile.d/vendor.sh`.

Consequence at runtime: `libatb.so` fails to load, and ATB-backed ops (`_npu_reshape_and_cache`, `_npu_rotary_embedding`) crash **during inference**. The only workaround was a manual `source /usr/local/Ascend/nnal/atb/set_env.sh` before `vllm serve` — exactly the `base_source` TODO this repo is trying to eliminate.

## Fix

Source the NNAL/ATB `set_env.sh` inside the **same** capture region (after CANN, which it builds on), so its env delta — `ATB_HOME_PATH`, the `ATB_*` tuning vars, and the `LD_LIBRARY_PATH`/`PATH` additions — is captured into `vendor.sh` alongside the toolkit env. Guarded on file existence so any non-NNAL rebuild is unaffected. The top-level `atb/set_env.sh` selects the cxx11-ABI (`cxx_abi_1`) variant, matching torch's ABI.

9.0.0-only: `ascend-cann8.5.0` does not install NNAL, so it has no ATB to source.

## Verification

On hw25 (910B4, CANN 9.0.0), sourcing the ATB `set_env.sh` exports:

```
ATB_HOME_PATH=/usr/local/Ascend/nnal/atb/latest/atb/cxx_abi_1
LD_LIBRARY_PATH=.../nnal/atb/latest/atb/cxx_abi_1/lib:...
```

plus the `ATB_*` tuning vars — all new vs. the pre-source env, so the `comm -13` delta captures them. Full E2E (serve + inference) is green with this env in place; see report §2.8.
