### PR TITLE
Update environment settings for Enflame backend

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -243,6 +243,7 @@ vendors:
         runtime:
           TORCH_GCU_ENABLE_INT64_AND_UINT64: "1"
           ENABLE_I64_CHECK: "0"
+          ENFLAME_PT_OP_DEBUG_CONFIG: "fallback_cpu=all_ops"
       deps:
         - pyefml==1.9.10
         - torch==2.10.0+cpu
@@ -277,6 +278,7 @@ vendors:
           TORCH_GCU_ENABLE_INT64_AND_UINT64: "1"
           ENABLE_I64_CHECK: "0"
           TORCHGCU_INDUCTOR_ENABLE: "1"
+          ENFLAME_PT_OP_DEBUG_CONFIG: "fallback_cpu=all_ops"
       deps:
         - pyefml==1.10.6
         - torch==2.11.0+cpu


### PR DESCRIPTION
The Enflame chip doesn't support int64 yet, they need a special env var to make sure unsupported operators fall back to CPU.