### PR TITLE
feat(megatron-builder): build megatron-core wheels via a reusable toolchain image

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -25,6 +25,11 @@ registry:
   prefixes:
     base: flagos-base
     runtime: flagos-runtime
+    # Builder toolchain images all live in the shared flagos-dev project; the
+    # tool + python is the repository (megatron-builder-py310/311/312 today, and
+    # the future transformerengine-builder-*, verl-builder-*, vllm-builder-*,
+    # sglang-builder-* ...).
+    builder: flagos-dev
     # app: <prefix>       # TODO: fill in when app image CI lands
 
 # Which runner builds each image (base containerfile name -> runs-on).

--- a/.github/workflows/megatron-builder-image.yml
+++ b/.github/workflows/megatron-builder-image.yml
@@ -1,0 +1,165 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Megatron Builder Image (manual)
+
+# Build the reusable megatron-builder toolchain image (megatron-builder/
+# Containerfile stage "toolchain") for one or all Python versions, optionally
+# pushing to Harbor.
+#
+# This is the EXPENSIVE layer (apt + deadsnakes + build-deps pins). It is meant
+# to be built rarely — only when the pins change — and reused by every
+# megatron-wheel.yml build via BASE_IMAGE, instead of each wheel build
+# installing everything from scratch (the flagtree-builder pain point).
+
+on:
+  workflow_dispatch:
+    inputs:
+      python:
+        description: 'Python version(s) for the toolchain image'
+        type: choice
+        options:
+          - all
+          - '3.10'
+          - '3.11'
+          - '3.12'
+        default: all
+      push:
+        description: 'Push image(s) to the registry'
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/check-trigger-author
+
+  set-matrix:
+    needs: authorize
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: set-matrix
+        shell: bash
+        run: |
+          if [[ "${{ inputs.python }}" == "all" ]]; then
+            pyvers="3.10 3.11 3.12"
+          else
+            pyvers="${{ inputs.python }}"
+          fi
+          matrix='{"include":['
+          for py in $pyvers; do
+            pynodot=${py//./}
+            matrix+="{\"py\":\"$py\",\"pynodot\":\"$pynodot\"},"
+          done
+          matrix="${matrix%,}]}"
+          echo "$matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: set-matrix
+    if: ${{ fromJSON(needs.set-matrix.outputs.matrix).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    runs-on: [self-hosted, h20]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Install PyYAML
+        # Self-hosted runners (h20) have an externally-managed system Python
+        # (PEP 668) that rejects `pip install`. Skip if PyYAML is already
+        # importable; otherwise install to the user site with the override.
+        run: |
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages pyyaml
+
+      # Tag = configs.yaml version (same flat tag convention as base/runtime
+      # images; a rebuilt toolchain overwrites the tag during a release cycle).
+      - name: Resolve version and registry
+        id: resolve
+        run: |
+          version=$(python3 -c "import yaml;print(yaml.safe_load(open('configs.yaml'))['version'])")
+          host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
+          builder=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['builder'])")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "host=${host}" >> "$GITHUB_OUTPUT"
+          echo "builder=${builder}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to the Container registry
+        if: ${{ inputs.push }}
+        env:
+          HARBOR_USER: ${{ secrets.HARBOR_USER }}
+          HARBOR_PW: ${{ secrets.HARBOR_PASSWORD }}
+          # Harbor is internal — bypass any HTTP_PROXY/HTTPS_PROXY the runner
+          # may have set for GitHub access. Only uppercase HTTP_PROXY/HTTPS_PROXY
+          # (lowercase clash with runner env vars set by the runner config).
+          HTTP_PROXY: ""
+          HTTPS_PROXY: ""
+          no_proxy: "harbor.baai.ac.cn,.baai.ac.cn"
+        run: |
+          if [ -z "${HARBOR_PW:-}" ]; then
+            echo "ERROR: secret HARBOR_PASSWORD is empty or unset" >&2
+            exit 1
+          fi
+          for i in 1 2 3; do
+            if printf '%s' "${HARBOR_PW}" | docker login "${{ steps.resolve.outputs.host }}" -u "${HARBOR_USER}" --password-stdin; then
+              exit 0
+            fi
+            echo "Harbor login attempt $i failed, retrying in 30s..."
+            sleep 30
+          done
+          echo "::error::Harbor login failed after 3 attempts"
+          exit 1
+
+      - name: Check disk space
+        run: |
+          FREE_KB=$(df -P . | awk 'NR==2{print $4}')
+          FREE_GB=$((FREE_KB / 1024 / 1024))
+          echo "Free disk space: ${FREE_GB}G"
+          if [ "$FREE_GB" -lt 10 ]; then
+            echo "ERROR: insufficient disk space (${FREE_GB}G < 10G). Docker needs cleanup."
+            df -h .
+            exit 1
+          fi
+
+      - name: Build the toolchain image
+        working-directory: megatron-builder
+        env:
+          IMAGE: "${{ steps.resolve.outputs.host }}/${{ steps.resolve.outputs.builder }}/megatron-builder-py${{ matrix.pynodot }}:${{ steps.resolve.outputs.version }}"
+        run: |
+          set -euo pipefail
+          docker build --target toolchain \
+            --build-arg PYTHON_VERSION=${{ matrix.py }} \
+            -t "$IMAGE" \
+            -f Containerfile .
+
+      - name: Push the toolchain image
+        if: ${{ inputs.push }}
+        run: |
+          set -euo pipefail
+          docker push "${{ steps.resolve.outputs.host }}/${{ steps.resolve.outputs.builder }}/megatron-builder-py${{ matrix.pynodot }}:${{ steps.resolve.outputs.version }}"

--- a/.github/workflows/megatron-wheel.yml
+++ b/.github/workflows/megatron-wheel.yml
@@ -1,0 +1,195 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Megatron wheel
+
+# Build megatron-core wheels from the Megatron-LM-FL fork for one or all Python
+# versions, and (optionally) upload them to the internal PyPI.
+#
+# megatron-core ships a compiled extension (megatron.core.datasets.helpers_cpp),
+# so wheels are CPython-ABI-specific: cp310 / cp311 / cp312. All three must be
+# uploaded — the runtime matrix uses 3.10 (kunlunxin, hygon, ...), 3.11 (ascend)
+# and 3.12 (nvidia, metax, enflame, ...).
+#
+# Each build starts from the pushed megatron-builder toolchain image
+# (megatron-builder-image.yml) via BASE_IMAGE — the apt/pip setup is not
+# repeated per build. The Containerfile's own gates (.so-in-wheel, smoke test,
+# requires-python patch) fail `docker build` on a broken wheel, so a bad wheel
+# never reaches the extract/upload steps.
+#
+# Upload target defaults to flagos-pypi-hosted (the release repo;
+# flagos-pypi-daily is the dev repo). There is no schedule: uploads are manual.
+
+on:
+  workflow_dispatch:
+    inputs:
+      python:
+        description: 'Python version(s) for the wheel'
+        type: choice
+        options:
+          - all
+          - '3.10'
+          - '3.11'
+          - '3.12'
+        default: all
+      mlf_ref:
+        description: 'Megatron-LM-FL git ref to build (branch/tag)'
+        type: string
+        default: main
+      mlf_version:
+        description: 'Wheel version override (blank = repo version, e.g. 0.17.1.post20260812)'
+        type: string
+        default: ''
+      upload:
+        description: 'upload the wheel to the internal PyPI'
+        type: boolean
+        default: false
+      pypi_repo:
+        description: 'Nexus PyPI repo (default flagos-pypi-hosted)'
+        type: string
+        default: flagos-pypi-hosted
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/check-trigger-author
+
+  set-matrix:
+    needs: authorize
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: set-matrix
+        shell: bash
+        run: |
+          if [[ "${{ inputs.python }}" == "all" ]]; then
+            pyvers="3.10 3.11 3.12"
+          else
+            pyvers="${{ inputs.python }}"
+          fi
+          matrix='{"include":['
+          for py in $pyvers; do
+            pynodot=${py//./}
+            matrix+="{\"py\":\"$py\",\"pynodot\":\"$pynodot\"},"
+          done
+          matrix="${matrix%,}]}"
+          echo "$matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: set-matrix
+    if: ${{ fromJSON(needs.set-matrix.outputs.matrix).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    runs-on: [self-hosted, h20]
+    env:
+      IMAGE: megatron-wheel-py${{ matrix.pynodot }}:${{ github.run_id }}
+    steps:
+      - name: Checkout build-infra
+        uses: actions/checkout@v7
+
+      - name: Install PyYAML
+        # Self-hosted runners (h20) have an externally-managed system Python
+        # (PEP 668) that rejects `pip install`. Skip if PyYAML is already
+        # importable; otherwise install to the user site with the override.
+        run: |
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages pyyaml
+
+      - name: Resolve version and registry
+        id: resolve
+        run: |
+          version=$(python3 -c "import yaml;print(yaml.safe_load(open('configs.yaml'))['version'])")
+          host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
+          builder=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['builder'])")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "host=${host}" >> "$GITHUB_OUTPUT"
+          echo "builder=${builder}" >> "$GITHUB_OUTPUT"
+
+      - name: Build the wheel image
+        working-directory: megatron-builder
+        env:
+          BASE_IMAGE: "${{ steps.resolve.outputs.host }}/${{ steps.resolve.outputs.builder }}/megatron-builder-py${{ matrix.pynodot }}:${{ steps.resolve.outputs.version }}"
+          MLF_REF: ${{ inputs.mlf_ref }}
+          MLF_VERSION: ${{ inputs.mlf_version }}
+        run: |
+          set -euo pipefail
+          # Requires-python patch, .so-in-wheel gate and smoke test run inside
+          # this build; a failure here means the wheel is broken and must not
+          # be published.
+          docker build \
+            --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+            --build-arg PYTHON_VERSION=${{ matrix.py }} \
+            --build-arg MLF_REF="${MLF_REF}" \
+            --build-arg MLF_VERSION="${MLF_VERSION}" \
+            -t "$IMAGE" \
+            -f Containerfile .
+
+      - name: Extract the wheel
+        working-directory: megatron-builder
+        run: |
+          set -euo pipefail
+          rm -rf wheels && mkdir -p wheels
+          cid=$(docker create "$IMAGE")
+          docker cp "$cid:/wheels/." wheels/
+          docker rm "$cid" >/dev/null
+          ls -la wheels/*.whl
+
+      # Upload only when explicitly requested (default false so a manual build
+      # from a branch is safe). The wheel is published as-is — the build gates
+      # already vetted it.
+      - name: Upload to internal PyPI
+        if: ${{ inputs.upload }}
+        working-directory: megatron-builder
+        env:
+          NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEXUS_TOKEN:-}" ]; then
+            echo "ERROR: NEXUS_TOKEN secret is empty or unset" >&2
+            exit 1
+          fi
+          pypi_repo="${{ inputs.pypi_repo }}"
+          pypi_repo="${pypi_repo:-flagos-pypi-hosted}"
+          echo ">>> uploading $(ls wheels/*.whl) to ${pypi_repo}"
+          # Self-hosted Python is PEP 668 externally-managed; install to the user
+          # site with the override (matches imagebuild.yml). Upgrade pkginfo too:
+          # setuptools >=77 (PEP 639) stamps Metadata-Version 2.4 into the wheel,
+          # which older pkginfo can't parse ("Metadata is missing required fields:
+          # Name, Version") -> twine aborts before upload. pkginfo >=1.11 reads 2.4.
+          python3 -m pip install --user --break-system-packages --quiet --upgrade twine pkginfo \
+            || python3 -m pip install --quiet --upgrade twine pkginfo
+          export TWINE_USERNAME="${NEXUS_TOKEN%%:*}"
+          export TWINE_PASSWORD="${NEXUS_TOKEN#*:}"
+          python3 -m twine upload \
+            --repository-url "https://resource.flagos.net/repository/${pypi_repo}/" \
+            --non-interactive \
+            wheels/*.whl
+
+      - name: Clean up the build image
+        if: ${{ always() }}
+        run: docker rmi "$IMAGE" 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ It builds three layers for 13+ GPU/NPU vendors:
 |---|---|---|
 | **Base images** | Vendor SDK + toolchain on Ubuntu 24.04 | `base/<vendor>-<backend>` Containerfiles |
 | **Runtime images** | Base + Python venv + FlagGems + compilers (FlagTree/Triton) | `runtime/Containerfile` (one for all) |
-| **Wheels** | FlagTree (C++ compiler) + FlagGems (pure Python) | `flagtree-builder/`, `flaggems-builder/` |
+| **Wheels** | FlagTree (C++ compiler) + FlagGems (pure Python) + Megatron-LM-FL (pybind11 ext) | `flagtree-builder/`, `flaggems-builder/`, `megatron-builder/` |
 
 ## Key commands
 
@@ -83,6 +83,8 @@ Two stages: **builder** (installs uv, venv, deps, compilers, FlagGems wheel) →
 - **`trigger.yml`** — Base Image Build (manual). `workflow_dispatch` with backend + push inputs. Generates matrix via `generate_matrix.py`, calls reusable `imagebuild.yml` per backend.
 - **`runtime.yml`** — Runtime Image Build (manual). Same pattern, additionally checks out FlagGems repo for version derivation.
 - **`flaggems-wheel.yml`** — Daily (01:17 UTC) + manual FlagGems wheel build + upload to `flagos-pypi-daily` via twine.
+- **`megatron-builder-image.yml`** — Manual. Builds the reusable `megatron-builder` toolchain image (apt + deadsnakes Python + build-deps pins) for py3.10/3.11/3.12, optional Harbor push. Built rarely — only when the pins change; every megatron wheel build reuses it via `BASE_IMAGE` (see `megatron-builder/Containerfile`).
+- **`megatron-wheel.yml`** — Manual (no schedule; release repo). Builds megatron-core wheels from Megatron-LM-FL (`MLF_REF` input) for py3.10/3.11/3.12, FROM the toolchain image, uploads to `flagos-pypi-hosted` via twine when `upload=true`. All three cp-version wheels must be uploaded — the package ships a compiled `helpers_cpp` extension.
 - **`gendoc-base.yaml`** — Triggered on base image build completion. Extracts system package versions from built images (`dpkg-query`), runs `gen_data.py` + `gen_descriptions.py`, opens a **review-gated PR** with the version diff. Publication to Harbor (`pubdoc-base.yaml`) only happens when that PR lands on `main` (push to `base/*.md`).
 - **`gendoc-runtime.yaml`** — Runtime twin of `gendoc-base.yaml` (manual trigger; runtime images rebuild often during FlagGems testing, so no auto `workflow_run`). Opens a review-gated PR with `runtime/*.md`. Publication to Harbor (`pubdoc-runtime.yaml`) happens when that PR lands on `main` (push to `runtime/*.md`).
 - **`hugo-site.yaml`** — Builds + deploys docs site to GitHub Pages (triggered on push to `main` when `docs/**`, `configs.yaml`, or `base/**` changes).

--- a/megatron-builder/Containerfile
+++ b/megatron-builder/Containerfile
@@ -1,0 +1,166 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build Megatron-LM-FL (megatron-core) wheels — one wheel per CPython ABI.
+#
+# The package ships a compiled extension (megatron.core.datasets.helpers_cpp),
+# so every wheel is cp-version-specific: cp310 / cp311 / cp312. The runtime
+# matrix uses Python 3.10 (kunlunxin, hygon, ...), 3.11 (ascend) and 3.12
+# (nvidia, metax, enflame, ...), so all three wheels must be built.
+#
+# Two stages:
+#   toolchain — Ubuntu 22.04 (glibc 2.35, so the .so loads on older-glibc
+#               nodes) + deadsnakes Python + the exact build deps. This is the
+#               expensive apt/pip work; build it ONCE per Python version and
+#               push to Harbor, then every wheel build starts from it (no
+#               re-installing everything from scratch — the flagtree-builder
+#               pain point).
+#   wheel     — clones Megatron-LM-FL at a ref, patches requires-python on the
+#               fly (>=3.12 -> >=3.10), stamps an optional version override,
+#               builds the wheel. Output -> /wheels.
+#
+# Build:
+#   # toolchain (once per Python version):
+#   docker build --target toolchain --build-arg PYTHON_VERSION=3.12 \
+#       -t <host>/flagos-dev/megatron-builder-py312:<version> .
+#   # wheel (per ref):
+#   docker build --build-arg BASE_IMAGE=<toolchain image> \
+#       --build-arg MLF_REF=<ref> -t megatron-wheel:py312 .
+#   # extract:
+#   cid=$(docker create megatron-wheel:py312); docker cp $cid:/wheels/. ./wheels; docker rm $cid
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — toolchain (reusable, built rarely, pushed to Harbor)
+# ════════════════════════════════════════════════════════════════
+FROM ubuntu:22.04 AS toolchain
+
+# Proxy is only consumed during build (predefined ARG, not persisted).
+ARG http_proxy=
+ARG https_proxy=
+# Python version for the toolchain + wheel: 3.10 / 3.11 / 3.12 (the per-wheel knob).
+ARG PYTHON_VERSION=3.12
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System build deps + Python (deadsnakes covers 3.10/3.11/3.12 on 22.04).
+# gnupg/dirmngr are needed by add-apt-repository to import the PPA key.
+# unzip is for the .so-in-wheel gate in stage 2.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common ca-certificates gnupg dirmngr \
+        git wget curl unzip \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        python${PYTHON_VERSION} python${PYTHON_VERSION}-venv python${PYTHON_VERSION}-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# pip for the deadsnakes Python (ensurepip ships via the python*-venv package).
+RUN python${PYTHON_VERSION} -m ensurepip --upgrade \
+    && python${PYTHON_VERSION} -m pip install --no-cache-dir --upgrade pip wheel setuptools
+
+# Build deps for megatron.core.datasets.helpers_cpp. These are ABI contracts,
+# not just versions:
+#  - pybind11==3.0.3: matches configs.yaml runtime_prereqs. pybind11 type
+#    registries are shared between the .so and the runtime's own pybind11, and
+#    a version mismatch (3.1.0 bumped internals to v12) breaks the extension at
+#    call time — the exact flagtree-builder lesson.
+#  - numpy==1.26.4: build against numpy 1.x headers so the .so runs on BOTH
+#    numpy 1.x and 2.x runtimes (a 2.x-built .so requires numpy>=2). hygon
+#    pins numpy==1.26.4, so this is the lowest common denominator.
+#  - setuptools<80 + packaging>=24.2: match pyproject.toml build-system
+#    requires, needed because the wheel builds with --no-build-isolation.
+RUN python${PYTHON_VERSION} -m pip install --no-cache-dir \
+        "setuptools<80.0.0" \
+        "wheel" \
+        "pybind11==3.0.3" \
+        "numpy==1.26.4" \
+        "packaging>=24.2"
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — wheel (every wheel build starts here)
+# ════════════════════════════════════════════════════════════════
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG PYTHON_VERSION=3.12
+# Megatron-LM-FL source (branch or tag — --branch clone below).
+ARG MLF_REPO=https://github.com/flagos-ai/Megatron-LM-FL.git
+ARG MLF_REF=main
+# Optional wheel-version override (e.g. 0.17.1.post20260812); blank = the
+# repo's own version (0.17.1). Handled by stamp_version.py.
+ARG MLF_VERSION=
+
+COPY stamp_version.py /usr/local/bin/stamp_version.py
+
+# Clone (retry loop, flagtree idiom). Force HTTP/1.1 for git.
+RUN git config --global http.version HTTP/1.1 \
+    && for i in 1 2 3 4 5 6 7 8; do \
+         git clone --branch "${MLF_REF}" --depth 1 "${MLF_REPO}" /opt/megatron-lm-fl && break; \
+         echo ">>> megatron clone attempt $i failed, retrying in 5s..."; \
+         rm -rf /opt/megatron-lm-fl; sleep 5; \
+       done \
+    && test -d /opt/megatron-lm-fl/.git
+
+# Requires-Python >=3.12 (upstream's uv-sync bump in the 0.17.0 sync) makes pip
+# refuse the wheel on the py3.10/py3.11 runtimes. Patch it ON THE FLY before
+# building so the wheel installs everywhere. The fork repo itself stays
+# untouched — relaxing it there is a proposed follow-up once this path is
+# verified end to end. The grep gate fails the build if the patch didn't land
+# (i.e. the source moved on and now ships a different requires-python).
+RUN cd /opt/megatron-lm-fl \
+    && sed -i 's/^requires-python = ">=3\.12"$/requires-python = ">=3.10"/' pyproject.toml \
+    && grep -n 'requires-python' pyproject.toml \
+    && grep -q 'requires-python = ">=3.10"' pyproject.toml
+
+# Optional wheel-version stamp (no-op when MLF_VERSION is blank).
+RUN MLF_VERSION="${MLF_VERSION}" python${PYTHON_VERSION} /usr/local/bin/stamp_version.py
+
+# Build the wheel. --no-build-isolation uses the toolchain env (setuptools,
+# pybind11, numpy, packaging already present). --no-deps is essential: pip wheel
+# would otherwise try to build a torch wheel from PyPI.
+RUN cd /opt/megatron-lm-fl \
+    && for i in 1 2 3 4 5; do \
+         python${PYTHON_VERSION} -m pip wheel . --no-deps --no-build-isolation -w /wheels -v && break; \
+         echo ">>> wheel build attempt $i failed, retrying in 10s..."; sleep 10; \
+       done \
+    && ls -la /wheels/*.whl
+
+# Anti-silent-skip gate: helpers_cpp is declared optional=True in setup.py, so a
+# failed compile is skipped silently — but megatron/core/datasets/helpers.py
+# imports it unconditionally at runtime, so a wheel without the .so is broken.
+# Fail the build here instead of shipping a broken wheel.
+RUN unzip -l /wheels/*.whl | grep -q 'helpers_cpp.*\.so' \
+    || { echo "ERROR: helpers_cpp .so missing from the wheel (compile failed?)" >&2; exit 1; }
+
+# Smoke test: install the wheel and load helpers_cpp directly. Importing
+# megatron.core would pull in torch, which the build env intentionally lacks;
+# loading the .so with importlib executes the pybind11 init and proves the
+# extension is loadable and its functions are bound.
+RUN python${PYTHON_VERSION} -m pip install --no-cache-dir --no-deps /wheels/*.whl \
+    && python${PYTHON_VERSION} - <<'PY'
+import importlib.metadata
+import importlib.util
+import sys
+
+dist = importlib.metadata.distribution('megatron-core')
+root = dist.locate_file('')
+so = sorted((root / 'megatron/core/datasets').glob('helpers_cpp*.so'))
+assert so, "helpers_cpp .so not found in the installed wheel"
+spec = importlib.util.spec_from_file_location('helpers_cpp', str(so[0]))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+assert callable(mod.build_sample_idx_int32), "build_sample_idx_int32 not bound"
+assert callable(mod.build_sample_idx_int64), "build_sample_idx_int64 not bound"
+assert callable(mod.build_exhaustive_blending_indices), "build_exhaustive_blending_indices not bound"
+print('OK helpers_cpp', mod.__file__)
+PY

--- a/megatron-builder/README.md
+++ b/megatron-builder/README.md
@@ -1,0 +1,151 @@
+<!--
+ Copyright 2026 FlagOS Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# megatron-builder
+
+Builds **megatron-core** wheels from the [Megatron-LM-FL](https://github.com/flagos-ai/Megatron-LM-FL)
+fork, for single-command install into the pre-built `flagos-runtime-{vendor}-{backend}`
+images.
+
+## Why per-Python wheels
+
+`megatron-core` ships a compiled extension, `megatron.core.datasets.helpers_cpp`.
+Every wheel is therefore CPython-ABI-specific — **cp310 / cp311 / cp312**, never
+`py3-none-any` — and all three must be built and uploaded, because the runtime
+matrix uses all three Pythons:
+
+| Python | Vendors                                                        |
+|--------|----------------------------------------------------------------|
+| 3.10   | kunlunxin, hygon, mthreads, iluvatar, tsingmicro               |
+| 3.11   | ascend                                                         |
+| 3.12   | nvidia, metax, enflame                                         |
+
+`helpers_cpp` is **mandatory, not optional**: `megatron/core/datasets/helpers.py`
+imports it unconditionally, yet `setup.py` declares the extension
+`optional=True`. A failed compile is silently skipped, producing a broken wheel.
+The Containerfile gates on the `.so` being inside the wheel to catch this.
+
+## Two-layer build
+
+The expensive apt/pip setup is baked into a **toolchain image** once per Python
+version and pushed to Harbor, then every wheel build starts from it — no
+re-installing everything from scratch on each run (the flagtree-builder pain
+point).
+
+```
+megatron-builder/Containerfile
+ ├─ stage "toolchain"  →  FROM ubuntu:22.04 + deadsnakes Python + build deps  ← built ONCE, pushed
+ └─ stage "wheel"      →  FROM ${BASE_IMAGE=toolchain image}                  ← every wheel build
+```
+
+### 1. Toolchain image (rarely rebuilt)
+
+```sh
+# once per Python version; run from inside megatron-builder/
+VERSION=$(python3 -c "import yaml;print(yaml.safe_load(open('configs.yaml'))['version'])")
+docker build --target toolchain --build-arg PYTHON_VERSION=3.12 \
+    -t harbor.baai.ac.cn/flagos-dev/megatron-builder-py312:${VERSION} .
+docker push harbor.baai.ac.cn/flagos-dev/megatron-builder-py312:${VERSION}
+```
+
+Only rebuilt when the pins change. It contains, on **ubuntu:22.04** (glibc 2.35,
+so the `.so` loads on older-glibc nodes):
+
+- `python3.{10,11,12}` via deadsnakes, `build-essential`, `git`, `unzip`
+- `setuptools<80.0.0 wheel pybind11==3.0.3 numpy==1.26.4 packaging>=24.2`
+
+**pybind11 and numpy are ABI contracts, not just versions:**
+
+- **pybind11==3.0.3** matches the runtime images' pin (`runtime_prereqs` /
+  `flaggems_cpp_build_deps` in configs.yaml). `helpers_cpp` and the runtime's
+  own pybind11 share type registries, and a mismatch (3.1.0 bumped internals to
+  v12) breaks the extension at call time — the flagtree-builder lesson.
+- **numpy==1.26.4** (1.x headers): the `.so` then runs on both numpy 1.x and 2.x
+  runtimes, while a 2.x-built `.so` requires numpy≥2. hygon pins numpy==1.26.4,
+  so this is the lowest common denominator.
+
+### 2. Wheel stage (every build)
+
+```sh
+VERSION=$(python3 -c "import yaml;print(yaml.safe_load(open('configs.yaml'))['version'])")
+docker build \
+    --build-arg BASE_IMAGE=harbor.baai.ac.cn/flagos-dev/megatron-builder-py312:${VERSION} \
+    --build-arg MLF_REF=main \
+    -t megatron-wheel:py312 .
+cid=$(docker create megatron-wheel:py312)
+docker cp $cid:/wheels/. ./wheels
+docker rm $cid
+ls wheels/*.whl   # megatron_core-0.17.1-cp312-cp312-linux_x86_64.whl
+```
+
+Useful build args:
+
+| ARG            | Default                              | Meaning                                        |
+|----------------|--------------------------------------|------------------------------------------------|
+| `BASE_IMAGE`   | *(required)*                         | The pushed toolchain image for this Python    |
+| `PYTHON_VERSION`| `3.12`                              | Must match the toolchain image's Python       |
+| `MLF_REPO`     | `https://github.com/flagos-ai/Megatron-LM-FL.git` | Source repo                  |
+| `MLF_REF`      | `main`                               | Branch or tag to build                        |
+| `MLF_VERSION`  | *(blank)*                            | Optional wheel-version override (e.g. `0.17.1.post20260812`); blank = the repo's own version (`0.17.1`) |
+
+The wheel stage: clones the fork, **patches `requires-python` on the fly**
+(`>=3.12` → `>=3.10`, see below), optionally stamps `MLF_VERSION` into
+`megatron/core/package_info.py` (`stamp_version.py`), builds with
+`pip wheel . --no-deps --no-build-isolation` (no uv, no lock file), then runs two
+gates:
+
+1. **`.so`-in-wheel gate** — `unzip -l /wheels/*.whl` must contain
+   `helpers_cpp*.so`; catches the silent `optional=True` skip.
+2. **Smoke test** — installs the wheel and loads `helpers_cpp` directly via
+   `importlib` (importing `megatron.core` would pull in torch, which the build
+   env intentionally lacks), asserting `build_sample_idx_*` are bound.
+
+## requires-python on the fly
+
+The fork's `pyproject.toml` declares `requires-python = ">=3.12"` (tightened from
+upstream's `>=3.10` in the 0.17.0 sync). pip enforces Requires-Python at install
+time, so the cp310/cp311 wheels would be refused on those runtimes. The wheel
+stage patches the source **after clone, before build**:
+
+```dockerfile
+RUN cd /opt/megatron-lm-fl \
+    && sed -i 's/^requires-python = ">=3\.12"$/requires-python = ">=3.10"/' pyproject.toml \
+    && grep -q 'requires-python = ">=3.10"' pyproject.toml
+```
+
+The fork repo is **not modified** by this. Relaxing it there is a proposed
+follow-up, once this end-to-end path is verified.
+
+## Single-command install
+
+Inside any `flagos-runtime-{vendor}-{backend}:{version}` container (the `/flagos`
+venv is on PATH):
+
+```bash
+pip install --no-deps megatron-core==0.17.1 \
+  --index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
+```
+
+- `--no-deps` is **mandatory**: torch/numpy/flagtree/triton are already pinned
+  per-backend in the image (and vendor-provided for triton/flagtree) — the
+  resolver must not touch them.
+- pip auto-selects the `cp310` / `cp311` / `cp312` wheel matching the image's
+  Python.
+- Verify:
+
+  ```bash
+  python -c "import megatron.core; print(megatron.core.__version__)"   # 0.17.1
+  ```

--- a/megatron-builder/stamp_version.py
+++ b/megatron-builder/stamp_version.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stamp the wheel version into Megatron-LM-FL's package_info.py.
+
+Reads MLF_VERSION from the environment (e.g. "0.17.1.post20260812"), parses it
+as MAJOR.MINOR.PATCH[<pre-release>] and rewrites the four static constants in
+``megatron/core/package_info.py``. Blank MLF_VERSION is a no-op (the repo's own
+version, e.g. 0.17.1, is used).
+
+package_info.py is a pure static module (no imports), so setuptools' dynamic
+``version = {attr = ...}`` resolves it via AST without importing anything —
+rewriting the constants is therefore safe in the torch-free build env.
+
+PEP 440 note: the module joins the version as
+``'.'.join(MAJOR.MINOR.PATCH) + PRE_RELEASE``, so a pre-release/stamp must carry
+its own leading separator: "0.17.1.post20260812" -> PRE_RELEASE = ".post20260812".
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+PACKAGE_INFO = Path("/opt/megatron-lm-fl/megatron/core/package_info.py")
+
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(.*)$")
+# Line-oriented replaces (package_info.py declares one constant per line).
+_CONST_RE = {
+    "MAJOR": re.compile(r"^MAJOR = .*$", re.M),
+    "MINOR": re.compile(r"^MINOR = .*$", re.M),
+    "PATCH": re.compile(r"^PATCH = .*$", re.M),
+    "PRE_RELEASE": re.compile(r'^PRE_RELEASE = .*$', re.M),
+}
+
+
+def main() -> int:
+    version = os.environ.get("MLF_VERSION", "")
+    if not version:
+        print("MLF_VERSION unset/blank — keeping the repo's own version")
+        return 0
+
+    m = _VERSION_RE.match(version)
+    if not m:
+        print(f"ERROR: MLF_VERSION '{version}' is not X.Y.Z[<pre-release>]", file=sys.stderr)
+        return 1
+    major, minor, patch, pre_release = m.groups()
+
+    src = PACKAGE_INFO.read_text()
+    src = _CONST_RE["MAJOR"].sub(f"MAJOR = {major}", src)
+    src = _CONST_RE["MINOR"].sub(f"MINOR = {minor}", src)
+    src = _CONST_RE["PATCH"].sub(f"PATCH = {patch}", src)
+    src = _CONST_RE["PRE_RELEASE"].sub(f'PRE_RELEASE = "{pre_release}"', src)
+    PACKAGE_INFO.write_text(src)
+
+    print(f"stamped version {version} into {PACKAGE_INFO}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# feat(megatron-builder): megatron-core wheels via a reusable toolchain image

## What

Builds **megatron-core** wheels from the [Megatron-LM-FL](https://github.com/flagos-ai/Megatron-LM-FL) fork so they can be installed into the pre-built `flagos-runtime-{vendor}-{backend}` images with a **single pip command** (`pip install --no-deps megatron-core==… --index-url …/flagos-pypi-hosted/simple`).

The wheel ships a compiled extension (`megatron.core.datasets.helpers_cpp`), so wheels are CPython-ABI-specific: **cp310 / cp311 / cp312** — all three must be built, because the runtime matrix uses 3.10 (kunlunxin, hygon, …), 3.11 (ascend), 3.12 (nvidia, metax, …).

## Design (WIP — validation pending)

Two-stage builder, mirroring the base → runtime layering:

- **toolchain stage** (built once per Python, pushed to `harbor.baai.ac.cn/flagos-dev/megatron-builder-py{310,311,312}:{version}`): ubuntu:22.04 (glibc 2.35) + deadsnakes Python + `setuptools<80 wheel pybind11==3.0.3 numpy==1.26.4 packaging`. This is the expensive apt/pip layer — built **rarely**, reused by every wheel build via `BASE_IMAGE` (no re-installing everything from scratch, the flagtree-builder pain point).
- **wheel stage** (every build): clone Megatron-LM-FL at a ref → **patch requires-python on the fly** (`>=3.12` → `>=3.10`, grep-gated; fork repo untouched for now) → optional `MLF_VERSION` stamp → `pip wheel . --no-deps --no-build-isolation` → two gates:
  1. **`.so`-in-wheel** — `setup.py` declares `helpers_cpp` `optional=True`, so a failed compile is silently skipped; the build fails if `helpers_cpp*.so` isn't in the wheel.
  2. **torch-free smoke test** — installs the wheel, loads `helpers_cpp*.so` via `importlib` (importing `megatron.core` would pull in torch, which the build env intentionally lacks), asserts the `build_sample_idx_*` symbols are bound.

Key ABI pins (rationale in `megatron-builder/README.md`): **pybind11==3.0.3** (matches the runtime images' pin — a 3.1.0 mismatch breaks the extension at call time) and **numpy==1.26.4** (1.x headers → the `.so` runs on both numpy 1.x and 2.x runtimes; hygon pins 1.26.4).

## Files

| File | Purpose |
|---|---|
| `megatron-builder/Containerfile` | two-stage build (toolchain + wheel) |
| `megatron-builder/stamp_version.py` | optional wheel-version override (`MLF_VERSION`) rewritten into `megatron/core/package_info.py` |
| `megatron-builder/README.md` | two-layer build, ABI rationale, build args, single-command install |
| `.github/workflows/megatron-builder-image.yml` | manual: build + push the toolchain image (rarely) |
| `.github/workflows/megatron-wheel.yml` | manual: build wheel(s), upload to `flagos-pypi-hosted` when `upload=true` (no schedule — release repo) |
| `.github/build-config.yml` | `registry.prefixes.builder: flagos-dev` — builder toolchain images share this project; the tool+python is the repository (`megatron-builder-py*`, future `transformerengine-builder-*`, `verl-builder-*`, …) |
| `CLAUDE.md` | workflow docs |

## Not done yet (next steps)

- [ ] Local verification: build toolchain → build wheel → extract → confirm `helpers_cpp*.so` → install into a real `flagos-runtime` image
- [ ] Push toolchain images + wheels (workflows with `push`/`upload=true`)
- [ ] End-to-end install check on py3.10/py3.11/py3.12 runtimes (kunlunxin / ascend / nvidia)
- [ ] Proposed follow-up: relax `requires-python` in the fork repo itself once the on-the-fly patch path is verified

No uv, no lock file anywhere — the wheel builds with plain `pip wheel` and the runtime install is a single `pip install --no-deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
