### PR TITLE
fix(base): stop ascend vendor.sh from leaking CANN set_env.sh function bodies

### DIFF
--- a/base/ascend-cann8.5.0
+++ b/base/ascend-cann8.5.0
@@ -92,6 +92,13 @@ ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEN
 # bash child contains any such exit and matches step 15's `bash -c source`.
 # LC_ALL=C pins collation so the two sorts and `comm` agree; a locale-shifted
 # `comm` otherwise aborts (exit 2) claiming the input is "not in sorted order".
+# CANN's set_env.sh exports bash functions; `env` renders each as a multi-line
+# block. Filtering only `^BASH_` drops the `BASH_FUNC_x%%=() {` header but lets
+# the body lines leak, and LC_ALL=C sorts those space-leading fragments to the
+# top where they become bogus `export ...(...)` lines — the syntax error that
+# broke sourcing at runtime. Anchoring on a valid var-name start drops the
+# leaked bodies (and the `%%` header), and single-quoting each value keeps any
+# embedded ) " $ ` literal.
 RUN env | LC_ALL=C sort > /tmp/_v_before && \
     bash -c 'set -a; \
       . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true; \
@@ -99,9 +106,11 @@ RUN env | LC_ALL=C sort > /tmp/_v_before && \
       set +a; env' \
       | LC_ALL=C sort > /tmp/_v_after && \
     { LC_ALL=C comm -13 /tmp/_v_before /tmp/_v_after || true; } \
-      | { grep -v '^_\|^PWD=\|^SHLVL=\|^OLDPWD=\|^BASH_' || true; } \
+      | { grep -Ev '^(_|PWD|SHLVL|OLDPWD)=' || true; } \
+      | { grep -E '^[A-Za-z_][A-Za-z0-9_]*=' || true; } \
       | while IFS='=' read -r var val; do \
-          printf 'export %s="%s"\n' "$var" "$val"; \
+          esc=$(printf '%s' "$val" | sed "s/'/'\\\\''/g"); \
+          printf "export %s='%s'\n" "$var" "$esc"; \
         done \
       > /etc/profile.d/vendor.sh && \
     rm -f /tmp/_v_before /tmp/_v_after && \

--- a/base/ascend-cann9.0.0
+++ b/base/ascend-cann9.0.0
@@ -90,6 +90,13 @@ ENV LD_LIBRARY_PATH="${ASCEND_HOME}/lib64:/usr/local/Ascend/driver/lib64:${ASCEN
 # bash child contains any such exit and matches step 15's `bash -c source`.
 # LC_ALL=C pins collation so the two sorts and `comm` agree; a locale-shifted
 # `comm` otherwise aborts (exit 2) claiming the input is "not in sorted order".
+# CANN's set_env.sh exports bash functions; `env` renders each as a multi-line
+# block. Filtering only `^BASH_` drops the `BASH_FUNC_x%%=() {` header but lets
+# the body lines leak, and LC_ALL=C sorts those space-leading fragments to the
+# top where they become bogus `export ...(...)` lines — the syntax error that
+# broke sourcing at runtime. Anchoring on a valid var-name start drops the
+# leaked bodies (and the `%%` header), and single-quoting each value keeps any
+# embedded ) " $ ` literal.
 RUN env | LC_ALL=C sort > /tmp/_v_before && \
     bash -c 'set -a; \
       . /usr/local/Ascend/cann/set_env.sh > /dev/null 2>&1 || true; \
@@ -97,9 +104,11 @@ RUN env | LC_ALL=C sort > /tmp/_v_before && \
       set +a; env' \
       | LC_ALL=C sort > /tmp/_v_after && \
     { LC_ALL=C comm -13 /tmp/_v_before /tmp/_v_after || true; } \
-      | { grep -v '^_\|^PWD=\|^SHLVL=\|^OLDPWD=\|^BASH_' || true; } \
+      | { grep -Ev '^(_|PWD|SHLVL|OLDPWD)=' || true; } \
+      | { grep -E '^[A-Za-z_][A-Za-z0-9_]*=' || true; } \
       | while IFS='=' read -r var val; do \
-          printf 'export %s="%s"\n' "$var" "$val"; \
+          esc=$(printf '%s' "$val" | sed "s/'/'\\\\''/g"); \
+          printf "export %s='%s'\n" "$var" "$esc"; \
         done \
       > /etc/profile.d/vendor.sh && \
     rm -f /tmp/_v_before /tmp/_v_after && \


### PR DESCRIPTION
## Problem

Both ascend backends **built green** in the 2.1.2 cycle but **failed `verify-runtime`** (run 31407391901) — every other backend passed. On real hardware the very first line of the verify job was:

```
/etc/profile.d/vendor.sh: line 9: syntax error near unexpected token `)'
/etc/profile.d/vendor.sh: line 9: `export  *)=""'
```

Because `vendor.sh` failed to source, the whole vendor env was missing and everything cascaded:
- `torch FAIL: Failed to load the backend extension: torch_npu`
- `triton FAIL: libascend_hal.so: cannot open shared object file`
- `flag_gems FAIL: ... single TORCH_LIBRARY ...`
- `use_gems+add FAIL: name 'flag_gems' is not defined` (cann9 then segfaulted, exit 139)

## Root cause

The env-capture step (added in #353/#355, hardened in #356) rebuilds `vendor.sh` from the vars that appear after sourcing CANN's `set_env.sh`. CANN exports bash **functions**; under `set -a; env` bash renders each as a multi-line block:

```
BASH_FUNC_x%%=() {  ...
   case ... in
   *) ... ;;
}
```

The old `grep -v '^BASH_'` dropped only the **header** line, so the function **body** leaked. `LC_ALL=C sort` floated those space-leading fragments to the top, and `printf 'export %s="%s"'` turned a `*)` case branch into `export  *)=""` — the line-9 syntax error.

The **build** succeeded because #356 only sources env inside a build-time `bash -c`; it never re-sources the generated file. bash 3.2 on macOS also tolerates the garbage, so local `bash -n` missed it — bash 5 in-container does not.

## Fix

- Anchor reconstruction on a valid shell var-name start (`grep -E '^[A-Za-z_][A-Za-z0-9_]*='`) — drops leaked function bodies and the `%%` header.
- Single-quote each value (`sed "s/'/'\\''/g"`) so any `) " $ \`` literal in a path survives. Four backslashes in the Dockerfile → dash emits the correct `'\''`.

## Verification

Tested in-place in the actual `flagos-runtime-ascend` containers on real NPUs — **hw25 (cann9.0.0)** and **hw26 (cann8.5.0)**:

- shipped `vendor.sh` reproduces the exact `line 9 ... *)` syntax error;
- regenerated `vendor.sh` parses cleanly (`bash -n` OK), with `ATB_HOME_PATH`, `LD_LIBRARY_PATH`, `PATH`, `PYTHONPATH` all captured;
- after swapping it in: `torch OK`, `triton OK`, `flag_gems OK 5.3.4`, `use_gems+add OK shape=[2, 3]`, python exit 0 on davinci0.

## Follow-up (after merge)

Rebuild + push both ascend base `2.1.2` → rebuild runtime `2.1.2` → re-run `verify-runtime` for the two ascend backends to confirm green end-to-end.


---

This PR was written in part with the assistance of generative AI.
