### PR TITLE
fix(base): isolate ascend vendor set_env.sh sourcing in bash + pin comm collation

### DIFF
--- a/base/ascend-cann8.5.0
+++ b/base/ascend-cann8.5.0
@@ -85,16 +85,21 @@ ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEN
 # libatb.so fails to load and ATB ops (_npu_reshape_and_cache,
 # _npu_rotary_embedding) crash at inference. The top-level atb/set_env.sh
 # selects the cxx11-ABI (cxx_abi_1) variant, matching torch's ABI.
-RUN env_before=$(env | sort) && \
-    set -a && \
-    { . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true; } && \
-    { [ -f /usr/local/Ascend/nnal/atb/set_env.sh ] && . /usr/local/Ascend/nnal/atb/set_env.sh > /dev/null 2>&1 || true; } && \
-    set +a && \
-    env_after=$(env | sort) && \
-    printf '%s\n' "$env_before" > /tmp/_v_before && \
-    printf '%s\n' "$env_after" > /tmp/_v_after && \
-    comm -13 /tmp/_v_before /tmp/_v_after \
-      | grep -v '^_\|^PWD=\|^SHLVL=\|^OLDPWD=' \
+# NOTE: the sourcing runs inside `bash -c`, not the RUN's /bin/sh (dash on
+# ubuntu:24.04). The vendor set_env.sh scripts are bash scripts; sourcing them
+# under dash can hit a code path that calls `exit` (killing the RUN before
+# `|| true` can catch it — a silent non-zero exit). Isolating the source in a
+# bash child contains any such exit and matches step 15's `bash -c source`.
+# LC_ALL=C pins collation so the two sorts and `comm` agree; a locale-shifted
+# `comm` otherwise aborts (exit 2) claiming the input is "not in sorted order".
+RUN env | LC_ALL=C sort > /tmp/_v_before && \
+    bash -c 'set -a; \
+      . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true; \
+      [ -f /usr/local/Ascend/nnal/atb/set_env.sh ] && . /usr/local/Ascend/nnal/atb/set_env.sh > /dev/null 2>&1 || true; \
+      set +a; env' \
+      | LC_ALL=C sort > /tmp/_v_after && \
+    { LC_ALL=C comm -13 /tmp/_v_before /tmp/_v_after || true; } \
+      | { grep -v '^_\|^PWD=\|^SHLVL=\|^OLDPWD=\|^BASH_' || true; } \
       | while IFS='=' read -r var val; do \
           printf 'export %s="%s"\n' "$var" "$val"; \
         done \

--- a/base/ascend-cann9.0.0
+++ b/base/ascend-cann9.0.0
@@ -83,16 +83,21 @@ ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEN
 # without them libatb.so fails to load and ATB ops (_npu_reshape_and_cache,
 # _npu_rotary_embedding) crash at inference. The top-level atb/set_env.sh
 # selects the cxx11-ABI (cxx_abi_1) variant, matching torch's ABI.
-RUN env_before=$(env | sort) && \
-    set -a && \
-    { . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true; } && \
-    { [ -f /usr/local/Ascend/nnal/atb/set_env.sh ] && . /usr/local/Ascend/nnal/atb/set_env.sh > /dev/null 2>&1 || true; } && \
-    set +a && \
-    env_after=$(env | sort) && \
-    printf '%s\n' "$env_before" > /tmp/_v_before && \
-    printf '%s\n' "$env_after" > /tmp/_v_after && \
-    comm -13 /tmp/_v_before /tmp/_v_after \
-      | grep -v '^_\|^PWD=\|^SHLVL=\|^OLDPWD=' \
+# NOTE: the sourcing runs inside `bash -c`, not the RUN's /bin/sh (dash on
+# ubuntu:24.04). The vendor set_env.sh scripts are bash scripts; sourcing them
+# under dash can hit a code path that calls `exit` (killing the RUN before
+# `|| true` can catch it — a silent non-zero exit). Isolating the source in a
+# bash child contains any such exit and matches step 15's `bash -c source`.
+# LC_ALL=C pins collation so the two sorts and `comm` agree; a locale-shifted
+# `comm` otherwise aborts (exit 2) claiming the input is "not in sorted order".
+RUN env | LC_ALL=C sort > /tmp/_v_before && \
+    bash -c 'set -a; \
+      . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true; \
+      [ -f /usr/local/Ascend/nnal/atb/set_env.sh ] && . /usr/local/Ascend/nnal/atb/set_env.sh > /dev/null 2>&1 || true; \
+      set +a; env' \
+      | LC_ALL=C sort > /tmp/_v_after && \
+    { LC_ALL=C comm -13 /tmp/_v_before /tmp/_v_after || true; } \
+      | { grep -v '^_\|^PWD=\|^SHLVL=\|^OLDPWD=\|^BASH_' || true; } \
       | while IFS='=' read -r var val; do \
           printf 'export %s="%s"\n' "$var" "$val"; \
         done \


### PR DESCRIPTION
## Problem

Rebuilding `flagos-base-ascend-cann8.5.0:2.1.2` failed at the env-capture step (step 19) with `returned a non-zero code: 2` — ~0.6s in, no stderr. The block landed by #353 (9.0.0) / #355 (8.5.0) sources the CANN and NNAL/ATB `set_env.sh` scripts **directly in the RUN's `/bin/sh`**, which is **dash** on `ubuntu:24.04`.

Two failure modes, both silent:
1. Those are **bash** scripts. Under dash they can hit a path that calls `exit`, which kills the RUN **before `|| true` can catch it** — a silent non-zero exit.
2. `comm` requires both inputs in the **same** collation. `env_before` is sorted *before* sourcing; if a sourced script shifts the locale, `comm` runs under the new collation and aborts (exit 2) claiming the input is "not in sorted order".

## Fix

- Source both `set_env.sh` inside **`bash -c`** (their intended shell, matching step 15's existing `bash -c source` for NNAL). Any `exit` is contained to the child; dash-vs-bash parsing is a non-issue.
- Pin **`LC_ALL=C`** on both sorts and on `comm` so collation always agrees.
- Make the `grep` filter and `comm` non-fatal (`|| true`) so an empty match can't break the chain. Also drop `BASH_*` vars now that sourcing runs in a bash child.

`ATB_HOME_PATH` and the ATB lib path are still captured into `/etc/profile.d/vendor.sh` — the whole point of #353/#355.

## Verification

Simulated the exact hardened block under dash with a stub ATB `set_env.sh` that does `exit 2` when sourced outside bash (the suspected killer). Result: RUN exits **0**, and `vendor.sh` captures `ASCEND_HOME`, `ATB_HOME_PATH`, `LD_LIBRARY_PATH`, and `PATH`. Full CI build+push of both ascend backends to follow on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
