### PR TITLE
fix(flagtree-metax): pin pybind11 to v11 ABI for prebuilt plugin

### DIFF
--- a/flagtree-builder/README.md
+++ b/flagtree-builder/README.md
@@ -37,6 +37,18 @@ is built on Ubuntu 24.04 and links `libtriton.so` against `GLIBC_2.38` +
 **objdump gate fails the build** if any 22.04-incompatible symbol
 (`GLIBC_2.38`, `GLIBCXX_3.4.31/32`, `__isoc23_*`) reappears in `libtriton.so`.
 
+It also **pins pybind11** (`PYBIND11_SPEC`, default `>=3.0,<3.1`) because that is
+an ABI contract, not just a dependency. The prebuilt `metaxTritonPlugin.so` is
+compiled against pybind11 internals **v11**; `libtriton.so` and the plugin share
+pybind11 type registries only when their internals versions match. FlagTree
+requires only `pybind11>=2.13.1` (no upper bound), so an unpinned build pulls
+pybind11 3.1.0 — which bumped the internals version to **v12** — and the wheel
+imports fine but fails on real MetaX hardware at kernel-compile time with
+`metax.load_dialects(ctx)` → `TypeError: incompatible function arguments`. The
+CI smoke test (`import triton`) runs on a GPU-less box and cannot catch this, so
+the gate additionally **asserts libtriton's pybind11 internals are v11**
+(verified on metax124: v11 → `test_abs.py` 36/36 pass; v12 → 36/36 fail).
+
 ## Build
 
 Run from inside this folder:

--- a/flagtree-builder/metax
+++ b/flagtree-builder/metax
@@ -57,6 +57,17 @@ ARG DEPS_BASE=https://baai-cp-web.ks3-cn-beijing.ksyuncs.com/trans
 ARG LLVM_TARBALL=metax-llvm19-3.8.0.6-x86_64_v0.6.0.tar.gz
 ARG PLUGIN_TARBALL=metaxTritonPlugin-cpython3.12-x86_64_v0.6.1.tar.gz
 ARG TRITON_DEPS_TARBALL=build-deps-triton_3.6.x-linux-x64.tar.gz
+# pybind11 version spec, pinned. FlagTree's build-system requires only
+# "pybind11>=2.13.1" (no upper bound), so a plain build pulls whatever pybind11
+# is newest -- and pybind11 3.1.0 bumped PYBIND11_INTERNALS_VERSION 11 -> 12.
+# libtriton and the prebuilt metaxTritonPlugin.so share pybind11 type registries
+# only when their internals versions match; the plugin is compiled against v11,
+# so a v12 libtriton makes `metax.load_dialects(ctx)` raise
+# "TypeError: incompatible function arguments" at kernel-compile time on real
+# MetaX hardware (the CI smoke test can't catch it -- no GPU). Pinning to the
+# v11 range (FlagTree's own _PYBIND11_INTERNALS_TO_PIP maps 11 -> ">=3.0,<3.1")
+# keeps libtriton binary-compatible with the plugin. The gate below asserts v11.
+ARG PYBIND11_SPEC=>=3.0,<3.1
 ENV DEBIAN_FRONTEND=noninteractive
 
 # System build deps for the LLVM/Triton native build + Python 3.12 (deadsnakes).
@@ -111,6 +122,7 @@ RUN git config --global http.version HTTP/1.1 \
     && test -d /opt/flagtree/.git \
     && cd /opt/flagtree \
     && python3.12 -m pip install --no-cache-dir -r python/requirements.txt \
+    && python3.12 -m pip install --no-cache-dir "pybind11${PYBIND11_SPEC}" \
     && export FLAGTREE_BACKEND=metax \
     && export FLAGTREE_WHEEL_VERSION="${FLAGTREE_WHEEL_VERSION}" \
     && export TRITON_APPEND_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release" \
@@ -146,6 +158,20 @@ if hits:
     sys.exit(1)
 maxglibc = max(sorted(set(__import__("re").findall(r"GLIBC_[0-9.]+", syms))))
 print(f"OK: libtriton.so is 22.04-clean (max {maxglibc}, no forbidden symbols)")
+# pybind11 ABI gate: the prebuilt metaxTritonPlugin.so is compiled against
+# pybind11 internals v11. libtriton MUST expose the same internals version or
+# `metax.load_dialects(ctx)` fails on-device with a pybind11 type mismatch
+# (verified on metax124: v11 -> test_abs 36/36 pass; v12 -> 36/36 fail). The
+# PYBIND11_SPEC pin above holds this at v11; assert it here so a future drift
+# fails the build instead of shipping a wheel that only breaks on hardware.
+with open(so, "rb") as f:
+    blob = f.read()
+internals = sorted(set(__import__("re").findall(rb"__pybind11_internals_v(\d+)", blob)))
+if internals != [b"11"]:
+    print(f"FAIL: libtriton.so pybind11 internals {internals} (expected [b'11']; "
+          "plugin needs v11 -- adjust PYBIND11_SPEC)")
+    sys.exit(1)
+print("OK: libtriton.so pybind11 internals v11 (matches metaxTritonPlugin.so)")
 PY
 
 # Smoke test: install the freshly built wheel and import it (fails the build if broken).


### PR DESCRIPTION
## What

Pin pybind11 to the v11-internals range in `flagtree-builder/metax` and
assert it in the build gate, so the rebuilt MetaX wheel is
binary-compatible with the prebuilt `metaxTritonPlugin.so`.

## Why

The 22.04 rebuild (PR #362) cleared the `GLIBC_2.38` blocker, but the
resulting wheel still failed on real MetaX hardware: every FlagGems
kernel test aborted at compile time with

```
metax.load_dialects(ctx)
TypeError: load_dialects(): incompatible function arguments.
    supported: (arg0: mlir::MLIRContext) -> None
    invoked with: <triton._C.libtriton.ir.context object ...>
```

This is a **pybind11 ABI mismatch**, not a GLIBC issue. FlagTree's
build-system requires only `pybind11>=2.13.1` (no upper bound), so an
unpinned build pulls pybind11 3.1.0, which bumped
`PYBIND11_INTERNALS_VERSION` 11 → 12. The prebuilt plugin is compiled
against internals **v11**; two pybind11 modules share type registries
only within the same internals version, so a v12 libtriton can't hand an
`MLIRContext` to the v11 plugin. The wheel imports fine — the CI smoke
test runs GPU-less — so the break only appears on-device.

## Fix

- `ARG PYBIND11_SPEC=>=3.0,<3.1` (FlagTree's own `_PYBIND11_INTERNALS_TO_PIP`
  maps v11 → this range), installed after `requirements.txt`.
- Build gate extended to assert `libtriton.so` exposes
  `__pybind11_internals_v11`; drift fails the build rather than shipping a
  wheel that only breaks on hardware.
- README documents pybind11 as an ABI pin.

## Verified

On metax124, into the FlagGems `.venv`:

- our v11 wheel → `pytest tests/test_abs.py` → **36 passed**
  (v12 wheel was 36 failed)
- `libtriton.so` still GLIBC-clean (max `GLIBC_2.34`, zero forbidden
  symbols) and reports `__pybind11_internals_v11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
