### PR TITLE
refactor(ci): align gendoc-runtime with gendoc-base upload-artifact transport

### DIFF
--- a/.github/workflows/gendoc-runtime.yaml
+++ b/.github/workflows/gendoc-runtime.yaml
@@ -14,21 +14,56 @@
 
 name: Generate docs for runtime images
 
-# Post-build: generate runtime image description markdown (single source for the
-# docs site, the in-repo runtime/<name>.md file, and the Harbor repository
-# description), then commit + upload.
+# Post-build: verify each runtime image best-effort, compose a per-image
+# description markdown (single source for the docs site, the in-repo
+# runtime/<name>.md file, and the Harbor repository description), then
+# commit + upload.
 #
-# Triggered manually when the final runtime image (v2, with flag_gems) has been
-# built and pushed. Not triggered by workflow_run because runtime:v2 is rebuilt
-# repeatedly during the FlagGems testing phase — automatic triggering would
-# produce noisy empty PRs.
+# Aligned with gendoc-base.yaml: the runtime description refresh uses the same
+# upload-artifact transport, per-backend extract jobs on hardware runners, and
+# self-healing retry loop. Verify counts in the PR body come from the extract
+# jobs' real e2e verification (scripts/verify_runtime.py), not hand-entered
+# workflow inputs.
+#
+# Manual-only (no workflow_run trigger): runtime images are rebuilt repeatedly
+# during the FlagGems testing phase, so auto-triggering would produce noisy
+# empty PRs.
+#
+# Transport: each extract job writes an empty version TSV and annotates it with
+# metadata headers (run id, verify outcome) via scripts/annotate_version_tsv.py,
+# then uploads it as a per-backend artifact (versions-<backend>) with
+# upload-artifact. The TSV is a metadata carrier only — the description CONTENT
+# is configs-driven: docs/gen_descriptions.py's render_runtime() does not read
+# TSV data, so finalize regenerates it fresh from configs.yaml via gen_data.py.
+# Accumulate downloads all matching artifacts with download-artifact, merges
+# them, and saves the cumulative set to a git state branch
+# (auto/versions-<label>-state) so retries don't lose already-collected data.
+#
+# Self-healing: self-hosted runner connectivity to GitHub is unreliable across
+# vendors. The accumulate job collects whatever extractors succeed, saves partial
+# results to the state branch, then self-triggers with only the missing backends.
+# This loops until all are collected or the retry cap (50) is hit.
 
 on:
   workflow_dispatch:
+    inputs:
+      backend:
+        description: 'Backends to process — "all" or space-separated names'
+        type: string
+        default: 'all'
+      retry_count:
+        description: 'Number of retries so far (set by the workflow itself)'
+        type: number
+        default: 0
 
 permissions:
   contents: write
   pull-requests: write
+  actions: write
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   authorize:
@@ -41,38 +76,275 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/check-trigger-author
 
-  finalize:
+  set-matrix:
     needs: authorize
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --user pyyaml
+
+      - id: m
+        env:
+          BACKEND: ${{ github.event.inputs.backend || 'all' }}
+        run: |
+          if [[ "${BACKEND}" == "all" ]]; then
+            python3 scripts/generate_matrix.py --runtime > matrix.json
+          else
+            python3 scripts/generate_matrix.py --runtime ${BACKEND} > matrix.json
+          fi
+          echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+  extract:
+    needs: set-matrix
+    # Self-hosted runners are best-effort. When a runner is unreachable
+    # (checkout / Harbor login / docker permissions), the job fails here.
+    # The accumulate job detects the gap and re-dispatches only that backend.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    runs-on: ${{ fromJSON(matrix.runson) }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install PyYAML
-        run: python3 -m pip install --user pyyaml
+        run: |
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages pyyaml
 
-      - name: Generate data and descriptions
+      - name: Harbor login (for image pull)
         env:
