### PR TITLE
feat(megatron-wheel): commit-level version provenance 0.17.1+fl.<date>.g<sha>

### DIFF
--- a/.github/workflows/megatron-wheel.yml
+++ b/.github/workflows/megatron-wheel.yml
@@ -53,7 +53,7 @@ on:
         type: string
         default: main
       mlf_version:
-        description: 'Wheel version override (blank = repo version, e.g. 0.17.1.post20260812)'
+        description: 'Wheel version override (e.g. 0.17.1+fl.0.2.0 for a release build); blank = auto-derived commit provenance 0.17.1+fl.<date>.g<sha>'
         type: string
         default: ''
       upload:

--- a/packaging/megatron/builder/Containerfile
+++ b/packaging/megatron/builder/Containerfile
@@ -56,8 +56,9 @@ ARG EXTRA_PYPI="https://mirrors.aliyun.com/pypi/simple"
 # Megatron-LM-FL source (branch or tag — --branch clone below).
 ARG MLF_REPO=https://github.com/flagos-ai/Megatron-LM-FL.git
 ARG MLF_REF=main
-# Optional wheel-version override (e.g. 0.17.1.post20260812); blank = the
-# repo's own version (0.17.1). Handled by stamp_version.py.
+# Optional wheel-version override (e.g. 0.17.1+fl.0.2.0 for a release build);
+# blank = auto-derive commit-level provenance (0.17.1+fl.<date>.g<commit-sha>)
+# from the cloned checkout. Handled by stamp_version.py.
 ARG MLF_VERSION=
 
 # Outbound proxy for the git clone (CN runners can't reach github.com
@@ -117,7 +118,7 @@ RUN cd /opt/megatron-lm-fl \
     && grep -n 'requires-python' pyproject.toml \
     && grep -q 'requires-python = ">=3.10"' pyproject.toml
 
-# Optional wheel-version stamp (no-op when MLF_VERSION is blank).
+# Optional wheel-version stamp (blank MLF_VERSION = auto-derive provenance).
 RUN MLF_VERSION="${MLF_VERSION}" python /usr/local/bin/stamp_version.py
 
 # Build the wheel. --no-build-isolation uses the build deps installed above

--- a/packaging/megatron/builder/README.md
+++ b/packaging/megatron/builder/README.md
@@ -77,7 +77,7 @@ docker build \
 cid=$(docker create megatron-wheel:hygon-dtk26.04)
 docker cp $cid:/wheels/. ./wheels
 docker rm $cid
