### PR TITLE
refactor(flagtree-builder): unify version arg to FLAGTREE_VERSION

### DIFF
--- a/.github/workflows/flagtree-wheel.yml
+++ b/.github/workflows/flagtree-wheel.yml
@@ -33,6 +33,10 @@ on:
           - metax
           - nvidia-cuda
         default: metax
+      flagtree_version:
+        description: 'FlagTree tag/ref to build (blank = Containerfile default)'
+        type: string
+        default: ''
       upload:
         description: 'upload the wheel to the vendor PyPI'
         type: boolean
@@ -68,12 +72,20 @@ jobs:
 
       - name: Build the FlagTree wheel image
         working-directory: flagtree-builder
+        env:
+          FLAGTREE_VERSION: ${{ inputs.flagtree_version }}
         run: |
           set -euo pipefail
           test -f "$TARGET" || { echo "ERROR: flagtree-builder/$TARGET not found" >&2; exit 1; }
+          # FLAGTREE_VERSION is the single version knob (tag/ref + wheel version);
+          # blank means use the Containerfile default for the target.
+          build_args=()
+          if [ -n "${FLAGTREE_VERSION:-}" ]; then
+            build_args+=(--build-arg "FLAGTREE_VERSION=${FLAGTREE_VERSION}")
+          fi
           # The objdump + clean-version gates run inside this build; a failure
           # here means the wheel is not 22.04-safe and must not be published.
-          docker build -t "$IMAGE" -f "$TARGET" .
+          docker build "${build_args[@]}" -t "$IMAGE" -f "$TARGET" .
 
       - name: Extract the wheel
         working-directory: flagtree-builder

--- a/flagtree-builder/README.md
+++ b/flagtree-builder/README.md
@@ -51,10 +51,13 @@ podman build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_p
 
 Useful build args (see the Containerfile for the full list):
 
-- `FLAGTREE_REF` — git branch/tag to build (default `0.6.0`).
-- `FLAGTREE_WHEEL_VERSION` — wheel version string (default `0.6.0`). A clean
-  version (no `+git<sha>`) also needs `FLAGTREE_PYPI_KEY`; otherwise the wheel
-  is versioned `<ver>.git<sha>`.
+- `FLAGTREE_VERSION` — FlagTree git tag/ref to build; also the wheel version
+  string (default `0.6.0` for `nvidia-cuda`, `0.6.1+metax3.6` for `metax`). This
+  is the single version knob.
+- `FLAGTREE_WHEEL_VERSION` — wheel version string; defaults to `FLAGTREE_VERSION`,
+  so you normally only set `FLAGTREE_VERSION`. A clean version (no `+git<sha>`)
+  also needs `FLAGTREE_PYPI_KEY`; otherwise the wheel is versioned `<ver>.git<sha>`
+  (the `metax` builder gets a clean version without the key by dropping `.git`).
 - `FLAGTREE_PYPI_KEY` — unlocks the clean version (md5-gated in FlagTree's
   `setup.py`).
 

--- a/flagtree-builder/metax
+++ b/flagtree-builder/metax
@@ -35,18 +35,20 @@ FROM ubuntu:22.04
 # Proxy is only consumed during build (predefined ARG, not persisted in the image).
 ARG http_proxy=
 ARG https_proxy=
-# Vendor release tag. FlagTree tags one commit per backend (0.6.1+metax3.6 is an
-# annotated tag on the same commit as 0.6.1 / 0.6.1+enflame3.6); the backend is
-# selected at build time via FLAGTREE_BACKEND, not by source.
-ARG FLAGTREE_TAG=0.6.1+metax3.6
+# FlagTree release tag to build (the single version knob). FlagTree tags one
+# commit per backend (0.6.1+metax3.6 is an annotated tag on the same commit as
+# 0.6.1 / 0.6.1+enflame3.6); the backend is selected at build time via
+# FLAGTREE_BACKEND, not by source.
+ARG FLAGTREE_VERSION=0.6.1+metax3.6
 # Wheel version string. FlagTree's setup.py (get_flagtree_version) appends a
 # dirty "+git<sha>" / ".git<sha>" suffix to every build unless it either holds
 # the vendor's secret FLAGTREE_PYPI_KEY or finds no .git dir (git rev-parse then
 # fails and the suffix resolves empty). We don't have the vendor key, so the
 # build removes .git before `pip wheel` -> the version comes out clean, exactly
