### PR TITLE
fix(runtime): install compilers before deps so bare triton resolves to vendor pin

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -123,41 +123,6 @@ RUN pip install --no-cache-dir --upgrade pip
 # download in this build (DEPS, FlagTree, Triton, FlagGems).
 ENV PIP_RESUME_RETRIES=100
 
-# ── Install vendor dependencies (explicit, no extras) ──────────
-# Dependencies come from configs.yaml deps: — explicit, no resolver ambiguity.
-# Each vendor has exactly one primary index (FLAGOS_PYPI); EXTRA_PYPI serves as
-# fallback for transitive deps (numpy, sympy, etc.) that aren't in vendor indexes.
-RUN if [ -n "${DEPS}" ]; then \
-      _installed=1; \
-      for i in 1 2 3; do \
-        if PIP_INDEX_URL="${FLAGOS_PYPI}" \
-           PIP_EXTRA_INDEX_URL="${EXTRA_PYPI}" \
-           pip install --no-cache-dir ${DEPS}; then \
-          _installed=0; break; \
-        fi; \
-        echo "DEPS install attempt $i failed, retrying..."; \
-      done; \
-      [ "$_installed" -eq 0 ] || { echo "ERROR: DEPS install failed after 3 attempts"; exit 1; }; \
-    fi
-
-# ── Install runtime prerequisites ───────────────────────────────
-# Common packages from configs.yaml runtime_prereqs, installed from
-# the mirror before FlagGems. pybind11 is a runtime dep of flagtree;
-# ninja is needed for C++ extension builds; PyYAML is a FlagGems
-# core dep that vendor torch packages import without declaring.
-# numpy is pinned per-backend in configs.yaml deps.
-RUN if [ -n "${RUNTIME_PREREQS}" ]; then \
-      _installed=1; \
-      for i in 1 2 3; do \
-        if PIP_INDEX_URL="${EXTRA_PYPI}" \
-           pip install --no-cache-dir ${RUNTIME_PREREQS}; then \
-          _installed=0; break; \
-        fi; \
-        echo "RUNTIME_PREREQS install attempt $i failed, retrying..."; \
-      done; \
-      [ "$_installed" -eq 0 ] || { echo "ERROR: RUNTIME_PREREQS install failed after 3 attempts"; exit 1; }; \
-    fi
-
 # ── Install FlagTree (default compiler, if configured) ──────────
 # FlagTree installs to /opt/flagtree — a side dir, symmetric with /opt/triton.
 # Keeping both compilers out of site-packages isolates their dist-infos, so
@@ -210,6 +175,49 @@ RUN if [ -n "${TRITON_PKG}" ]; then \
         done; \
         [ "$_installed" -eq 0 ] || { echo "ERROR: Triton extra install failed after 3 attempts"; exit 1; }; \
       fi; \
+    fi
+
+# ── Install vendor dependencies (explicit, no extras) ──────────
+# Dependencies come from configs.yaml deps: — explicit, no resolver ambiguity.
+# Each vendor has exactly one primary index (FLAGOS_PYPI); EXTRA_PYPI serves as
+# fallback for transitive deps (numpy, sympy, etc.) that aren't in vendor indexes.
+# Compilers are installed ABOVE (before this step) so their side-dir dist-infos
+# exist while DEPS resolves. DEPS packages that declare a bare `triton` (e.g.
+# flash_linear_attention on metax 3.8.1.3) are then satisfied by the pinned
+# vendor triton in /opt/triton via PYTHONPATH below — otherwise pip would pull
+# a fresh upstream triton into site-packages and silently override the pin.
+# (/opt/flagtree cannot satisfy this: flagtree bundles triton/ without a
+# triton-*.dist-info, so pip doesn't see it; /opt/triton always carries one.)
+RUN if [ -n "${DEPS}" ]; then \
+      _installed=1; \
+      for i in 1 2 3; do \
+        if PYTHONPATH="/opt/triton" \
+           PIP_INDEX_URL="${FLAGOS_PYPI}" \
+           PIP_EXTRA_INDEX_URL="${EXTRA_PYPI}" \
+           pip install --no-cache-dir ${DEPS}; then \
+          _installed=0; break; \
+        fi; \
+        echo "DEPS install attempt $i failed, retrying..."; \
+      done; \
+      [ "$_installed" -eq 0 ] || { echo "ERROR: DEPS install failed after 3 attempts"; exit 1; }; \
+    fi
+
+# ── Install runtime prerequisites ───────────────────────────────
+# Common packages from configs.yaml runtime_prereqs, installed from
+# the mirror before FlagGems. pybind11 is a runtime dep of flagtree;
+# ninja is needed for C++ extension builds; PyYAML is a FlagGems
+# core dep that vendor torch packages import without declaring.
+# numpy is pinned per-backend in configs.yaml deps.
+RUN if [ -n "${RUNTIME_PREREQS}" ]; then \
+      _installed=1; \
+      for i in 1 2 3; do \
+        if PIP_INDEX_URL="${EXTRA_PYPI}" \
+           pip install --no-cache-dir ${RUNTIME_PREREQS}; then \
+          _installed=0; break; \
+        fi; \
+        echo "RUNTIME_PREREQS install attempt $i failed, retrying..."; \
+      done; \
+      [ "$_installed" -eq 0 ] || { echo "ERROR: RUNTIME_PREREQS install failed after 3 attempts"; exit 1; }; \
     fi
 
 # ── FlagGems — skip when building the build-platform (runtime:v1).


### PR DESCRIPTION
## Background

`runtime/Containerfile` installed in the order **DEPS → FlagTree → Triton → FlagGems**. On metax 3.8.1.3, the deps include `flash_linear_attention==0.5.0+metax3.8.1.0torch2.10`, which declares a bare `Requires-Dist: triton` (no version pin). At DEPS time the compilers were not yet installed, so pip pulled upstream triton 3.7.1 from aliyun into site-packages — silently overriding the `triton==3.6.0+metax3.8.1.0` pin from configs.yaml. A full image scan confirmed that package is the only one in the image declaring bare triton.

## Change

1. **Move the FlagTree / Triton install blocks before the DEPS step** (compilers still land in /opt side dirs, not site-packages; the `compiler()` switch mechanism is unchanged);
2. **Run the DEPS pip install with `PYTHONPATH=/opt/triton`** — verified on metax124 that pip sees the /opt/triton dist-info via PYTHONPATH ("Requirement already satisfied"), so bare `triton` no longer pulls 3.7.1.

Key detail: `/opt/flagtree` cannot serve this role — the flagtree wheel bundles triton/ as a bare directory under the flagtree dist-info, **with no triton-*.dist-info**, so pip does not recognize it. The PYTHONPATH must therefore point at `/opt/triton`. The default runtime compiler (flagtree) is unaffected.

## Feasibility (checked across all backends)

- Every backend pins triton (configs.yaml `triton:` field) → /opt/triton always carries a dist-info;
- The compilers do not depend on torch (no install-order cycle); `triton-gcu`/`triton_ascend` are separate package names and do not conflict;
- For backends whose deps never mention triton, the reorder + PYTHONPATH is a no-op.

## Consequence

All runtime v2/v1 images (19 backends × `:2.1.2` / `:2.1.2-build`) must be rebuilt. Rebuilding also resolves a second issue: the existing 2.1.2 images predate OCI label stamping (#334, 2026-08-07), so `runtime_image_status.py` reports them all as UNKNOWN — after the rebuild the labels land and drift checking starts working.

This PR was written in part with the assistance of generative AI.