### PR TITLE
feat(ci): fold no_flaggems toggle into flaggems input ("none" = skip)

### DIFF
--- a/.github/workflows/runtime-image.yaml
+++ b/.github/workflows/runtime-image.yaml
@@ -19,9 +19,9 @@ name: Builid Runtime Image (manual)
 # the two produce identical job names, so without this they are indistinguishable.
 # Shows: layer (v1/v2) · backend · push/no-push · no-cache · pinned flaggems ver.
 run-name: >-
-  ${{ inputs.no_flaggems && 'v1 build' || 'v2 flag_gems' }}
+  ${{ inputs.flaggems == 'none' && 'v1 build' || 'v2 flag_gems' }}
   · ${{ inputs.backend }}
-  · ${{ inputs.push && 'push' || 'no-push' }}${{ inputs.no_cache && ' · no-cache' || '' }}${{ inputs.flaggems != '' && format(' · fg={0}', inputs.flaggems) || '' }}
+  · ${{ inputs.push && 'push' || 'no-push' }}${{ inputs.no_cache && ' · no-cache' || '' }}${{ inputs.flaggems != '' && inputs.flaggems != 'none' && format(' · fg={0}', inputs.flaggems) || '' }}
 
 # Runtime images are built on demand, not on every push/PR. They layer
 # FlagGems (pure Python + optional C++ extension) on top of a base image
@@ -39,13 +39,9 @@ on:
         type: boolean
         default: false
       flaggems:
-        description: 'FlagGems wheel version to install (e.g. 5.3.2)'
+        description: 'FlagGems wheel version to install. Empty = version pinned in configs.yaml. "none" = skip flag_gems entirely (v1, -build image).'
         type: string
         default: ''
-      no_flaggems:
-        description: 'Skip flag_gems install — produce -build image'
-        type: boolean
-        default: false
       skip_cpp:
         description: 'Skip flag_gems C++ extension install (Python wheel only)'
         type: boolean
@@ -135,7 +131,7 @@ jobs:
       - name: Env + parameters
         run: |
           flaggems_ver="${{ inputs.flaggems }}"
-          [[ -z "$flaggems_ver" ]] && flaggems_ver="${{ matrix.flaggems_version }}"
+          [[ -z "$flaggems_ver" || "$flaggems_ver" == "none" ]] && flaggems_ver="${{ matrix.flaggems_version }}"
 
           echo "hostname: $(hostname)"
           echo "arch: $(uname -m)"
@@ -143,7 +139,7 @@ jobs:
           echo "base_image:         ${{ matrix.base_image }}"
           echo "image_tag:          ${{ matrix.image_tag }}"
           echo "flaggems_version:   ${flaggems_ver}"
-          echo "no_flaggems:         ${{ inputs.no_flaggems }}"
+          echo "flaggems_mode:      ${{ inputs.flaggems == 'none' && 'none (v1 -build)' || 'install' }}"
           echo "python_version:      ${{ matrix.python_version }}"
           echo "deps:                ${{ matrix.deps }}"
           echo "cpp_extra:           ${{ matrix.cpp_extra }}"
@@ -160,11 +156,11 @@ jobs:
       - name: Build runtime image
         run: |
           flaggems_ver="${{ inputs.flaggems }}"
-          [[ -z "$flaggems_ver" ]] && flaggems_ver="${{ matrix.flaggems_version }}"
+          [[ -z "$flaggems_ver" || "$flaggems_ver" == "none" ]] && flaggems_ver="${{ matrix.flaggems_version }}"
 
           no_flaggems_arg=""
           image_tag="${{ matrix.image_tag }}"
-          [[ "${{ inputs.no_flaggems }}" == "true" ]] && no_flaggems_arg='--build-arg NO_FLAGGEMS=1' && image_tag="${image_tag}-build"
+          [[ "${{ inputs.flaggems }}" == "none" ]] && no_flaggems_arg='--build-arg NO_FLAGGEMS=1' && image_tag="${image_tag}-build"
 
           cpp_extra="${{ matrix.cpp_extra }}"
           [[ "${{ inputs.skip_cpp }}" == "true" ]] && cpp_extra=""
