### PR TITLE
docs(app): add under-construction warning to vllm and megatron pages

### DIFF
--- a/docs/content/en/application/megatron.md
+++ b/docs/content/en/application/megatron.md
@@ -20,6 +20,12 @@ weight: 20
  -->
 
 
+{{< alert context="danger" >}}
+🚧 **Under construction.** The Megatron app image is still being built and
+validated. It is **not yet published** — the content below documents work in
+progress, not a released product. Do not treat it as usable.
+{{< /alert >}}
+
 The **Megatron app image** is built on top of a `flagos-runtime` image and
 packages a usable megatron-core library for megatron-lm based training.
 

--- a/docs/content/en/application/vllm.md
+++ b/docs/content/en/application/vllm.md
@@ -20,6 +20,12 @@ weight: 10
  -->
 
 
+{{< alert context="danger" >}}
+🚧 **Under construction.** The vLLM app image is still being built and
+validated. It is **not yet published** — the content below documents work in
+progress, not a released product. Do not treat it as usable.
+{{< /alert >}}
+
 The **vLLM app image** is built on top of a `flagos-runtime` image and
 packages a ready-to-run vLLM server with vllm-plugin-FL.
 

--- a/docs/content/zh-cn/application/megatron.md
+++ b/docs/content/zh-cn/application/megatron.md
@@ -20,6 +20,11 @@ weight: 20
  -->
 
 
+{{< alert context="danger" >}}
+🚧 **施工中。** Megatron 应用镜像仍在构建与验证阶段，**尚未发布**——下文内容记录的
+是进行中的工作，而非已发布的产品，请勿将其视为可用状态。
+{{< /alert >}}
+
 **Megatron 应用镜像**构建在 `flagos-runtime` 之上，打包可用的 megatron-core
 库，用于 megatron-lm 训练栈。
 

--- a/docs/content/zh-cn/application/vllm.md
+++ b/docs/content/zh-cn/application/vllm.md
@@ -20,6 +20,11 @@ weight: 10
  -->
 
 
+{{< alert context="danger" >}}
+🚧 **施工中。** vLLM 应用镜像仍在构建与验证阶段，**尚未发布**——下文内容记录的是
+进行中的工作，而非已发布的产品，请勿将其视为可用状态。
+{{< /alert >}}
+
 **vLLM 应用镜像**构建在 `flagos-runtime` 之上，打包一个可运行的 vLLM 服务
 与 vllm-plugin-FL 插件。
 


### PR DESCRIPTION
## What

The vLLM and Megatron **app images are still being built and validated**, but
their documentation pages are already live on the site (added in #370/#221).
Visitors could mistake the published pages for a released product.

This PR adds a prominent **danger alert** ("Under construction / 施工中") at the
top of all four pages:

- `docs/content/en/application/vllm.md`
- `docs/content/en/application/megatron.md`
- `docs/content/zh-cn/application/vllm.md`
- `docs/content/zh-cn/application/megatron.md`

The alert uses the Lotus Docs `{{< alert context="danger" >}}` shortcode (the
site already renders it via the theme).

## Verify

Local `hugo` build renders exactly one `alert-danger` box on each page
(en/zh × vllm/megatron), warning text included.

## Follow-up

Remove the alert once the app images are published and validated.

This PR was written in part with the assistance of generative AI.