-          VERSIONS_DIR: ${{ github.workspace }}/versions
+          HARBOR_USER: ${{ secrets.HARBOR_USER }}
+          HARBOR_PW: ${{ secrets.HARBOR_PASSWORD }}
+          # Harbor is internal — bypass any HTTP_PROXY/HTTPS_PROXY the runner
+          # may have set for GitHub access, otherwise docker login routes
+          # Harbor traffic through the proxy and fails.
+          # Only uppercase HTTP_PROXY/HTTPS_PROXY (lowercase clash with runner
+          # env vars set by the GitHub Actions runner config).
+          HTTP_PROXY: ""
+          HTTPS_PROXY: ""
+          no_proxy: "harbor.baai.ac.cn,.baai.ac.cn"
+        run: |
+          host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
+          for i in 1 2 3; do
+            if printf '%s' "$HARBOR_PW" | docker login "$host" -u "$HARBOR_USER" --password-stdin; then
+              exit 0
+            fi
+            echo "Harbor login attempt $i failed, retrying in 30s..."
+            sleep 30
+          done
+          echo "::warning::Harbor login failed after 3 attempts — skipping ${{ matrix.name }}"
+          exit 1
+
+      - name: Verify runtime image (best-effort)
+        continue-on-error: true
+        id: verify
         run: |
           python3 docs/gen_data.py
-          mkdir -p versions
-          python3 docs/gen_descriptions.py
+          python3 scripts/verify_runtime.py "${{ matrix.name }}"
 