@@ -183,7 +179,7 @@ jobs:
             --label last-updated=${git_created} \
             --label org.opencontainers.image.source=https://github.com/flagos-ai/build-infra \
             --label flagos.base=${{ matrix.base_image }}"
-          [[ "${{ inputs.no_flaggems }}" != "true" ]] && label_args="${label_args} --label flagos.flaggems=${flaggems_ver}"
+          [[ "${{ inputs.flaggems }}" != "none" ]] && label_args="${label_args} --label flagos.flaggems=${flaggems_ver}"
 
           docker build \
             ${no_cache_arg} \
@@ -210,5 +206,5 @@ jobs:
         if: ${{ inputs.push }}
         run: |
           image_tag="${{ matrix.image_tag }}"
-          [[ "${{ inputs.no_flaggems }}" == "true" ]] && image_tag="${image_tag}-build"
+          [[ "${{ inputs.flaggems }}" == "none" ]] && image_tag="${image_tag}-build"
           docker push "${image_tag}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -84,7 +84,7 @@ gh pr list --head auto/image-descriptions-*
 > **手动触发。** 产出不含 FlagGems 的运行时镜像（`:{version}-build`），用于步骤 5 的 FlagGems wheel 编译。
 
 ```bash
-gh workflow run "Runtime Image Build (manual)" -f backend="all" -f push="true" -f no_flaggems="true"
+gh workflow run "Runtime Image Build (manual)" -f backend="all" -f push="true" -f flaggems="none"
 ```
 
 镜像 tag: `:{version}-build`（如 `:2.2.0-build`）。
@@ -100,8 +100,8 @@ gh run view <RUN_ID> --json jobs -q '...'  # 同步骤 2
 
 如果只有部分 backend 需要 runtime:v1（比如只验证 nvidia），可以只触发指定 backend：
 ```bash
-gh workflow run "Runtime Image Build (manual)" -f backend="nvidia-cuda13.3" -f no_flaggems="true"
-gh workflow run "Runtime Image Build (manual)" -f backend="nvidia-cuda13.3" -f push="true" -f no_flaggems="true"
+gh workflow run "Runtime Image Build (manual)" -f backend="nvidia-cuda13.3" -f flaggems="none"
+gh workflow run "Runtime Image Build (manual)" -f backend="nvidia-cuda13.3" -f push="true" -f flaggems="none"
 ```
 
 ## 5. FlagGems 构建 wheels


### PR DESCRIPTION
## What

Fold the `no_flaggems` boolean toggle into the existing `flaggems` string input:

| `flaggems` value | Meaning |
|---|---|
| _(empty)_ | Install flag_gems at the version pinned in `configs.yaml` |
| `5.4.0` (concrete) | Install flag_gems, pinning the version |
| `none` | Skip flag_gems entirely — v1 build-platform image (`-build` tag) |

`no_flaggems` is removed from `workflow_dispatch` inputs, so there is a single
dimension with no contradictory states (e.g. `flaggems=X` + `no_flaggems=true`
was previously expressible).

## Why

The old dispatch for the plain v2 build read like:

```bash
gh workflow run ... -f flaggems=5.3.2 -f no_flaggems=false
```

— specifying a FlagGems version *and* "no flag_gems" in the same command was
confusing. With this change v2 is simply:

```bash
gh workflow run "Runtime Image Build (manual)" -f backend=all -f push=true
```

and v1 is `-f flaggems=none`.

## Also

- `RELEASE.md` step 4 dispatch commands updated to `flaggems="none"`.
- Run name still self-labels v1/v2 for the Actions list.

This PR was written in part with the assistance of generative AI.