-# FLAGTREE_WHEEL_VERSION (default matches the vendor tag so this is a drop-in
-# replacement for the broken vendor wheel).
-ARG FLAGTREE_WHEEL_VERSION=0.6.1+metax3.6
+# FLAGTREE_WHEEL_VERSION. It defaults to FLAGTREE_VERSION so one arg drives both
+# the checkout and the wheel label (the default matches the vendor tag, so this
+# is a drop-in replacement for the broken vendor wheel).
+ARG FLAGTREE_WHEEL_VERSION=${FLAGTREE_VERSION}
 # Prebuilt metax deps, pinned by URL. These are backend inputs, not source:
 #  - metax-llvm19: prebuilt LLVM, statically linked into libtriton.so (clean).
 #  - metaxTritonPlugin.so: prebuilt metax codegen (needs only GLIBC_2.32).
@@ -101,7 +103,7 @@ RUN mkdir -p /root/.flagtree/metax /root/.triton \
 # RUN but not persisted. Force HTTP/1.1 for git and retry the flaky network steps.
 RUN git config --global http.version HTTP/1.1 \
     && for i in 1 2 3 4 5 6 7 8; do \
-         git clone --branch "${FLAGTREE_TAG}" --depth 1 \
+         git clone --branch "${FLAGTREE_VERSION}" --depth 1 \
            https://github.com/flagos-ai/flagtree /opt/flagtree && break; \
          echo ">>> flagtree clone attempt $i failed, retrying in 5s..."; \
          rm -rf /opt/flagtree; sleep 5; \

--- a/flagtree-builder/nvidia-cuda
+++ b/flagtree-builder/nvidia-cuda
@@ -29,14 +29,17 @@ FROM ubuntu:22.04
 # Proxy is only consumed during build (predefined ARG, not persisted in the image).
 ARG http_proxy=
 ARG https_proxy=
-ARG FLAGTREE_REF=0.6.0
+# FlagTree git tag/ref to build (the single version knob).
+ARG FLAGTREE_VERSION=0.6.0
 # Clean version + lean build, matching FlagTree's official nv-delivery CI:
-#  - FLAGTREE_WHEEL_VERSION sets the wheel version; a clean (no +git<sha>) version
-#    also requires the secret FLAGTREE_PYPI_KEY (md5-gated in setup.py). Without the
-#    key you get "<ver>.git<sha>"; with nothing set you get "0.6.0+git<sha>".
+#  - FLAGTREE_WHEEL_VERSION is the env var FlagTree's setup.py reads for the wheel
+#    version; it defaults to FLAGTREE_VERSION so one arg drives both. A clean
+#    (no +git<sha>) version also requires the secret FLAGTREE_PYPI_KEY (md5-gated
+#    in setup.py). Without the key you get "<ver>.git<sha>"; with nothing set you
+#    get "0.6.0+git<sha>".
 #  - Release build type strips the .so and drops asserts (fixes the ~840 MB
 #    unstripped libtriton.so -> ~150 MB).
-ARG FLAGTREE_WHEEL_VERSION=0.6.0
+ARG FLAGTREE_WHEEL_VERSION=${FLAGTREE_VERSION}
 ARG FLAGTREE_PYPI_KEY=
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -65,7 +68,7 @@ RUN python3.12 -m ensurepip --upgrade \
 # network-heavy steps.
 RUN git config --global http.version HTTP/1.1 \
     && for i in 1 2 3 4 5 6 7 8; do \
-         git clone --branch "${FLAGTREE_REF}" --depth 1 \
+         git clone --branch "${FLAGTREE_VERSION}" --depth 1 \
            https://github.com/flagos-ai/flagtree /opt/flagtree && break; \
          echo ">>> flagtree clone attempt $i failed, retrying in 5s..."; \
          rm -rf /opt/flagtree; sleep 5; \


### PR DESCRIPTION
## What

Unify the FlagTree builders' version knob to a single `FLAGTREE_VERSION` arg.

Previously the two Containerfiles spelled the clone ref differently — `nvidia-cuda` used `FLAGTREE_REF`, `metax` used `FLAGTREE_TAG` — and each also carried a `FLAGTREE_WHEEL_VERSION` whose default just duplicated the ref. The `flagtree-wheel.yml` workflow couldn't set the version at all; it always used the Containerfile default.

## Changes

- **`FLAGTREE_VERSION`** — one arg, the git tag/ref to build, in both builders.
- **`FLAGTREE_WHEEL_VERSION`** now defaults to `${FLAGTREE_VERSION}`. It's kept because it's the env var FlagTree's `setup.py` reads for the wheel label, but callers normally set only `FLAGTREE_VERSION`.
- **`flagtree-wheel.yml`** gains a `flagtree_version` dispatch input, passed uniformly as a single `--build-arg`; blank keeps the Containerfile default for the target.
- `FLAGTREE_PYPI_KEY` unchanged. README build-args section updated.

## Test

- `grep` confirms no `FLAGTREE_REF` / `FLAGTREE_TAG` remain.
- Workflow YAML validates.
- Not yet run through a full CI container build (heavy LLVM pull + compile on the metax node).

This PR was written in part with the assistance of generative AI.
