### PR TITLE
Add flash-attn to hygon runtime image

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -317,6 +317,7 @@ vendors:
       triton: triton==3.3.0+das.opt1.dtk2604.torch290
       flagtree: flagtree==0.6.1+hcu3.6
       deps:
+        - flash_attn==2.8.3+das.opt1.dtk2604.torch290
         - torch==2.9.0+das.opt1.dtk2604
         # torch built against the numpy 1.x C ABI
         # opencv-python-headless declares numpy>=2, but that is a pkg declaration only.


### PR DESCRIPTION
This PR adds the flash_attn package to the Hygon runtime image so that it can run RL service. It may help the VLLM packaging as well.