-      - name: Finalize (commit + PR)
+      # The TSV is a metadata transport only — description content is
+      # configs-driven and regenerated at finalize. An empty TSV still carries
+      # the # verify: outcome (real e2e result → PR body counts) and # run: id,
+      # and marks the backend as collected (annotate_version_tsv.py requires
+      # the file to exist; collect_version_tsvs.py counts .tsv files).
+      - name: Create version TSV (transport)
+        run: |
+          mkdir -p versions
+          : > "versions/${{ matrix.name }}.tsv"
+
+      - name: Record verify status
+        if: always()
+        run: |
+          mkdir -p versions
+          echo "${{ steps.verify.outcome }}" > "versions/${{ matrix.name }}.verify_outcome"
+
+      - name: Annotate version TSV
+        run: python3 scripts/annotate_version_tsv.py "${{ matrix.name }}" versions
+
+      - name: Upload version artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: versions-${{ matrix.name }}
+          path: versions/${{ matrix.name }}.tsv
+          if-no-files-found: warn
+
+  accumulate:
+    needs: [set-matrix, extract]
+    if: always() && needs.set-matrix.result == 'success'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RETRY_COUNT: ${{ github.event.inputs.retry_count || 0 }}
+      MAX_RETRIES: 50
+    outputs:
+      done: ${{ steps.collect.outputs.done }}
+      missing: ${{ steps.collect.outputs.missing }}
+      count: ${{ steps.collect.outputs.count }}
+      label: ${{ steps.collect.outputs.label }}
+      verify_ok: ${{ steps.collect.outputs.verify_ok }}
+      verify_fail: ${{ steps.collect.outputs.verify_fail }}
+      verify_skip: ${{ steps.collect.outputs.verify_skip }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --user pyyaml
+
+      # merge-multiple flattens the per-backend artifact contents into
+      # versions-dl/<backend>.tsv, which collect_version_tsvs.py reads.
+      - name: Download version artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          path: versions-dl
+          pattern: versions-*
+          merge-multiple: true
+
+      # Restore previously-collected TSVs from the state branch so that
+      # backends not refreshed this retry retain their data across runs.
+      # On retry=0 the state branch doesn't exist yet — that's fine, we
+      # start fresh.
+      # For scoped runs, only restore TSVs for the backends being collected.
+      - name: Restore state from previous retries
+        env:
+          GIT_AUTHOR_NAME: flagos-ci
+          GIT_AUTHOR_EMAIL: noreply@flagos.net
+          GIT_COMMITTER_NAME: flagos-ci
+          GIT_COMMITTER_EMAIL: noreply@flagos.net
+          SCOPE: ${{ github.event.inputs.backend || 'all' }}
+        run: |
+          label="$(python3 -c 'import yaml;print(yaml.safe_load(open("configs.yaml"))["version"])' 2>/dev/null || echo 'unknown')"
+          state_branch="auto/versions-${label}-state"
+          if git ls-remote --heads origin "refs/heads/${state_branch}" | grep -q refs; then
+            echo "Restoring state from ${state_branch}"
+            git fetch origin "${state_branch}"
+            mkdir -p versions
+            if [[ "${SCOPE}" == "all" ]]; then
+              git checkout FETCH_HEAD -- versions/
+            else
+              for bk in ${SCOPE}; do
+                f="versions/${bk}.tsv"
+                if git show "FETCH_HEAD:${f}" > "${f}" 2>/dev/null; then
+                  echo "  Restored ${bk}.tsv"
+                fi
+              done
+            fi
+          else
+            echo "No state branch (${state_branch}) — starting fresh"
+            mkdir -p versions
+          fi
+
+      # collect: merge TSVs → check completeness.
+      # State was restored above; this step overwrites any stale entries
+      # with freshly-downloaded data. Always exits 0 — the next step
+      # (Finalize or Retry) acts on the done/missing outputs.
+      - id: collect
+        env:
+          GIT_AUTHOR_NAME: flagos-ci
+          GIT_AUTHOR_EMAIL: noreply@flagos.net
+          GIT_COMMITTER_NAME: flagos-ci
+          GIT_COMMITTER_EMAIL: noreply@flagos.net
+        run: |
+          # Collect: merge TSVs → check completeness.
+          # Determine the expected backend set — the same scope set-matrix
+          # used, so scoped runs don't auto-retry for backends that were
+          # never requested.
+          SCOPE="${{ github.event.inputs.backend || 'all' }}"
+          if [[ "${SCOPE}" == "all" ]]; then
+            EXPECTED=""
+          else
+            EXPECTED="${SCOPE}"
+          fi
+          result=$(python3 scripts/collect_version_tsvs.py \
+            --versions versions --remote versions-dl \
+            --retry "${RETRY_COUNT:-0}" \
+            --expected "${EXPECTED}")
+          echo "$result"
+
+          # Parse JSON once, write each field to GITHUB_OUTPUT.
+          echo "$result" | python3 -c "
+          import sys, json
+          d = json.load(sys.stdin)
+          for k in ('done', 'count', 'label', 'missing',
+                    'verify_ok', 'verify_fail', 'verify_skip'):
+              print(f'{k}={d[k]}')
+          " | tee -a "$GITHUB_OUTPUT"
+
+      # Persist collected TSVs to the state branch so they survive
+      # across retries (each accumulate runs on a fresh ubuntu-latest VM).
+      # Each save is a full snapshot of versions/ — no incremental merge.
+      - name: Save state for next retry
+        if: always() && steps.collect.outcome == 'success'
+        env:
+          GIT_AUTHOR_NAME: flagos-ci
+          GIT_AUTHOR_EMAIL: noreply@flagos.net
+          GIT_COMMITTER_NAME: flagos-ci
+          GIT_COMMITTER_EMAIL: noreply@flagos.net
+        run: |
+          label="$(python3 -c 'import yaml;print(yaml.safe_load(open("configs.yaml"))["version"])' 2>/dev/null || echo 'unknown')"
+          state_branch="auto/versions-${label}-state"
+
+          if [ ! -d versions ] || [ -z "$(ls -A versions 2>/dev/null)" ]; then
+            echo "No version data to save"
+            exit 0
+          fi
+
+          # Stage all TSV files so write-tree captures them (collect step
+          # copies them from versions-dl/ — they are untracked).
+          git add -f versions/*.tsv 2>/dev/null || true
+
+          # Build a tree of the versions/ directory contents, then wrap it
+          # in an outer tree so restore via checkout -- versions/ works.
+          inner_tree=$(git write-tree --prefix=versions/)
+          if [ -z "$inner_tree" ]; then
+            echo "Failed to create inner tree"
+            git restore --staged versions/ 2>/dev/null || true
+            exit 0
+          fi
+          outer_tree=$(printf "040000 tree %s\tversions" "$inner_tree" | git mktree)
+
+          # Use previous state commit as parent if it exists.
+          parent=""
+          if git ls-remote --heads origin "refs/heads/${state_branch}" | grep -q refs; then
+            parent=$(git rev-parse "origin/${state_branch}" 2>/dev/null || echo "")
+          fi
+          parent_opt=""
+          if [ -n "$parent" ]; then
+            parent_opt="-p $parent"
+          fi
+          commit=$(echo "state:${label}" | git commit-tree "$outer_tree" $parent_opt)
+          git push -f origin "${commit}:refs/heads/${state_branch}"
+          echo "Saved state to ${state_branch} (commit ${commit:0:12})"
+
+          # Unstage to keep working tree clean for the finalize step.
+          git restore --staged versions/ 2>/dev/null || true
+
+      - name: Finalize (descriptions + PR) or retry
+        if: always() && steps.collect.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSIONS_DIR: ${{ github.workspace }}/versions
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          git config user.name flagos-ci
-          git config user.email noreply@flagos.net
+          # collect poisons the index (git add -f versions/); unstage it.
+          git restore --staged .
+          git clean -fd -- versions-dl 2>/dev/null || true
 
-          LABEL=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo latest)
           python3 scripts/finalize_descriptions.py \
             --mode runtime \
-            --done true \
-            --count 14 \
-            --label "$LABEL" \
-            --verify-ok 0 --verify-fail 0 --verify-skip 0
+            --done "${{ steps.collect.outputs.done }}" \
+            --count "${{ steps.collect.outputs.count || 0 }}" \
+            --label "${{ steps.collect.outputs.label || 'unknown' }}" \
+            --missing "${{ steps.collect.outputs.missing || '' }}" \
+            --verify-ok "${{ steps.collect.outputs.verify_ok || 0 }}" \
+            --verify-fail "${{ steps.collect.outputs.verify_fail || 0 }}" \
+            --verify-skip "${{ steps.collect.outputs.verify_skip || 0 }}" \
+            --retry "${{ env.RETRY_COUNT || 0 }}" \
+            --max-retries "${MAX_RETRIES:-50}"

--- a/scripts/finalize_descriptions.py
+++ b/scripts/finalize_descriptions.py
@@ -61,6 +61,7 @@ MODE_CONFIG = {
             "\n\n**Verify:** {verify_ok} passed, {verify_fail} failed, {verify_skip} skipped"
         ),
         "commit_msg": "docs(base): refresh image descriptions for {label}",
+        "workflow": "gendoc-base.yaml",
     },
     "runtime": {
         "add_paths": [
@@ -76,6 +77,7 @@ MODE_CONFIG = {
             "\n\n**Verify:** {verify_ok} passed, {verify_fail} failed, {verify_skip} skipped"
         ),
         "commit_msg": "docs(runtime): refresh image descriptions for {label}",
+        "workflow": "gendoc-runtime.yaml",
     },
 }
 
@@ -189,6 +191,7 @@ def _finalize(args) -> None:
 
 def _retry(args) -> None:
     """Self-trigger the workflow for missing backends."""
+    cfg = MODE_CONFIG[args.mode]
     missing = args.missing.strip()
     retry = args.retry
     max_retries = args.max_retries
@@ -222,7 +225,7 @@ def _retry(args) -> None:
     # display name ("Generate docs for base images") has changed before and
     # silently broke the retry loop.
     subprocess.run(
-        ["gh", "workflow", "run", "gendoc-base.yaml",
+        ["gh", "workflow", "run", cfg["workflow"],
          "-f", f"backend={missing}", "-f", f"retry_count={next_retry}"],
         check=True, cwd=REPO_ROOT,
     )


### PR DESCRIPTION
Aligns `gendoc-runtime.yaml` with `gendoc-base.yaml` — same `upload-artifact` transport, same self-healing retry loop.

**Workflow shape (mirrors gendoc-base.yaml):**

- `extract` — per-backend job on the hardware runner (`continue-on-error: true`): Harbor login → `scripts/verify_runtime.py` (best-effort) → empty TSV as metadata carrier → `annotate_version_tsv.py` stamps `# run:` + `# verify:` → `upload-artifact` as `versions-<backend>`
- `accumulate` — on `ubuntu-latest`: `download-artifact` → restore `auto/versions-<label>-state` → `collect_version_tsvs.py` → save state → `finalize_descriptions.py`

**Design notes:**

- Runtime description **content** stays configs-driven: `render_runtime()` never reads TSV data, so `finalize` regenerates it fresh from `configs.yaml` via `gen_data.py`. The TSV is transport/metadata only — its `# verify:` header carries the real e2e outcome into the PR body counts (no more hardcoded `0/0/0`, last cycle's #328 shipped "14 backends / 0 passed").
- Self-healing: missing backends self-trigger the workflow by **file name** (`gendoc-runtime.yaml`), not display name. Fixed `scripts/finalize_descriptions.py` `_retry()` which hardcoded `gendoc-base.yaml` — runtime-mode retries would have re-dispatched the base workflow.

Supersedes #396 (input-param approach). This PR was written in part with the assistance of generative AI.
