### PR TITLE
Bump flagtree versions for all backends

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -65,7 +65,7 @@
 #
 # At release: bump both fields → git tag v<VERSION> → done.
 version: "2.1.2"
-flaggems: "5.3.3"
+flaggems: "5.3.4"
 
 # Versions of build tools needed to compile the cpp operator wheel inside the
 # runtime:v1 container.  Pinned so a future pip install won't silently pull an
@@ -105,7 +105,7 @@ vendors:
       python: "3.12"
       cmake_backend: CUDA
       triton: triton==3.6.0
-      flagtree: flagtree==0.6.0
+      flagtree: flagtree==0.6.1
       env:
         base:
           PATH: /usr/local/cuda/bin:$PATH
@@ -125,7 +125,7 @@ vendors:
       python: "3.12"
       cmake_backend: CUDA
       triton: triton==3.6.0
-      flagtree: flagtree==0.6.0
+      flagtree: flagtree==0.6.1
       env:
         base:
           PATH: /usr/local/cuda/bin:$PATH
@@ -154,6 +154,7 @@ vendors:
       sdk:
         - CANN Toolkit 8.5.0 (aarch64)     # Ascend-cann-toolkit_8.5.0_linux-aarch64.run
         - CANN 910B Ops 8.5.0 (aarch64)    # Ascend-cann-910b-ops_8.5.0_linux-aarch64.run
+        - CANN NNAL 8.5.0 (aarch64)        # Ascend-cann-nnal_8.5.0_linux-aarch64.run
 
     cann9.0.0:
       extras: ascend-cann900
@@ -162,7 +163,7 @@ vendors:
       python: "3.11"
       cmake_backend: NPU
       triton: triton==3.5.0
-      flagtree: flagtree==0.6.0+ascend3.5
+      flagtree: flagtree==0.6.1+ascend3.5
       triton_post_install:
         - triton_ascend==3.2.1
       deps:
@@ -270,8 +271,7 @@ vendors:
       triton: triton==3.6.0
       triton_post_install:
         - triton-gcu==3.6.0+1.0.20260722
-      # This version of flagtree doesn't work yet
-      # flagtree: flagtree==0.6.0+enflame.git657f543d
+      flagtree: flagtree==0.6.1+enflame3.6
       env:
         runtime:
           TORCH_GCU_ENABLE_INT64_AND_UINT64: "1"
@@ -287,8 +287,6 @@ vendors:
         - flash-attn==2.7.2+torch.2.11.0.gcu.3.8.20260706
         - tops-extension==3.6.20260529+torch.2.11.0
         - topstx==1.10.6
-        # this version pins transformers at 4.42.4, which conflicts with enflame-modelopt
-        # - xfuser==0.4.1+gcu.3.6.20260609
         - enflame-modelopt==3.6.20260615+torch.2.11.0
         - numpy==2.3.5
       sdk:
@@ -315,14 +313,12 @@ vendors:
       driver: "6.3.30-V1.4.1a"
       python: "3.10"
       triton: triton==3.3.0+das.opt1.dtk2604.torch290
-      flagtree: flagtree==0.5.1+hcu3.1
+      flagtree: flagtree==0.6.1+hcu3.6
       deps:
         - torch==2.9.0+das.opt1.dtk2604
-        # torch built against the numpy 1.x C ABI — numpy 2.x breaks it
-        # ("Numpy is not available"). opencv-python-headless declares numpy>=2
-        # but that is a packaging declaration only (its wheel is runtime
-        # backward-compatible with numpy>=1.19), so 1.26.4 is safe. See
-        # vllm-repack/E2E-REPORT.md §2.4 / §1.7.
+        # torch built against the numpy 1.x C ABI
+        # opencv-python-headless declares numpy>=2, but that is a pkg declaration only.
+        # Its wheel is runtime backward-compatible with numpy>=1.19
         - numpy==1.26.4
       sdk:
         - Hygon DTK 26.04      # DTK-26.04-Ubuntu22.04-x86_64.tar.gz
@@ -358,7 +354,7 @@ vendors:
       driver: "5.37.1"
       python: "3.10"
       triton: triton==3.0.0+a48aedef
-      flagtree: flagtree==0.5.1+xpu3.0
+      flagtree: flagtree==0.6.1+xpu3.6
       env:
         base:
           PATH: /usr/local/xpu/bin:$PATH
@@ -414,7 +410,7 @@ vendors:
       driver: "3.9.6"
       python: "3.12"
       triton: triton==3.6.0+metax3.8.1.0
-      flagtree: flagtree==0.6.1a2+metax3.6
+      flagtree: flagtree==0.6.1+metax3.6
       env:
         base:
           PATH: /opt/maca/mxgpu_llvm/bin:/opt/maca/bin:${PATH}
@@ -468,7 +464,7 @@ vendors:
       python: "3.10"
       cmake_backend: MUSA
       triton: triton==3.6.0
-      flagtree: flagtree==0.6.0+mthreads3.6
+      flagtree: flagtree==0.6.1+mthreads3.6
       env:
         base:
           MUSA_HOME: /usr/local/musa


### PR DESCRIPTION
This PR bumps the flagtree version for almost all backends.