### PR TITLE
fix(base-image-status): read OCI labels under their real key 'Labels'

### DIFF
--- a/scripts/base_image_status.py
+++ b/scripts/base_image_status.py
@@ -132,7 +132,10 @@ def image_labels(host: str, repo: str, tag: str, auth: str) -> dict | None:
         timeout=30,
     ) as r:
         config = json.load(r)
-    return (config.get("config") or {}).get("labels") or {}
+    # The OCI image-config JSON key is "Labels" (capital L, as Docker and
+    # podman write it). A lowercase key never matches, so every pushed image
+    # was reported UNKNOWN ("no revision label") despite carrying labels.
+    return (config.get("config") or {}).get("Labels") or {}
 
 
 def containerfile_changed(revision: str, name: str) -> bool | None:


### PR DESCRIPTION
## Problem

`scripts/base_image_status.py` reported every pushed base image as UNKNOWN
("image has no revision label"), and `runtime_image_status.py` (which imports
`image_labels` from it) as UNKNOWN ("built before label stamping") — even
though every image carries the `org.opencontainers.image.*` labels.

Root cause: the OCI image-config JSON key is **`Labels`** (capital L, as
Docker and podman write it). The script read `.get("labels")` (lowercase),
which never matches — so the labels were present on the pushed images all
along, but the script never saw them.

## Change

```diff
-return (config.get("config") or {}).get("labels") or {}
+return (config.get("config") or {}).get("Labels") or {}
```

One line, plus a comment explaining the key name.

## Verification

Before (17 UNKNOWN + 2 NOT_BUILT), after (17 UP_TO_DATE + 2 NOT_BUILT — the
pushed base images genuinely reflect HEAD's Containerfiles, with
`org.opencontainers.image.revision` now visible).

`runtime_image_status.py` now shows real statuses too (34 OUTDATED with
build-input diffs — the exact rebuild list for the runtime reorder in #377).

This PR was written in part with the assistance of generative AI.