### PR TITLE
fix(ci): point enflame-tops1.9.10 at the shared enflame runner label

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -48,7 +48,8 @@ runners:
     ascend-cann9.0.0: [self-hosted, cann9]
     cambricon-neuware4.4.3: [self-hosted, cambricon]
     cambricon-neuware4.7.2: [self-hosted, cambricon]
-    enflame-tops1.9.10: [self-hosted, tops1910]
+    # Both enflame SDKs build on the same runner (shared label tops1106).
+    enflame-tops1.9.10: [self-hosted, tops1106]
     enflame-tops1.10.6: [self-hosted, tops1106]
     hygon-dtk26.04: [self-hosted, hygon]
     iluvatar-corex4.4.0: [self-hosted, iluvatar]


### PR DESCRIPTION
Fix enflame-tops1.9.10 base-image runner label

`enflame-tops1.9.10` was mapped to `tops1910`, a label no runner carries, so
its base-image build sat queued forever. Both enflame SDKs build on the same
runner, which is labeled `tops1106` (the label `enflame-tops1.10.6` already
uses and which has succeeded). Point both at `tops1106`.

This PR was written in part with the assistance of generative AI.
