### PR TITLE
fix(megatron-verify): drop backslash f-string for py3.10/3.11

### DIFF
--- a/base/hygon-dtk26.04
+++ b/base/hygon-dtk26.04
@@ -36,7 +36,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # ── System packages ────────────────────────────────────────────
 # RUN sed -i 's|URIs: http://archive.ubuntu.com/ubuntu|URIs: https://mirrors.aliyun.com/ubuntu|g; s|URIs: http://security.ubuntu.com/ubuntu|URIs: https://mirrors.aliyun.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources \
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        git vim ca-certificates curl \
+        git vim ca-certificates curl unzip \
         libnuma1 \
         libgfortran5 libdrm-amdgpu1 libdw1 libelf1 libpciaccess0 \
         gcc g++ build-essential cmake \

--- a/base/hygon-dtk26.04.md
+++ b/base/hygon-dtk26.04.md
@@ -29,6 +29,7 @@ Explicitly installed; the version is the one baked into this image:
 - `libnuma1` — 2.0.18
 - `libpciaccess0` — 0.17
 - `pciutils` — 3.10.0
+- `unzip` — 6.0-28ubuntu2
 - `vim` — 9.1.0016
 
 ### SDK components

--- a/packaging/megatron/verify/verify-megatron-backend.sh
+++ b/packaging/megatron/verify/verify-megatron-backend.sh
@@ -169,14 +169,16 @@ snapshot() {
     docker exec "${CONTAINER}" bash -c '
         source /opt/dtk-26.04/env.sh 2>/dev/null || true
         for pkg in '"${WATCH_PKGS}"'; do
+            # No f-string with embedded backslash: runtime pythons are 3.10/3.11,
+            # where that is a SyntaxError (PEP 701 only in 3.12+).
             python3 - "$pkg" <<'"'"'PY'"'"'
 import sys, importlib.metadata as m
 pkg = sys.argv[1]
 try:
     dist = m.distribution(pkg)
-    print(f"{pkg} {dist.version} {dist.locate_file(\"\")}")
+    print(pkg, dist.version, dist.locate_file(""))
 except m.PackageNotFoundError:
-    print(f"{pkg} MISSING")
+    print(pkg, "MISSING")
 PY
         done
     '


### PR DESCRIPTION
## What

Bugfix for `packaging/megatron/verify/verify-megatron-backend.sh` (from #379): the BEFORE snapshot used `f"{pkg} {dist.version} {dist.locate_file(\"\")}"` — a backslash inside an f-string expression, which is a **SyntaxError before Python 3.12** (PEP 701). The runtime venvs are 3.10 (hygon / kunlunxin / mthreads) and 3.11 (ascend), so on the first real run the script died at Step 2, before the install even executed:

```
SyntaxError: f-string expression part cannot include a backslash
```

Fix: plain `print(pkg, dist.version, dist.locate_file(""))` — identical output, no backslash in the expression.

## Verified on the hygon node

Full run now passes end-to-end against `flagos-runtime-hygon-dtk26.04:2.1.2`:

```
unchanged: torch 2.9.0+das.opt1.dtk2604 /flagos/lib/python3.10/site-packages
unchanged: triton MISSING
unchanged: flag_gems 5.3.4 /flagos/lib/python3.10/site-packages
unchanged: numpy 1.26.4 /flagos/lib/python3.10/site-packages
Dependency matrix intact: torch / triton / flag_gems / numpy unchanged.
megatron.core imported: /flagos/lib/python3.10/site-packages/megatron/core/__init__.py
megatron-core version: 0.17.1
helpers_cpp bindings OK
```

So the single-step `pip install megatron-core==0.17.1` from `flagos-pypi-hygon` is inert on the runtime matrix — the app-image safety property holds.

This PR was written in part with the assistance of generative AI.
