### PR TITLE
feat(megatron): reorganize into two facilities — wheel factory + app-image automation

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -30,7 +30,10 @@ registry:
     # the future transformerengine-builder-*, verl-builder-*, vllm-builder-*,
     # sglang-builder-* ...).
     builder: flagos-dev
-    # app: <prefix>       # TODO: fill in when app image CI lands
+    # App images live under flagos-app (e.g. flagos-app/megatron-nvidia-cuda12.8,
+    # flagos-app/vllm-nvidia-cuda12.8). Consumed by the app-image workflows
+    # (megatron-app-image.yml) to compose the image tag.
+    app: flagos-app
 
 # Which runner builds each image (base containerfile name -> runs-on).
 # Backends not listed under `overrides` use `default`.

--- a/.github/workflows/megatron-app-image.yml
+++ b/.github/workflows/megatron-app-image.yml
@@ -1,0 +1,157 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Megatron app image
+
+# STUB — structure landed only; the build/verify steps are filled during the
+# hygon25 verification phase (see megatron-repack/report-megatron-0.17.1.md).
+#
+# Facility 2 (app-image automation): installs the repacked megatron-core wheel
+# into a flagos-runtime-{vendor}-{backend} image and produces the app image
+# flagos-app/megatron-{vendor}-{backend}:{version}. The Containerfile installs
+# with a single-step `pip install` (no --no-deps) — the wheel's METADATA has
+# already been stripped of torch by megatron-repack/, so the runtime's
+# torch/triton/flag_gems matrix cannot be disturbed.
+#
+# Backend matrix comes from scripts/generate_matrix.py --runtime (same source
+# as runtime-image.yaml). Per-vendor PyPI (flagos_pypi) is searched first;
+# aliyun is the fallback.
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: 'Backend to build (e.g. hygon-dtk26.04), or "all"'
+        type: string
+        default: all
+      megatron_version:
+        description: 'megatron-core version to install (e.g. 0.17.1)'
+        type: string
+        default: 0.17.1
+      push:
+        description: 'Push image(s) to the registry'
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/check-trigger-author
+
+  set-matrix:
+    needs: authorize
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      harbor_host: ${{ steps.harbor-host.outputs.host }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+
+      - id: set-matrix
+        shell: bash
+        run: |
+          if [[ "${{ inputs.backend }}" == "all" ]]; then
+            python3 scripts/generate_matrix.py --runtime > matrix.json
+          else
+            python3 scripts/generate_matrix.py --runtime ${{ inputs.backend }} > matrix.json
+          fi
+          cat matrix.json
+          echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+      - id: harbor-host
+        shell: bash
+        run: |
+          host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
+          echo "host=$host" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: set-matrix
+    if: ${{ fromJSON(needs.set-matrix.outputs.matrix).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    name: app-${{ matrix.name }}
+    runs-on: ${{ fromJSON(matrix.runson) }}
+    env:
+      IMAGE: megatron-app-${{ matrix.name }}:${{ github.run_id }}
+    steps:
+      - name: Checkout build-infra
+        uses: actions/checkout@v7
+
+      - name: Harbor login (push only)
+        if: ${{ inputs.push }}
+        env:
+          HARBOR_USER: ${{ secrets.HARBOR_USER }}
+          HARBOR_PW: ${{ secrets.HARBOR_PASSWORD }}
+        run: |
+          host="${{ needs.set-matrix.outputs.harbor_host }}"
+          for i in 1 2 3; do
+            if printf '%s' "$HARBOR_PW" | docker login "$host" -u "$HARBOR_USER" --password-stdin; then
+              exit 0
+            fi
+            echo "Harbor login attempt $i failed, retrying..."
+            sleep 30
+          done
+          echo "::error::Harbor login failed after 3 attempts"
+          exit 1
+
+      - name: Pull runtime image
+        run: |
+          docker pull "${{ matrix.image_tag }}" || {
+            echo "::error::Failed to pull runtime image ${{ matrix.image_tag }}"
+            exit 1
+          }
+
+      - name: Build megatron app image
+        run: |
+          set -euo pipefail
+          host="${{ needs.set-matrix.outputs.harbor_host }}"
+          app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
+          app_tag="${host}/${app_prefix}/megatron-${{ matrix.name }}:${{ matrix.version }}"
+          docker build \
+            --build-arg "RUNTIME_IMAGE=${{ matrix.image_tag }}" \
+            --build-arg "MEGATRON_VERSION=${{ inputs.megatron_version }}" \
+            --build-arg "FLAGOS_PYPI=${{ matrix.flagos_pypi }}" \
+            --build-arg "EXTRA_PYPI=${{ matrix.extra_pypi }}" \
+            -t "${app_tag}" \
+            -f app/megatron/Containerfile .
+          echo "Built: ${app_tag}"
+
+      - name: Push megatron app image
+        if: ${{ inputs.push }}
+        run: |
+          host="${{ needs.set-matrix.outputs.harbor_host }}"
+          app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
+          app_tag="${host}/${app_prefix}/megatron-${{ matrix.name }}:${{ matrix.version }}"
+          docker push "${app_tag}"
+
+      # TODO (hygon25 verification phase): verify step — after the build,
+      # run megatron-repack/verify-megatron-backend.sh (or its workflow
+      # equivalent) against the app image: before/after dependency snapshot
+      # (torch/triton/flag_gems/numpy unchanged) + `import megatron.core`
+      # with helpers_cpp loaded.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,13 +5,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project
 
 FlagOS container image build infrastructure — **configs.yaml is the single source of truth**.
-It builds three layers for 13+ GPU/NPU vendors:
+It builds four layers for 13+ GPU/NPU vendors:
 
 | Layer | What | Built by |
 |---|---|---|
 | **Base images** | Vendor SDK + toolchain on Ubuntu 24.04 | `base/<vendor>-<backend>` Containerfiles |
 | **Runtime images** | Base + Python venv + FlagGems + compilers (FlagTree/Triton) | `runtime/Containerfile` (one for all) |
 | **Wheels** | FlagTree (C++ compiler) + FlagGems (pure Python) + Megatron-LM-FL (pybind11 ext) | `flagtree-builder/`, `flaggems-builder/`, `megatron-builder/` |
+| **App images** | Runtime + megatron-core from a repacked wheel (torch stripped from METADATA) | `megatron-repack/` + `app/megatron/Containerfile` (mirrors `vllm-repack/` + `app/vllm/`) |
 
 ## Key commands
 
@@ -85,6 +86,7 @@ Two stages: **builder** (installs uv, venv, deps, compilers, FlagGems wheel) →
 - **`flaggems-wheel.yml`** — Daily (01:17 UTC) + manual FlagGems wheel build + upload to `flagos-pypi-daily` via twine.
 - **`megatron-builder-image.yml`** — Manual. Builds the reusable `megatron-builder` toolchain image (apt + deadsnakes Python + build-deps pins) for py3.10/3.11/3.12, optional Harbor push. Built rarely — only when the pins change; every megatron wheel build reuses it via `BASE_IMAGE` (see `megatron-builder/Containerfile`).
 - **`megatron-wheel.yml`** — Manual (no schedule; release repo). Builds megatron-core wheels from Megatron-LM-FL (`MLF_REF` input) for py3.10/3.11/3.12, FROM the toolchain image, uploads to `flagos-pypi-hosted` via twine when `upload=true`. All three cp-version wheels must be uploaded — the package ships a compiled `helpers_cpp` extension.
+- **`megatron-app-image.yml`** — Manual. STUB — structure landed only; builds `flagos-app/megatron-{vendor}-{backend}:{version}` from `flagos-runtime-{vendor}-{backend}` by installing the repacked `+flagos` wheel (single-step, no `--no-deps`). The build/verify steps are filled during the hygon25 verification phase (see `megatron-repack/report-megatron-0.17.1.md`).
 - **`gendoc-base.yaml`** — Triggered on base image build completion. Extracts system package versions from built images (`dpkg-query`), runs `gen_data.py` + `gen_descriptions.py`, opens a **review-gated PR** with the version diff. Publication to Harbor (`pubdoc-base.yaml`) only happens when that PR lands on `main` (push to `base/*.md`).
 - **`gendoc-runtime.yaml`** — Runtime twin of `gendoc-base.yaml` (manual trigger; runtime images rebuild often during FlagGems testing, so no auto `workflow_run`). Opens a review-gated PR with `runtime/*.md`. Publication to Harbor (`pubdoc-runtime.yaml`) happens when that PR lands on `main` (push to `runtime/*.md`).
 - **`hugo-site.yaml`** — Builds + deploys docs site to GitHub Pages (triggered on push to `main` when `docs/**`, `configs.yaml`, or `base/**` changes).

--- a/app/megatron/Containerfile
+++ b/app/megatron/Containerfile
@@ -1,0 +1,57 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ============================================================
+# FlagOS Megatron app image
+#
+# Single Containerfile for all backends — build args drive the
+# per-vendor configuration.  See docs/ for the full guide.
+#
+# Revision history:
+#   2026-08-13   Initial version. megatron-core from repacked wheel
+#                (vendor PyPI). NO --no-deps: the repacked wheel's
+#                METADATA no longer declares torch, so a single-step
+#                install cannot disturb the runtime's torch/triton/
+#                flag_gems matrix (see megatron-repack/).
+# TODO
+#   - Publish-time verification (torch version, megatron.core import).
+# ============================================================
+
+ARG RUNTIME_IMAGE
+FROM ${RUNTIME_IMAGE}
+
+# --- Build arguments ------------------------------------------
+
+ARG MEGATRON_VERSION=0.17.1
+
+# Repacked megatron-core wheel lives here — searched first.
+ARG FLAGOS_PYPI=""
+
+# Fallback for all other dependencies.
+ARG EXTRA_PYPI="https://mirrors.aliyun.com/pypi/simple"
+
+# --- Install megatron-core (repacked wheel) -------------------
+
+# Single-step install, no --no-deps. The repacked wheel (megatron-core
+# <version>+flagos) carries no torch Requires-Dist, so pip resolves only
+# the packages that are actually missing (numpy / packaging are already
+# pinned in the runtime image).
+RUN pip install \
+  --index-url "${FLAGOS_PYPI}" \
+  --extra-index-url "${EXTRA_PYPI}" \
+  "megatron-core==${MEGATRON_VERSION}"
+
+# --- Runtime --------------------------------------------------
+
+WORKDIR /workspace

--- a/docs/content/en/application/megatron.md
+++ b/docs/content/en/application/megatron.md
@@ -1,0 +1,64 @@
+---
+title: Megatron
+weight: 20
+---
+
+<!--
+ Copyright 2026 FlagOS Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+
+The **Megatron app image** is built on top of a `flagos-runtime` image and
+packages a usable megatron-core library for megatron-lm based training.
+
+## Build arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `RUNTIME_IMAGE` | _(required)_ | Runtime image ref, e.g. `harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.2` |
+| `MEGATRON_VERSION` | `0.17.1` | megatron-core version to install. A repacked wheel (see below) must exist on `FLAGOS_PYPI`. |
+| `FLAGOS_PYPI` | `""` | Vendor PyPI index — hosts the **repacked** megatron-core wheel. Searched first. |
+| `EXTRA_PYPI` | `https://mirrors.aliyun.com/pypi/simple` | Aliyun mirror — fallback for all other dependencies. |
+
+## Repacked megatron-core wheel
+
+megatron-core's direct dependency surface is tiny (`torch>=2.6.0`, `numpy`,
+`packaging>=24.2`) — and the only real risk is `torch`: on a backend whose
+runtime torch is `< 2.6.0`, pip would pull public-PyPI torch over the vendor
+build. We run `megatron-repack/` (reusing `vllm-repack/repack.py`) to strip
+`Requires-Dist: torch` from the wheel's METADATA, then upload the repacked
+wheel to the vendor's `FLAGOS_PYPI` with a `+flagos` version suffix.
+
+During `pip install`, the vendor PyPI is searched first — the repacked wheel
+is found and used. All remaining (safe) dependencies are resolved from
+`EXTRA_PYPI`. Torch is already in the runtime venv and satisfies any
+transitive constraints, so pip skips it. The install is a **single-step**
+`pip install` (no `--no-deps`).
+
+The wheel itself is built by `megatron-builder/` from the Megatron-LM-FL fork
+(per-Python cp310/cp311/cp312 wheels — the package ships a compiled
+`helpers_cpp` extension; the fork's `requires-python >=3.12` is relaxed to
+`>=3.10` on the fly at build time). Classification rules live in
+`megatron-repack/config.yaml`.
+
+## Build example
+
+```bash
+docker build \
+  --build-arg RUNTIME_IMAGE=harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.2 \
+  --build-arg FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-hygon/simple \
+  -t harbor.baai.ac.cn/flagos-app/megatron-hygon-dtk26.04:2.1.2 \
+  -f app/megatron/Containerfile .
+```

--- a/docs/content/zh-cn/application/megatron.md
+++ b/docs/content/zh-cn/application/megatron.md
@@ -1,0 +1,59 @@
+---
+title: Megatron
+weight: 20
+---
+
+<!--
+ Copyright 2026 FlagOS Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+
+**Megatron 应用镜像**构建在 `flagos-runtime` 之上，打包可用的 megatron-core
+库，用于 megatron-lm 训练栈。
+
+## 构建参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `RUNTIME_IMAGE` | _(必填)_ | 运行时镜像引用，如 `harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.2` |
+| `MEGATRON_VERSION` | `0.17.1` | 要安装的 megatron-core 版本。该版本对应的"手术 wheel"必须已上传到 `FLAGOS_PYPI`。 |
+| `FLAGOS_PYPI` | `""` | 厂商 PyPI 索引 — 存放**手术后的** megatron-core wheel，优先搜索。 |
+| `EXTRA_PYPI` | `https://mirrors.aliyun.com/pypi/simple` | 阿里云镜像 — 其他所有依赖的回退源。 |
+
+## 手术后的 megatron-core wheel
+
+megatron-core 的直接依赖面极小（`torch>=2.6.0`、`numpy`、`packaging>=24.2`），
+其中唯一真正的风险点是 `torch`：若运行时 torch < 2.6.0，pip 会拉公有 PyPI 的
+torch 覆盖厂商构建。我们用 `megatron-repack/`（复用 `vllm-repack/repack.py`）
+将 `Requires-Dist: torch` 从 wheel 的 METADATA 中摘除，再以 `+flagos` 版本后缀
+上传到厂商的 `FLAGOS_PYPI`。
+
+`pip install` 时优先搜索厂商 PyPI — 找到手术后的 wheel 并使用。其余（安全）依赖
+全部从 `EXTRA_PYPI` 解析。torch 已存在于 runtime venv 中且满足所有传递约束，
+pip 不会去动它。安装是**单步** `pip install`（无 `--no-deps`）。
+
+wheel 本身由 `megatron-builder/` 从 Megatron-LM-FL fork 构建（cp310/cp311/cp312
+三个 ABI 专属 wheel；fork 的 `requires-python >=3.12` 在构建时 on-the-fly 放宽
+到 `>=3.10`）。分类规则见 `megatron-repack/config.yaml`。
+
+## 构建示例
+
+```bash
+docker build \
+  --build-arg RUNTIME_IMAGE=harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.2 \
+  --build-arg FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-hygon/simple \
+  -t harbor.baai.ac.cn/flagos-app/megatron-hygon-dtk26.04:2.1.2 \
+  -f app/megatron/Containerfile .
+```

--- a/megatron-builder/README.md
+++ b/megatron-builder/README.md
@@ -129,22 +129,37 @@ RUN cd /opt/megatron-lm-fl \
 The fork repo is **not modified** by this. Relaxing it there is a proposed
 follow-up, once this end-to-end path is verified.
 
-## Single-command install
+## Install into a runtime image
 
-Inside any `flagos-runtime-{vendor}-{backend}:{version}` container (the `/flagos`
-venv is on PATH):
+The megatron app image (`app/megatron/Containerfile`) installs the wheel with a
+**single-step `pip install` — no `--no-deps`**. The wheel is first **repacked**
+by `megatron-repack/` (reusing `vllm-repack/repack.py`) to strip
+`Requires-Dist: torch` from its METADATA and bump the version to a `+flagos`
+suffix; the repacked wheel is uploaded to the per-vendor PyPI index. Then:
 
-```bash
-pip install --no-deps megatron-core==0.17.1 \
-  --index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
+```dockerfile
+RUN pip install \
+  --index-url "${FLAGOS_PYPI}" \
+  --extra-index-url "${EXTRA_PYPI}" \
+  "megatron-core==${MEGATRON_VERSION}"
 ```
 
-- `--no-deps` is **mandatory**: torch/numpy/flagtree/triton are already pinned
-  per-backend in the image (and vendor-provided for triton/flagtree) — the
-  resolver must not touch them.
+- The vendor index is searched first — the `+flagos` repacked wheel is found
+  and used.
+- Torch is already in the runtime venv and satisfies any transitive
+  constraints, so pip skips it. `numpy`/`packaging` are pinned per-backend in
+  the image and resolved from `EXTRA_PYPI` if missing.
 - pip auto-selects the `cp310` / `cp311` / `cp312` wheel matching the image's
   Python.
-- Verify:
+
+Why not `--no-deps`: a bare `--no-deps` would refuse to install the repacked
+wheel (its version resolution needs the normal resolver), and more importantly
+a plain install with deps intact could pull public-PyPI torch over the vendor
+build. Stripping torch from METADATA gives the same safety without bypassing
+dependency resolution. See `megatron-repack/report-megatron-0.17.1.md` for the
+risk analysis.
+
+- Verify (after `source /opt/dtk-26.04/env.sh` on hygon):
 
   ```bash
   python -c "import megatron.core; print(megatron.core.__version__)"   # 0.17.1

--- a/megatron-builder/report-megatron-0.17.1.md
+++ b/megatron-builder/report-megatron-0.17.1.md
@@ -1,0 +1,95 @@
+# megatron-builder — megatron-core wheel 工厂验证报告（Facility 1）
+
+> 状态：进行中 —— 首个后端（hygon-dtk26.04）的实测基线已完成，wheel 构建 + 安装验证待跑。
+> 本文档是 **Facility 1（wheel 工厂）** 的验证报告，只覆盖 wheel 的构建与实测基线。
+> Facility 2（app 镜像自动化：wheel 依赖手术 + 单步安装 + 各后端验证）见
+> `megatron-repack/report-megatron-0.17.1.md`。所有数字均为在真实节点/镜像上的
+> **实测**，非推断。
+
+## 0. 背景
+
+`megatron-core`（Megatron-LM-FL fork）以 wheel 形式交付。它自带编译扩展
+`helpers_cpp`，因此 wheel 是 CPython-ABI 专属的（cp310/cp311/cp312，见 §3）。
+fork 的 `pyproject.toml` 声明 `requires-python = ">=3.12"` 和三个运行时依赖（§1）。
+
+**约束（用户确认）：**
+- **不用 uv、不用 lock file**（曾被 uv 坑过）。构建走 `pip wheel --no-build-isolation`。
+- fork 仓库不动；requires-python 与依赖处理都在 wheel 构建/repack 阶段**现做**。
+- 上传目标 `flagos-pypi-hosted`（release 仓库）。
+
+把 wheel 装进 runtime 镜像时是否会破坏精心匹配的 torch/triton 版本矩阵，属于
+Facility 2（`megatron-repack/`）的职责——megatron-core 的直接依赖面极小，唯一
+真正的风险点是 `torch`，处理方式与 vllm-repack 同类。
+
+## 1. megatron-core 的真实依赖面（来自 `Megatron-LM-FL/pyproject.toml`）
+
+```toml
+requires-python = ">=3.12"                       # fork 在 0.17.0 同步时收紧（上游原本 >=3.10）
+dependencies = ["torch>=2.6.0", "numpy", "packaging>=24.2"]
+```
+
+**只有三个运行时依赖。** 风险分级：
+
+| 依赖 | 声明 | 风险 |
+|---|---|---|
+| `torch>=2.6.0` | 版本下限 | **唯一真实风险** —— 若运行时 torch < 2.6.0，pip 会拉公有 PyPI torch 替换厂商构建 |
+| `numpy` | 无下限 | 低 —— 运行时已 pin（hygon 1.26.4）；我们的 `.so` 用 numpy 1.x 头编译，1.x/2.x 运行时都能跑 |
+| `packaging>=24.2` | 下限低 | 无 —— 纯 Python，极小 |
+
+注意 fork 自己的 `[tool.uv] override-dependencies` 就写着"装进 PyTorch base image
+时不想安装 torch/torchvision/triton"——上游用 uv override 解同一个问题；我们
+不用 uv，就用 repack 手段达到等价效果（见 Facility-2 报告 §2.2）。
+
+**额外事实（实测，见 §2）：** 公有 PyPI 上 **0.17.x 全部 `Requires-Python >=3.12`**
+——上游也在 0.17 收紧了 Python 下限。所以 py3.10 运行时（kunlunxin、hygon、
+mthreads、iluvatar、tsingmicro）**没有官方 wheel 可用**，fork wheel（配合
+Containerfile 里的 on-the-fly requires-python patch）是唯一通路。
+
+## 2. 实测基线（hygon25 节点，2026-08-12）
+
+**节点:** `hygon25`（Hygon BW1000 8× HCU，DTK 26.04）　**镜像:**
+`harbor.baai.ac.cn/flagos-runtime/flagos-runtime-hygon-dtk26.04:2.1.2`（本机缓存）
+**Python:** 3.10.20
+
+| 包 | 镜像内版本 | megatron 要求 | 满足？ |
+|---|---|---|---|
+| torch | **2.9.0+das.opt1.dtk2604**（厂商构建） | `torch>=2.6.0` | ✅ 2.9.0 ≥ 2.6.0 |
+| numpy | 1.26.4（configs.yaml hygon pin） | `numpy`（无下限） | ✅ |
+| packaging | 26.3 | `packaging>=24.2` | ✅ |
+| flag_gems | 5.3.4 | — | — |
+| triton | （无，由 flagtree 提供） | — | — |
+
+**结论：hygon 上 megatron 的三个依赖全部已被镜像矩阵满足 → pip 解析器没有
+理由触碰任何现有包，安装应为"只装 megatron-core 本身"，破坏风险实测为零。**
+pip 只在依赖要求不被满足时才替换包；`torch>=2.6.0` 已被厂商 2.9.0 满足。
+
+**两个额外发现：**
+
+1. **公有 PyPI 无 py3.10 兼容的 0.17.x**（`pip install --dry-run megatron-core==0.17.1`
+   报 `Requires-Python >=3.12` 被忽略；候选列表里 0.17.x 全部被跳过）。→ fork
+   wheel + on-the-fly requires-python patch 是 py3.10 运行时的唯一通路。
+2. **`import torch` 需要 DTK 环境**：裸 shell 下 `libgalaxyhip.so.5: cannot open
+   shared object file`。`/opt/dtk-26.04/env.sh` 存在（另有
+   `/opt/dtk-26.04/.hyhal/hydm/hydmi_env.sh`、`/opt/dtk-26.04/cuda/env.sh`）。
+   → 验证步骤必须先 `source /opt/dtk-26.04/env.sh` 再 `import torch`，与镜像
+   预期用法一致。
+
+## 3. 构建（已落地，PR #368 合并）
+
+`megatron-builder/Containerfile` 两阶段：
+
+- **toolchain**（`harbor.baai.ac.cn/flagos-dev/megatron-builder-py{310|311|312}`）：
+  ubuntu:22.04 + deadsnakes Python + `setuptools<80 wheel pybind11==3.0.3
+  numpy==1.26.4 packaging>=24.2`。pybind11/numpy 是 ABI 契约（与 runtime 镜像
+  的 pin 对齐）。极少重建。
+- **wheel**：`FROM ${BASE_IMAGE}`，clone fork → on-the-fly `requires-python
+  >=3.12 → >=3.10`（sed + grep gate）→ 可选版本 stamp → `pip wheel . --no-deps
+  --no-build-isolation` → **`.so`-in-wheel gate**（`helpers_cpp*.so` 必须存在，
+  防 `optional=True` 静默跳过编译）→ torch-free importlib 冒烟测试。
+
+产物 cp310/cp311/cp312 三个 wheel（`helpers_cpp` 是编译扩展，CPython-ABI 专属）。
+
+**相关文件：** `megatron-builder/Containerfile`、`megatron-builder/README.md`、
+`.github/workflows/megatron-builder-image.yml`、`.github/workflows/megatron-wheel.yml`
+（均已合并）。Facility-2 依赖手术与验证见
+`megatron-repack/report-megatron-0.17.1.md`。

--- a/megatron-repack/build-and-repack.sh
+++ b/megatron-repack/build-and-repack.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ============================================================
+# build-and-repack.sh — Repack a megatron-core wheel for one backend
+# ============================================================
+#
+# STUB — to be filled during the hygon25 verification phase.
+#
+# Facility 1 (megatron-builder/) produces the cp310/cp311/cp312 wheels;
+# this script consumes one of them and applies the dependency surgery
+# (megatron-repack/config.yaml) so a single-step `pip install` can never
+# disturb the runtime image's torch/triton/flag_gems matrix.
+#
+# Usage (intended):
+#   build-and-repack.sh hygon-dtk26.04 /path/to/megatron_core-0.17.1-cp310-cp310-linux_x86_64.whl
+#   build-and-repack.sh nvidia-cuda12.8 /path/to/megatron_core-0.17.1-cp312-...whl --upload
+#
+# Options (intended):
+#   --upload   twine-upload the repacked +flagos wheels to the per-vendor
+#              PyPI (flagos-pypi-<vendor>). Opt-in — publishing is outward
+#              facing, so it never runs by default.
+#
+# Prerequisites (intended):
+#   - Facility-1 wheel (from megatron-builder/) for the backend's Python
+#   - python3 + pyyaml on the host (for reading configs.yaml)
+#   - ../vllm-repack/repack.py — REUSED read-only, never copied or modified
+#   - twine on the host (only when --upload is used)
+
+set -euo pipefail
+
+# ── Parse arguments ─────────────────────────────────────────────────────
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <vendor>-<backend> <wheel> [--upload]" >&2
+    exit 1
+fi
+
+VENDOR_BACKEND="$1"
+WHEEL="$2"
+shift 2
+
+UPLOAD=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --upload) UPLOAD=true; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+VENDOR="${VENDOR_BACKEND%-*}"
+BACKEND="${VENDOR_BACKEND#*-}"
+
+# ── Paths ───────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="/tmp/megatron-repack-${VENDOR}-${BACKEND}"
+
+# ── TODO: fill during verification ─────────────────────────────────────
+# 1. Resolve STACK_VERSION from ${SCRIPT_DIR}/../configs.yaml.
+# 2. Copy the Facility-1 wheel + config.yaml + (read-only) repack.py into
+#    WORK_DIR, run:
+#      python3 ${WORK_DIR}/repack.py --config ${WORK_DIR}/config.yaml ${WORK_DIR}/input/megatron_core-*.whl
+#    → produces megatron_core-0.17.1+flagos-...whl in WORK_DIR/output/.
+# 3. Sanity-gate the repacked wheel: METADATA no longer contains
+#    `Requires-Dist: torch`, `+flagos` suffix present, .deps-manifest.yaml
+#    written.
+# 4. Upload (opt-in): twine upload --repository-url
+#    "https://resource.flagos.net/repository/flagos-pypi-${VENDOR}/" \
+#    ${WORK_DIR}/output/*.whl
+# 5. Report the removed/retained dependency manifest.
+
+echo "STUB: repack pipeline for ${VENDOR_BACKEND} not implemented yet." >&2
+echo "      Wheel:  ${WHEEL}" >&2
+echo "      See report-megatron-0.17.1.md §2.2 for the design." >&2
+exit 1

--- a/megatron-repack/config.yaml
+++ b/megatron-repack/config.yaml
@@ -1,0 +1,49 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ── Wheel Repack Classification Rules — megatron-core ──────────────────
+# Each key is a set of *package names* (no version, case-insensitive).
+# Same schema as vllm-repack/config.yaml — megatron-repack consumes the
+# Facility-1 wheel via vllm-repack/repack.py with THIS config.
+#
+# megatron-core's direct dep surface is tiny (torch>=2.6.0, numpy,
+# packaging>=24.2 — see megatron-builder/report-megatron-0.17.1.md §1).
+# torch is the ONLY real risk: on a backend whose runtime torch < 2.6.0,
+# pip would replace the vendor build with public-PyPI torch. numpy and
+# packaging are already satisfied by the runtime matrix on every backend,
+# so the rules below touch only the torch family.
+
+# ── Top-level removal rules (applied to megatron-core's own METADATA) ──
+
+# torch (and only torch) — stripped from megatron-core's Requires-Dist so
+# a single-step install can never pull public-PyPI torch in.
+remove_torch_chain:
+  - torch
+
+# megatron-core declares no CUDA-only packages.
+remove_cuda_only: []
+
+# Nothing was orphaned by the strips above.
+remove_orphaned: []
+
+# ── Indirect dependency stripping rules ───────────────────────────────
+# If megatron-core ever gains an indirect dep whose own METADATA declares
+# torch/triton, strip them there too. Kept to the torch family — never CUDA
+# infrastructure (the repacked dep may still need it at runtime).
+strip_from_indirect:
+  - torch
+  - triton
+
+# No per-package exceptions today.
+strip_extra_from_indirect: {}

--- a/megatron-repack/report-megatron-0.17.1.md
+++ b/megatron-repack/report-megatron-0.17.1.md
@@ -1,0 +1,103 @@
+# megatron-repack — megatron app 镜像自动化验证报告（Facility 2）
+
+> 状态：进行中 —— 目录 / Containerfile / config.yaml / 文档已落地（结构先行）；
+> 脚本与 workflow 为最小 stub，待 hygon25 验证阶段填充。
+> 本文档是 **Facility 2（app 镜像自动化）** 的验证报告。wheel 工厂（构建与实测
+> 基线）见 `megatron-builder/report-megatron-0.17.1.md`。所有数字均为在真实
+> 节点/镜像上的**实测**，非推断。
+
+## 0. 背景
+
+megatron 工作分两个 facility：
+
+- **Facility 1 — wheel 工厂**（`megatron-builder/`，仿 `flaggems-builder/`）：
+  产出可安装的 megatron-core wheel。**已完成**（PR #368），见其报告。
+- **Facility 2 — app 镜像自动化**（本目录 + `app/megatron/Containerfile` +
+  `.github/workflows/megatron-app-image.yml`）：把 wheel 装进
+  `flagos-runtime-{vendor}-{backend}` 镜像，产出 app 镜像。vllm 的对应物是
+  `vllm-repack/` + `app/vllm/Containerfile`。**本报告即此 facility 的设计与待办。**
+
+把 wheel 装进镜像时，若其 METADATA 的 `Requires-Dist` 与镜像内**精心匹配、反复
+验证过的版本矩阵**（厂商 torch / triton / flagtree / flag_gems / numpy）冲突，
+pip 解析器可能**替换或升级**其中的包，破坏整个运行时栈——与 vllm-repack 要解决的
+问题同类。与 vllm 不同的是，megatron-core 的**直接依赖面极小**（torch / numpy /
+packaging 三项，见 Facility-1 报告 §1），不需要 vllm 那套复杂的分类器，只需要
+针对唯一真正的风险点——`torch`——做精确处理。
+
+**约束（用户确认）：**
+- **不 brutal 地全剥依赖**（`pip install --no-deps` 被用户否决——"I'm always
+  worrisome about --no-deps, it breaks everything"）。要做的是"检测它是否会
+  破坏精心构建的 torch/triton 矩阵"，与 vllm-repack 同一思路，通过 repack
+  wheel METADATA 实现（§2.2）。
+- repack **复用** `vllm-repack/repack.py`（通用手术工具，该目录承载用户的
+  未提交修改——**只读引用，不复制不修改**）。
+- 安装是 vendor 为主索引的单步 `pip install`（无 `--no-deps`）。
+- fork 仓库不动；requires-python 与依赖处理都在 wheel 构建/repack 阶段**现做**。
+
+## 1. 破坏风险矩阵（各后端）
+
+| 后端 | 运行时 torch | 风险 |
+|---|---|---|
+| hygon-dtk26.04 | 2.9.0+das.opt1.dtk2604 | ✅ 无（2.9.0 ≥ 2.6.0） |
+| mthreads / metax / nvidia / ... | 待各节点实测 | ⬜ 待测 |
+| **任意 torch < 2.6.0 的后端** | 未知 | 🔴 pip 会拉公有 torch 替换厂商构建 → 必须靠 METADATA 处理（§2.2） |
+
+**结论：** "今天安全"依赖 torch 版本不下滑；"永远安全"要靠 §2.2 的 repack 把
+torch 声明从 wheel METADATA 里去掉/钉死——这正是 vllm-repack `remove_torch_chain`
+的思路。megatron 只需处理 torch 一项。
+
+## 2. 设计（依赖安全处理）
+
+### 2.1 构建（Facility 1，已落地）
+
+wheel 的构建、on-the-fly requires-python patch、`.so`-in-wheel gate、冒烟测试
+都在 `megatron-builder/`（PR #368 合并），详见 Facility-1 报告 §3。产物
+cp310/cp311/cp312 三个 wheel（`helpers_cpp` 是编译扩展，CPython-ABI 专属）。
+
+### 2.2 依赖处理（repack，仿 vllm-repack）
+
+现状：Containerfile/README 曾写 `pip install --no-deps` —— **被用户否决**。方向
+改为 vllm-repack 模式：
+
+- 对 Facility-1 产出的 wheel 做 repack：剥掉 `Requires-Dist: torch>=2.6.0`（或
+  钉成 `==<厂商 torch 版本>`），`+flagos` 后缀，`.deps-manifest.yaml` 记录
+  removed/retained，Metadata-Version 2.4→2.2。
+- 分类规则 `megatron-repack/config.yaml`（torch 是唯一真实风险）：
+  ```yaml
+  remove_torch_chain: [torch]
+  remove_cuda_only: []
+  remove_orphaned: []
+  strip_from_indirect: [torch, triton]
+  strip_extra_from_indirect: {}
+  ```
+- 安装命令变为 vendor 为主索引的单步安装（无 `--no-deps`）：
+  ```
+  pip install megatron-core==0.17.1+flagos \
+    --index-url https://resource.flagos.net/repository/flagos-pypi-<vendor>/simple \
+    --extra-index-url https://mirrors.aliyun.com/pypi/simple
+  ```
+- 验证：before/after 快照对比 torch/triton/flag_gems/numpy 版本**逐项相等**，
+  再 `import megatron.core` 确认 `helpers_cpp` 载入（镜像上先 `source
+  /opt/dtk-26.04/env.sh`）。
+
+## 3. 待办
+
+| 事项 | 状态 |
+|---|---|
+| megatron-repack/ 结构（config.yaml + 脚本/ workflow stub） | ✅ 本报告 |
+| app/megatron/Containerfile | ✅ |
+| 文档 docs/content/{zh-cn,en}/application/megatron.md | ✅ |
+| hygon25 上构建 Facility-1 wheel（py3.10, x86_64） | ⬜ |
+| 填充 build-and-repack.sh + verify-megatron-backend.sh + workflow | ⬜ |
+| repack（剥 torch、+flagos、manifest） | ⬜ |
+| runtime 容器内单步安装 + before/after 快照对比 | ⬜ |
+| `import megatron.core` + `helpers_cpp` 确认 | ⬜ |
+| 其余后端（mthreads/metax/... 节点恢复后）逐栈验证 | ⬜ |
+| 上传 `flagos-pypi-hosted`（用户申请上传权限中） | ⬜ |
+
+**相关文件：** `megatron-repack/config.yaml`、`megatron-repack/build-and-repack.sh`
+（stub）、`megatron-repack/verify-megatron-backend.sh`（stub）、
+`app/megatron/Containerfile`、`.github/workflows/megatron-app-image.yml`（stub）。
+vllm-repack 模式参考：`vllm-repack/repack.py` + `config.yaml` + `build-and-repack.sh`
++ `verify-vllm-backend.sh`。wheel 工厂参考：`megatron-builder/Containerfile` +
+`megatron-builder/report-megatron-0.17.1.md`。

--- a/megatron-repack/verify-megatron-backend.sh
+++ b/megatron-repack/verify-megatron-backend.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ============================================================
+# verify-megatron-backend.sh — Install and verify megatron-core on a backend
+# ============================================================
+#
+# STUB — to be filled during the hygon25 verification phase.
+#
+# Facility 2 verification: install the repacked megatron-core wheel into a
+# `flagos-runtime-{vendor}-{backend}` container and prove the dependency
+# surgery held — i.e. the carefully crafted torch/triton/flag_gems matrix is
+# byte-for-byte unchanged after the install, and megatron.core actually loads.
+#
+# Usage (intended):
+#   verify-megatron-backend.sh <vendor-backend>
+#   verify-megatron-backend.sh hygon-dtk26.04
+#
+# Prerequisites (intended):
+#   - Running on the target node with hardware access
+#   - Repacked megatron-core wheel (with +flagos suffix) uploaded to the
+#     vendor PyPI (flagos-pypi-<vendor>)
+
+set -euo pipefail
+
+# ── Parse arguments ─────────────────────────────────────────────────────
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <vendor>-<backend>" >&2
+    exit 1
+fi
+
+VENDOR_BACKEND="$1"
+VENDOR="${VENDOR_BACKEND%-*}"
+BACKEND="${VENDOR_BACKEND#*-}"
+
+# ── TODO: fill during verification ─────────────────────────────────────
+# 1. Resolve STACK_VERSION from ${SCRIPT_DIR}/../configs.yaml; start a
+#    runtime container with the vendor's run flags (build-config.yml `run:`),
+#    mirroring vllm-repack/verify-vllm-backend.sh.
+# 2. BEFORE snapshot: record versions of torch / triton / flag_gems / numpy
+#    (+ their site-package paths) inside the container.
+# 3. Single-step install (no --no-deps):
+#      pip install --index-url "https://resource.flagos.net/repository/flagos-pypi-${VENDOR}/simple" \
+#                  --extra-index-url "https://mirrors.aliyun.com/pypi/simple" \
+#                  "megatron-core==<version>+flagos"
+# 4. AFTER snapshot: compare each package version to BEFORE — must be equal
+#    item by item, or the install corrupted the matrix (fail).
+# 5. Import check: source the vendor env if needed (hygon:
+#    `source /opt/dtk-26.04/env.sh`), then
+#      python3 -c "import megatron.core; print(megatron.core.__version__)"
+#    and confirm `helpers_cpp` is importable (megatron.core.datasets.helpers_cpp).
+# 6. Report before/after table + import result.
+
+echo "STUB: verify pipeline for ${VENDOR_BACKEND} not implemented yet." >&2
+echo "      See report-megatron-0.17.1.md §2.2 for the design." >&2
+exit 1


### PR DESCRIPTION
Split the megatron work into its two facilities:

- **megatron-builder/** (Facility 1, unchanged): megatron-core wheel factory.
- **megatron-repack/** (Facility 2, new): app-image automation. Repacks the
  megatron-core wheel (strips `Requires-Dist: torch` via
  `vllm-repack/repack.py`, `+flagos` version suffix, per-vendor PyPI) and
  installs it into `flagos-runtime` images with a single-step `pip install` —
  **no `--no-deps`**.

Lands the Facility-2 **structure only**: `megatron-repack/` (config.yaml +
script stubs + report), `app/megatron/Containerfile`, the
`megatron-app-image.yml` workflow stub, the `app: flagos-app` registry prefix,
and the megatron application docs (zh + en). The megatron-builder README's
`--no-deps` install section is replaced with the repack-model single-step
install.

Scripts/workflow verification steps are filled during the hygon25 verification
phase (see `megatron-repack/report-megatron-0.17.1.md`).

Notes:
- `vllm-repack/` is intentionally **not** included — its uncommitted changes
  stay out of this PR.
- No Harbor push, no node operations.

This PR was written in part with the assistance of generative AI.
