### PR TITLE
fix(flagtree-wheel): upgrade pkginfo in upload step for Metadata-Version 2.4

### DIFF
--- a/.github/workflows/flagtree-wheel.yml
+++ b/.github/workflows/flagtree-wheel.yml
@@ -118,9 +118,12 @@ jobs:
           pypi_repo="${pypi_repo:-flagos-pypi-${vendor}}"
           echo ">>> uploading $(ls wheels/*.whl) to ${pypi_repo}"
           # Self-hosted Python is PEP 668 externally-managed; install to the user
-          # site with the override (matches imagebuild.yml).
-          python3 -m pip install --user --break-system-packages --quiet twine \
-            || python3 -m pip install --quiet twine
+          # site with the override (matches imagebuild.yml). Upgrade pkginfo too:
+          # setuptools >=77 (PEP 639) stamps Metadata-Version 2.4 into the wheel,
+          # which older pkginfo can't parse ("Metadata is missing required fields:
+          # Name, Version") -> twine aborts before upload. pkginfo >=1.11 reads 2.4.
+          python3 -m pip install --user --break-system-packages --quiet --upgrade twine pkginfo \
+            || python3 -m pip install --quiet --upgrade twine pkginfo
           export TWINE_USERNAME="${NEXUS_TOKEN%%:*}"
           export TWINE_PASSWORD="${NEXUS_TOKEN#*:}"
           python3 -m twine upload \


### PR DESCRIPTION
## What

Make the `flagtree-wheel.yml` `upload=true` leg actually work against the current build toolchain.

## Why

The builders `pip install --upgrade setuptools`, which pulls setuptools >=77 (PEP 639). That stamps `Metadata-Version: 2.4` into the wheel's `METADATA`. An older `pkginfo` (what twine uses to read distribution metadata) only understands up to 2.2, so it parses Name/Version as empty and twine aborts:

```
ERROR InvalidDistribution: Metadata is missing required fields: Name, Version.
```

This surfaced during a manual upload of the metax wheel. The wheel itself is standards-correct — the failure is purely a stale-parser gap on the upload side.

## Change

Upload step now `pip install --upgrade twine pkginfo` (was `twine` only). `pkginfo >= 1.11` reads Metadata-Version 2.4, so the upload succeeds without pinning the build toolchain down to accommodate an old client.

## Test

- Workflow YAML validates.
- Not yet exercised via a live `upload=true` dispatch (that publishes to the vendor index).

This PR was written in part with the assistance of generative AI.
