### PR TITLE
ascend-cann8.5.0: capture NNAL/ATB env into vendor.sh (follow-up to #354)

### DIFF
--- a/base/ascend-cann8.5.0
+++ b/base/ascend-cann8.5.0
@@ -80,8 +80,16 @@ ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEN
 # Users and downstream Dockerfiles no longer need to source set_env.sh —
 # the vendor env loads automatically in login, non-login interactive,
 # and non-interactive shells (via runtime's profile.d plumbing).
+# Source the NNAL/ATB set_env.sh after CANN's (ATB builds on the toolkit env)
+# so ATB_HOME_PATH and the ATB lib path are captured too — without them
+# libatb.so fails to load and ATB ops (_npu_reshape_and_cache,
+# _npu_rotary_embedding) crash at inference. The top-level atb/set_env.sh
+# selects the cxx11-ABI (cxx_abi_1) variant, matching torch's ABI.
 RUN env_before=$(env | sort) && \
-    set -a && . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true && set +a && \
+    set -a && \
+    { . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true; } && \
+    { [ -f /usr/local/Ascend/nnal/atb/set_env.sh ] && . /usr/local/Ascend/nnal/atb/set_env.sh > /dev/null 2>&1 || true; } && \
+    set +a && \
     env_after=$(env | sort) && \
     printf '%s\n' "$env_before" > /tmp/_v_before && \
     printf '%s\n' "$env_after" > /tmp/_v_after && \

--- a/configs.yaml
+++ b/configs.yaml
@@ -154,6 +154,7 @@ vendors:
       sdk:
         - CANN Toolkit 8.5.0 (aarch64)     # Ascend-cann-toolkit_8.5.0_linux-aarch64.run
         - CANN 910B Ops 8.5.0 (aarch64)    # Ascend-cann-910b-ops_8.5.0_linux-aarch64.run
+        - CANN NNAL 8.5.0 (aarch64)        # Ascend-cann-nnal_8.5.0_linux-aarch64.run
 
     cann9.0.0:
       extras: ascend-cann900


### PR DESCRIPTION
Follow-up to #354, which added the NNAL install for `ascend-cann8.5.0` but stopped short of wiring its env in.

## Problem
#354 installs NNAL, but the env-capture block (`RUN env_before=...`) sourced only CANN's `set_env.sh`. The NNAL/ATB `set_env.sh` was never sourced, so `ATB_HOME_PATH` and the ATB lib path never made it into `/etc/profile.d/vendor.sh`. At runtime `libatb.so` fails to load and the ascend vendor attention path crashes at inference — `_npu_reshape_and_cache` and `_npu_rotary_embedding` both dispatch into ATB. This is the exact bug 9.0.0 hit before #353.

## Fix
- `base/ascend-cann8.5.0`: source the NNAL/ATB `set_env.sh` right after CANN's, inside the same capture region, so its env delta lands in `vendor.sh`. Mirrors #353. Guarded with `[ -f ... ]` so it's a no-op if the layout differs.
- `configs.yaml`: list `CANN NNAL 8.5.0` in the 8.5.0 `sdk:` block (doc source of truth), matching 9.0.0.

## Verify after build
NNAL 8.5.0 is assumed to install `set_env.sh` at `/usr/local/Ascend/nnal/atb/set_env.sh` (same as 9.0.0). Confirm on the built image that `vendor.sh` contains `ATB_HOME_PATH`, and that 8.5.0 clears the same `vllm serve` + inference E2E that 9.0.0 did (report §2.8). ABI note: 8.5.0 uses torch_npu 2.9.0 vs 9.0.0's 2.10.0 — if ATB throws an ABI mismatch, check the `cxx_abi_1` vs `cxx_abi_0` variant selection.

This PR was written in part with the assistance of generative AI.