### PR TITLE
fix(megatron-wheel): bypass proxy for aliyun/flagos/baai endpoints (NO_PROXY)

### DIFF
--- a/.github/workflows/megatron-wheel.yml
+++ b/.github/workflows/megatron-wheel.yml
@@ -129,10 +129,9 @@ jobs:
           # inside this build; a failure here means the wheel is broken and
           # must not be published.
           #
-          # HTTPS_PROXY: the megatron source is cloned from github.com inside
-          # the build; CN runners can't reach it reliably, so route the clone
-          # through the HTTP_PROXY secret (exported as HTTPS_PROXY so git
-          # https:// traffic follows it). Never hardcoded.
+          # HTTPS_PROXY: route the github.com clone through the HTTP_PROXY
+          # secret (never hardcoded). aliyun/flagos/baai are bypassed inside
+          # the Containerfile's baked-in NO_PROXY.
           docker build \
             --build-arg BASE_IMAGE="${BASE_IMAGE}" \
             --build-arg EXTRA_PYPI="${EXTRA_PYPI}" \

--- a/packaging/megatron/builder/Containerfile
+++ b/packaging/megatron/builder/Containerfile
@@ -67,6 +67,8 @@ ARG MLF_VERSION=
 # the clone RUN below).
 ARG HTTPS_PROXY=
 
+ENV NO_PROXY=".aliyun.com,.flagos.net,.baai.ac.cn"
+
 COPY stamp_version.py /usr/local/bin/stamp_version.py
 
 # ── Build deps for megatron.core.datasets.helpers_cpp ─────────────────


### PR DESCRIPTION
The megatron wheel build failed twice this morning (runs [31859785959](https://github.com/flagos-ai/build-infra/actions/runs/31859785959) / [31860851021](https://github.com/flagos-ai/build-infra/actions/runs/31860851021)) at the build-deps pip install (`Step 9/15`):

```
WARNING: Retrying ... 'OSError('Tunnel connection failed: 500 Internal Server Error')': /pypi/simple/setuptools/
ERROR: No matching distribution found for setuptools<80.0.0
```

**Root cause** — the `HTTPS_PROXY` build-arg (`--build-arg HTTPS_PROXY="${HTTP_PROXY}"`, from the `HTTP_PROXY` secret, meant only for the github.com git clone) is auto-injected by BuildKit into **every** RUN env, so pip routed `mirrors.aliyun.com` through the proxy. The proxy allows github.com tunnels but rejects the aliyun CONNECT (`500 Internal Server Error`), so pip gave up after 5 retries. The git clone succeeded because github.com is an allowed proxy target — the asymmetry proves the diagnosis. Yesterday's successful run (no HTTP_PROXY secret on the runner) had the identical `Step 8/14 RUN pip install` succeed.

**Fix** — bake `ENV NO_PROXY=".aliyun.com,.flagos.net,.baai.ac.cn"` into the Containerfile. It's static config (not a secret), applies to every RUN, and covers the aliyun mirror (build deps + smoke install) plus the flagos.net / baai.ac.cn endpoints. github.com stays **out** of NO_PROXY — the megatron clone keeps using the proxy. No ARG plumbing needed; the workflow only passes the HTTPS_PROXY secret as before.

**After merge**: re-dispatch `megatron-wheel.yml` with `backend=hygon-dtk26.04`, `mlf_version` blank (auto provenance `0.17.1+fl.<date>.g<sha>`), `upload=true`, `pypi_repo=flagos-pypi-hygon` to rebuild the stale index wheel.

This PR was written in part with the assistance of generative AI.
