### PR TITLE
fix(ci): match gendoc-base workflow_run to the renamed base workflow

### DIFF
--- a/.github/workflows/gendoc-base.yaml
+++ b/.github/workflows/gendoc-base.yaml
@@ -45,7 +45,7 @@ on:
         type: number
         default: 0
   workflow_run:
-    workflows: ["Base Image Build (manual)"]
+    workflows: ["Build Base Image (manual)"]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
PR #339 renamed base-image.yaml to "Build Base Image (manual)" but
gendoc-base.yaml still watched "Base Image Build (manual)", silently
breaking the auto-trigger (no gendoc runs / description PRs since Aug 8).