-ls wheels/*.whl   # megatron_core-0.17.1-cp310-cp310-linux_x86_64.whl
+ls wheels/*.whl   # megatron_core-0.17.1+fl.20260814.gba22f6b673f3-cp310-cp310-linux_x86_64.whl (date+sha = cloned commit)
 ```
 
 Useful build args:
@@ -88,11 +88,15 @@ Useful build args:
 | `EXTRA_PYPI`   | `https://mirrors.aliyun.com/pypi/simple` | CN mirror for build deps                 |
 | `MLF_REPO`     | `https://github.com/flagos-ai/Megatron-LM-FL.git` | Source repo                  |
 | `MLF_REF`      | `main`                               | Branch or tag to build                        |
-| `MLF_VERSION`  | *(blank)*                            | Optional wheel-version override (e.g. `0.17.1.post20260812`); blank = the repo's own version (`0.17.1`) |
+| `MLF_VERSION`  | *(blank)*                            | Wheel-version override (e.g. `0.17.1+fl.0.2.0` for a release build); blank = auto-derived commit provenance `0.17.1+fl.<date>.g<sha>` |
 
 The Containerfile: clones the fork, **patches `requires-python` on the fly**
-(`>=3.12` → `>=3.10`, see below), optionally stamps `MLF_VERSION` into
-`megatron/core/package_info.py` (`stamp_version.py`), installs the missing build
+(`>=3.12` → `>=3.10`, see below), stamps the wheel version into
+`megatron/core/package_info.py` (`stamp_version.py`) — by default the
+**commit-level provenance label** `0.17.1+fl.<date>.g<sha>` (public part =
+upstream megatron-core version, `fl.<date>.g<sha>` = the fork commit's date and
+the exact commit cloned; PEP 440 ignores local labels in `==0.17.1` matching,
+so existing pins keep resolving) — installs the missing build
 deps into the runtime venv, builds with `pip wheel . --no-deps
 --no-build-isolation` (no uv, no lock file; `--no-deps` here means "don't build
 torch from PyPI", it is not an install), then runs two gates:
@@ -152,5 +156,5 @@ build image — proof that the install is inert before the wheel is published.
 - Verify (after `source /opt/dtk-26.04/env.sh` on hygon):
 
   ```bash
-  python -c "import megatron.core; print(megatron.core.__version__)"   # 0.17.1
+  python -c "import megatron.core; print(megatron.core.__version__)"   # 0.17.1+fl.20260814.gba22f6b673f3
   ```

--- a/packaging/megatron/builder/stamp_version.py
+++ b/packaging/megatron/builder/stamp_version.py
@@ -17,8 +17,21 @@
 
 Reads MLF_VERSION from the environment (e.g. "0.17.1.post20260812"), parses it
 as MAJOR.MINOR.PATCH[<pre-release>] and rewrites the four static constants in
-``megatron/core/package_info.py``. Blank MLF_VERSION is a no-op (the repo's own
-version, e.g. 0.17.1, is used).
+``megatron/core/package_info.py``. Blank MLF_VERSION derives commit-level
+provenance from the git checkout instead:
+
+  <repo public version>+fl.<commit-date>.g<short-sha>
+    e.g. 0.17.1+fl.20260814.gba22f6b673f3
+
+The public part stays the upstream megatron-core version (``==0.17.1`` pins
+keep resolving — PEP 440 ignores local labels in == matching). The local label
+carries two things: the committer date as a pure-numeric leading segment
+(``20260814`` — PEP 440 compares numeric segments numerically, so two wheels
+sort by build date and a human can see which is newer at a glance), and the
+exact flagos-ai/Megatron-LM-FL commit cloned into the build
+(``git clone --depth 1``) as the ``fl.g<sha>`` tail — so the wheel answers
+"which MLF code is this?" unambiguously. An explicit MLF_VERSION
+(e.g. ``0.17.1+fl.0.2.0`` for a release build) is used verbatim.
 
 package_info.py is a pure static module (no imports), so setuptools' dynamic
 ``version = {attr = ...}`` resolves it via AST without importing anything —
@@ -26,15 +39,19 @@ rewriting the constants is therefore safe in the torch-free build env.
 
 PEP 440 note: the module joins the version as
 ``'.'.join(MAJOR.MINOR.PATCH) + PRE_RELEASE``, so a pre-release/stamp must carry
-its own leading separator: "0.17.1.post20260812" -> PRE_RELEASE = ".post20260812".
+its own leading separator: "0.17.1.post20260812" -> PRE_RELEASE = ".post20260812",
+and a provenance local label its own "+": "0.17.1+fl.20260814.gba22f6b673f3" ->
+PRE_RELEASE = "+fl.20260814.gba22f6b673f3".
 """
 
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
-PACKAGE_INFO = Path("/opt/megatron-lm-fl/megatron/core/package_info.py")
+REPO_DIR = Path(os.environ.get("MLF_REPO_DIR", "/opt/megatron-lm-fl"))
+PACKAGE_INFO = REPO_DIR / "megatron" / "core" / "package_info.py"
 
 _VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(.*)$")
 # Line-oriented replaces (package_info.py declares one constant per line).
@@ -46,11 +63,39 @@ _CONST_RE = {
 }
 
 
+def _const(key: str) -> str:
+    return _CONST_RE[key].search(PACKAGE_INFO.read_text()).group(0).split("=", 1)[1].strip()
+
+
+def _repo_public_version() -> str:
+    """Upstream megatron-core version as the checkout currently declares it."""
+    return f"{_const('MAJOR')}.{_const('MINOR')}.{_const('PATCH')}" + _const("PRE_RELEASE").strip('"')
+
+
+def _derive_commit_version() -> str:
+    """<public>+fl.<commit-date>.g<short-sha> from the cloned checkout; '' if not a git repo."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO_DIR), "show", "-s", "--format=%H%n%cs", "HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip().splitlines()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if len(out) < 2 or not out[0] or not out[1]:
+        return ""
+    sha, date = out[0][:12], out[1].replace("-", "")
+    return f"{_repo_public_version()}+fl.{date}.g{sha}"
+
+
 def main() -> int:
     version = os.environ.get("MLF_VERSION", "")
     if not version:
-        print("MLF_VERSION unset/blank — keeping the repo's own version")
-        return 0
+        version = _derive_commit_version()
+        if version:
+            print(f"MLF_VERSION unset/blank — derived {version} from the git checkout")
+        else:
+            print("MLF_VERSION unset/blank and no git provenance available — keeping the repo's own version")
+            return 0
 
     m = _VERSION_RE.match(version)
     if not m:


### PR DESCRIPTION
## What

Blank `MLF_VERSION` now stamps the megatron-core wheel with **commit-level provenance** derived from the cloned checkout, instead of no-oping to the repo's own version:

```
<upstream public version>+fl.<commit-date>.g<short-sha>
0.17.1+fl.20260814.gba22f6b673f3
```

Addresses the review feedback that the previous `0.17.1+fl.g<sha>` label was not sortable — the SHA segment has no ordering meaning. The new scheme keeps:

- **Pins intact** — public part stays the upstream version; `==0.17.1` keeps matching (PEP 440 ignores local labels in `==` matching). The old `0.17.1.post20260812` scheme was a latent pin-breaker (`==` does not match post-releases).
- **Sortability/readability** — the committer date is a pure-numeric leading segment, so two wheels sort by build date and a human sees which is newer at a glance.
- **Exact provenance** — the `g<sha>` tail pins the exact fork commit cloned (`--depth 1`).

`stamp_version.py` derives it via `git show -s --format=%H%n%cs HEAD` (one subprocess, works on shallow clones); `REPO_DIR` is overridable via `MLF_REPO_DIR` for testing. Explicit `MLF_VERSION` (e.g. `0.17.1+fl.0.2.0` for a release build) is still used verbatim.

## Verification

Integration-tested against a real `--depth 1` shallow clone of Megatron-LM-FL:

- blank → derived `0.17.1+fl.20260814.gba22f6b673f3`, `PRE_RELEASE = "+fl.20260814.gba22f6b673f3"` ✓
- `Specifier("==0.17.1").contains(...)` → True (local label ignored) ✓
- ordering `0.17.1 < 0.17.1+fl.20260812.g… < 0.17.1+fl.20260814.g…` ✓
- explicit override `0.17.1+fl.0.2.0` verbatim ✓; no-git fallback keeps repo version ✓; invalid input errors ✓; py_compile ✓

Docs (builder README, Containerfile comments, `megatron-wheel.yml` input description) updated to the new scheme.

## Files

- `packaging/megatron/builder/stamp_version.py`
- `packaging/megatron/builder/README.md`
- `packaging/megatron/builder/Containerfile`
- `.github/workflows/megatron-wheel.yml`

This PR was written in part with the assistance of generative AI.
