### PR TITLE
fix(base): add unzip to base images missing it

### DIFF
--- a/base/enflame-tops1.10.6
+++ b/base/enflame-tops1.10.6
@@ -29,7 +29,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # ── System packages ────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl git vim ca-certificates libelf1 \
+        curl unzip git vim ca-certificates libelf1 \
         gcc g++ build-essential make cmake \
     && rm -rf /var/lib/apt/lists/*
 

--- a/base/enflame-tops1.9.10
+++ b/base/enflame-tops1.9.10
@@ -29,7 +29,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # ── System packages ────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl git vim ca-certificates libelf1 \
+        curl unzip git vim ca-certificates libelf1 \
         gcc g++ build-essential cmake \
     && rm -rf /var/lib/apt/lists/*
 

--- a/base/kunlunxin-xre5.37.1
+++ b/base/kunlunxin-xre5.37.1
@@ -32,7 +32,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # ── System packages ────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
-       git vim ca-certificates curl \
+       git vim ca-certificates curl unzip \
        gcc g++ build-essential make cmake \
        pciutils \
    && rm -rf /var/lib/apt/lists/*

--- a/base/metax-maca3.7.2.1
+++ b/base/metax-maca3.7.2.1
@@ -35,7 +35,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # base dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-      curl git vim ca-certificates libnuma1 libelf1 \
+      curl unzip git vim ca-certificates libnuma1 libelf1 \
       gcc g++ cmake make build-essential libpython3-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/base/metax-maca3.8.1.3
+++ b/base/metax-maca3.8.1.3
@@ -35,7 +35,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # base dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-      curl git vim ca-certificates libnuma1 libelf1 \
+      curl unzip git vim ca-certificates libnuma1 libelf1 \
       gcc g++ cmake make build-essential libpython3-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/base/mthreads-musa4.3.6
+++ b/base/mthreads-musa4.3.6
@@ -36,7 +36,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # ── System packages ────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl git vim ca-certificates \
+        curl unzip git vim ca-certificates \
         gcc g++ build-essential cmake \
         libelf1 libnuma-dev libgfortran5 libpython3-dev \
         libopenmpi-dev openmpi-bin \

--- a/base/mthreads-musa5.2.0
+++ b/base/mthreads-musa5.2.0
@@ -36,7 +36,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # ── System packages ────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl git vim ca-certificates \
+        curl unzip git vim ca-certificates \
         gcc g++ build-essential cmake \
         libelf1 libnuma-dev libgfortran5 libpython3-dev \
         libopenmpi-dev openmpi-bin \

--- a/base/nvidia-cuda12.8
+++ b/base/nvidia-cuda12.8
@@ -30,7 +30,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # base dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-      curl git vim ca-certificates libnuma1 libelf1 \
+      curl unzip git vim ca-certificates libnuma1 libelf1 \
       gcc g++ cmake make build-essential libpython3-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/base/nvidia-cuda13.3
+++ b/base/nvidia-cuda13.3
@@ -30,7 +30,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # base dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-      curl git vim ca-certificates libnuma1 libelf1 \
+      curl unzip git vim ca-certificates libnuma1 libelf1 \
       gcc g++ cmake make build-essential libpython3-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/base/sunrise-tangrt1.2.0
+++ b/base/sunrise-tangrt1.2.0
@@ -35,7 +35,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # ── System packages ────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        git vim ca-certificates curl \
+        git vim ca-certificates curl unzip \
         gcc g++ build-essential cmake pciutils \
     && rm -rf /var/lib/apt/lists/*
 

--- a/base/tsingmicro-tsm260610
+++ b/base/tsingmicro-tsm260610
@@ -37,7 +37,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # libfmt8 (22.04) — torch_txda links libfmt.so.8; 24.04 ships libfmt.so.9;
 # sudo is hardcoded dependency from TSM installers.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      curl git vim ca-certificates \
+      curl unzip git vim ca-certificates \
       gcc g++ build-essential cmake clang \
       libopenmpi3 sudo \
       libunwind8 \


### PR DESCRIPTION
## Summary

Issue #371 reported the hygon base image missing `unzip` (the megatron-core wheel build hit this and had to fall back to Python's `zipfile`). The hygon fix landed in #381; this PR covers the **11 remaining base images** that still lack it.

## Changes

Add `unzip` to the apt install list of:

- `base/enflame-tops1.10.6`, `base/enflame-tops1.9.10`
- `base/kunlunxin-xre5.37.1`
- `base/metax-maca3.7.2.1`, `base/metax-maca3.8.1.3`
- `base/mthreads-musa4.3.6`, `base/mthreads-musa5.2.0`
- `base/nvidia-cuda12.8`, `base/nvidia-cuda13.3`
- `base/sunrise-tangrt1.2.0`
- `base/tsingmicro-tsm260610`

The 5 bases that already had `unzip` (ascend ×2, cambricon ×2, iluvatar) are untouched.

## Note on docs

`base/<name>.md` package lists are generated artifacts (docs/gen_data.py + gendoc pipeline), so they are intentionally **not** hand-edited here. The `unzip` entries with real versions will be regenerated by the gendoc workflow after the images are rebuilt.

This PR was written in part with the assistance of generative AI.
