### PR TITLE
fix(megatron): patch compile_helpers to sysconfig during wheel builds

### DIFF
--- a/packaging/megatron/builder/Containerfile
+++ b/packaging/megatron/builder/Containerfile
@@ -70,6 +70,7 @@ ARG HTTPS_PROXY=
 ENV NO_PROXY=".aliyun.com,.flagos.net,.baai.ac.cn"
 
 COPY stamp_version.py /usr/local/bin/stamp_version.py
+COPY patch-compile-helpers-sysconfig.py /usr/local/bin/patch-compile-helpers-sysconfig.py
 
 # ── Build deps for megatron.core.datasets.helpers_cpp ─────────────────
 # Installed into the runtime venv (/flagos/bin/python is on PATH via ENV).
@@ -119,6 +120,19 @@ RUN cd /opt/megatron-lm-fl \
     && sed -i 's/^requires-python = ">=3\.12"$/requires-python = ">=3.10"/' pyproject.toml \
     && grep -n 'requires-python' pyproject.toml \
     && grep -q 'requires-python = ">=3.10"' pyproject.toml
+
+# compile_helpers() (megatron/core/datasets/utils.py, a FlagOS fork addition)
+# shells out to `python3-config --extension-suffix`, which uv-created venvs
+# don't carry (python3-config is a CPython build artifact, not a pip package)
+# — the dataset import path then dies with FileNotFoundError on the runtime
+# venv. Patch the checkout to derive the extension suffix from stdlib
+# sysconfig instead: the same one-line change as Megatron-LM-FL PR #112,
+# applied on the fly while that PR is unmerged. The patch is idempotent and
+# self-gating — no-op when the sysconfig form is already present, exit 1 if
+# the source moved on — so a silently-skipped patch can never ship a wheel
+# that still needs python3-config.
+RUN cd /opt/megatron-lm-fl \
+    && python /usr/local/bin/patch-compile-helpers-sysconfig.py megatron/core/datasets/utils.py
 
 # Optional wheel-version stamp (blank MLF_VERSION = auto-derive provenance).
 RUN MLF_VERSION="${MLF_VERSION}" python /usr/local/bin/stamp_version.py

--- a/packaging/megatron/builder/Containerfile
+++ b/packaging/megatron/builder/Containerfile
@@ -121,16 +121,9 @@ RUN cd /opt/megatron-lm-fl \
     && grep -n 'requires-python' pyproject.toml \
     && grep -q 'requires-python = ">=3.10"' pyproject.toml
 
-# compile_helpers() (megatron/core/datasets/utils.py, a FlagOS fork addition)
-# shells out to `python3-config --extension-suffix`, which uv-created venvs
-# don't carry (python3-config is a CPython build artifact, not a pip package)
-# — the dataset import path then dies with FileNotFoundError on the runtime
-# venv. Patch the checkout to derive the extension suffix from stdlib
-# sysconfig instead: the same one-line change as Megatron-LM-FL PR #112,
-# applied on the fly while that PR is unmerged. The patch is idempotent and
-# self-gating — no-op when the sysconfig form is already present, exit 1 if
-# the source moved on — so a silently-skipped patch can never ship a wheel
-# that still needs python3-config.
+# compile_helpers() uses python3-config (absent in uv venvs) — patch to
+# sysconfig (MLF PR #112, on the fly while unmerged). Idempotent, and fails
+# loudly if the source moved on.
 RUN cd /opt/megatron-lm-fl \
     && python /usr/local/bin/patch-compile-helpers-sysconfig.py megatron/core/datasets/utils.py
 

--- a/packaging/megatron/builder/patch-compile-helpers-sysconfig.py
+++ b/packaging/megatron/builder/patch-compile-helpers-sysconfig.py
@@ -13,63 +13,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""On-the-fly patch: compile_helpers() extension suffix via sysconfig.
-
-Megatron-LM-FL's compile_helpers() (megatron/core/datasets/utils.py, a
-FlagOS fork addition) shells out to `python3-config --extension-suffix` to
-locate the prebuilt helpers_cpp .so. python3-config is a CPython build
-artifact, not a pip package — uv-created venvs (as in the runtime images)
-do not carry it, so the dataset import path dies with FileNotFoundError.
-
-The proper fix is upstream: Megatron-LM-FL PR #112 switches to
-sysconfig.get_config_var("EXT_SUFFIX") (stdlib, present in every Python).
-This script is the build-infra fallback that applies the same change on the
-fly during wheel builds while that PR is unmerged. It is idempotent and
-fails loudly if the source moved on (exit 1 when neither form is found),
-so a silently-skipped patch can never ship a wheel that still needs
-python3-config.
-
-Usage: python patch-compile-helpers-sysconfig.py <megatron/core/datasets/utils.py>
-"""
+"""Replace python3-config with sysconfig in compile_helpers() (no-op if done)."""
 
 import pathlib
 import sys
 
+OLD = (
+    "    ext_suffix = subprocess.check_output(\n"
+    '        ["python3-config", "--extension-suffix"], text=True\n'
+    "    ).strip()\n"
+)
+NEW = '    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")\n'
+
 
 def main() -> int:
     if len(sys.argv) != 2:
-        print("usage: patch-compile-helpers-sysconfig.py <utils.py>", file=sys.stderr)
+        print(f"usage: {sys.argv[0]} <utils.py>", file=sys.stderr)
         return 2
     p = pathlib.Path(sys.argv[1])
     src = p.read_text()
-    marker = 'sysconfig.get_config_var("EXT_SUFFIX")'
-    old_import = "    import subprocess\n"
-    old_body = (
-        "    ext_suffix = subprocess.check_output(\n"
-        '        ["python3-config", "--extension-suffix"], text=True\n'
-        "    ).strip()\n"
-    )
-    if marker in src:
-        print(">>> compile_helpers: sysconfig form already present (no-op)")
-    elif old_body in src:
-        assert old_import in src, "compile_helpers imports changed unexpectedly"
-        src = src.replace(old_import, old_import + "    import sysconfig\n", 1)
-        src = src.replace(
-            old_body,
-            '    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")\n',
-            1,
-        )
-        p.write_text(src)
-        print(">>> compile_helpers: patched python3-config -> sysconfig")
-    else:
-        print(
-            "ERROR: compile_helpers source moved on — neither python3-config "
-            "nor sysconfig form found; rework the builder patch",
-            file=sys.stderr,
-        )
+    if NEW in src:
+        return 0  # already patched (upstream PR merged)
+    if OLD not in src:
+        print("ERROR: source moved on; rework the patch", file=sys.stderr)
         return 1
-    assert marker in p.read_text(), "compile_helpers sysconfig patch did not land"
-    print("gate OK: compile_helpers uses sysconfig")
+    src = src.replace("    import subprocess\n", "    import subprocess\n    import sysconfig\n", 1)
+    src = src.replace(OLD, NEW, 1)
+    p.write_text(src)
+    assert "    import sysconfig\n" in src and NEW in src, "patch did not land"
     return 0
 
 

--- a/packaging/megatron/builder/patch-compile-helpers-sysconfig.py
+++ b/packaging/megatron/builder/patch-compile-helpers-sysconfig.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""On-the-fly patch: compile_helpers() extension suffix via sysconfig.
+
+Megatron-LM-FL's compile_helpers() (megatron/core/datasets/utils.py, a
+FlagOS fork addition) shells out to `python3-config --extension-suffix` to
+locate the prebuilt helpers_cpp .so. python3-config is a CPython build
+artifact, not a pip package — uv-created venvs (as in the runtime images)
+do not carry it, so the dataset import path dies with FileNotFoundError.
+
+The proper fix is upstream: Megatron-LM-FL PR #112 switches to
+sysconfig.get_config_var("EXT_SUFFIX") (stdlib, present in every Python).
+This script is the build-infra fallback that applies the same change on the
+fly during wheel builds while that PR is unmerged. It is idempotent and
+fails loudly if the source moved on (exit 1 when neither form is found),
+so a silently-skipped patch can never ship a wheel that still needs
+python3-config.
+
+Usage: python patch-compile-helpers-sysconfig.py <megatron/core/datasets/utils.py>
+"""
+
+import pathlib
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: patch-compile-helpers-sysconfig.py <utils.py>", file=sys.stderr)
+        return 2
+    p = pathlib.Path(sys.argv[1])
+    src = p.read_text()
+    marker = 'sysconfig.get_config_var("EXT_SUFFIX")'
+    old_import = "    import subprocess\n"
+    old_body = (
+        "    ext_suffix = subprocess.check_output(\n"
+        '        ["python3-config", "--extension-suffix"], text=True\n'
+        "    ).strip()\n"
+    )
+    if marker in src:
+        print(">>> compile_helpers: sysconfig form already present (no-op)")
+    elif old_body in src:
+        assert old_import in src, "compile_helpers imports changed unexpectedly"
+        src = src.replace(old_import, old_import + "    import sysconfig\n", 1)
+        src = src.replace(
+            old_body,
+            '    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")\n',
+            1,
+        )
+        p.write_text(src)
+        print(">>> compile_helpers: patched python3-config -> sysconfig")
+    else:
+        print(
+            "ERROR: compile_helpers source moved on — neither python3-config "
+            "nor sysconfig form found; rework the builder patch",
+            file=sys.stderr,
+        )
+        return 1
+    assert marker in p.read_text(), "compile_helpers sysconfig patch did not land"
+    print("gate OK: compile_helpers uses sysconfig")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/megatron/docs/megatron-hygon25-e2e.md
+++ b/packaging/megatron/docs/megatron-hygon25-e2e.md
@@ -92,6 +92,14 @@
 - 因此 "repo checkout + 已安装 wheel" 的验证形态（完整训练服务）需先把 wheel 内的 `.so` 植入源码树。
 - 对 app 镜像**无影响**（wheel 自带 `.so`，单步安装即完整）；此缺口只影响仓库与 wheel 混用的验证/开发路径。
 
+### 2.4 venv 缺 `python3-config`（2026-08-16 实测）
+
+**发现（运行 #2，06:04:18 rc=1）：** venv `/flagos/bin` **缺 `python3-config` 符号链接**。`compile_helpers()`（`megatron/core/datasets/utils.py`，带 FlagScale 来源标注的 fork 补丁）执行 `subprocess.check_output(["python3-config", "--extension-suffix"])` 抛 `FileNotFoundError: 'python3-config'`，`pretrain_gpt.py` 在数据集构建 import 期即挂。该函数只在 wheel 已带预构建 `helpers_cpp{ext_suffix}.so` 时提前 return 跳过 make——但仍需 python3-config 算后缀。uv 托管的 Python 在 `/root/.local/share/uv/python/cpython-3.10-linux-x86_64-gnu/bin/` 下自带该二进制。修复（仅诊断用软链，非交付方案）：`ln -sf .../python3-config /flagos/bin/python3-config`，`--extension-suffix` 实测输出 `.cpython-310-x86_64-linux-gnu.so`。
+
+**对交付的启示（已落地，2026-08-16）：** 修复方向 = `compile_helpers()` 改用 `sysconfig.get_config_var("EXT_SUFFIX")`（标准库，任何 Python 环境都有），替代 `subprocess.check_output(["python3-config", ...])`。
+- **准备一（PR 已提交）：** flagos-ai/Megatron-LM-FL PR [#112](https://github.com/flagos-ai/Megatron-LM-FL/pull/112)（与 psutil PR #106 / tensorboard 同类的上游修复）。
+- **准备二（build-infra 兜底，已落地）：** wheel 是 build-infra 自产（`packaging/megatron/builder/Containerfile`），沿用现有 on-the-fly patch + grep gate 模式（同文件 requires-python 补丁）新增 `packaging/megatron/builder/patch-compile-helpers-sysconfig.py`，在 wheel 构建时对 checkout 打同样的 sysconfig 补丁。脚本幂等且自 gate：已是 sysconfig 形式 → no-op（PR #112 合并后自动跳过）；仍是 python3-config 形式 → 就地替换；源码演进（两种形式都找不到）→ exit 1 硬失败，补丁不可能静默失效。三状态逻辑已本地验证（对 origin/main 的 utils.py 实测 patch / no-op / 演进三例全过）。两路最终都落成同一段代码形态，不依赖 MLF merge 节奏。诊断软链（`/flagos/bin/python3-config` → uv python）仅容器现场用，非交付方案。
+
 ### 2.3 DTK 环境注入：镜像已内置
 
 - 运行时镜像已内置 DTK 环境：经 bash 运行的命令（含非交互）可直接 `import torch`，无需手动 `source /opt/dtk-26.04/env.sh`（实测：容器内非登录 `bash -c '/flagos/bin/python -c "import torch"'` 直接成功，torch 2.9.0）。


### PR DESCRIPTION
## Background

`compile_helpers()` (in `megatron/core/datasets/utils.py`, a FlagOS fork addition) shells out to `python3-config --extension-suffix` to locate the prebuilt `helpers_cpp` .so. **python3-config is a CPython build artifact, not a pip package** — uv-created venvs (as in the runtime images) don't carry it, so the dataset import path dies with `FileNotFoundError` on the runtime venv.

The proper fix is upstream: Megatron-LM-FL PR [#112](https://github.com/flagos-ai/Megatron-LM-FL/pull/112) switches to stdlib `sysconfig.get_config_var("EXT_SUFFIX")`, present in every Python. This PR is the **build-infra fallback for the window before PR #112 merges**: it applies the same change on the fly at wheel build time.

## Changes

- **New** `packaging/megatron/builder/patch-compile-helpers-sysconfig.py`: idempotent, self-gating three-state patch script
- **Modified** `packaging/megatron/builder/Containerfile`: COPY the script, run it after the existing requires-python on-the-fly patch

## Three-state patch logic (verified locally against origin/main's utils.py)

| State | Behavior |
|---|---|
| sysconfig form already present (after PR #112 merges) | no-op skip |
| python3-config form still present | in-place replace with sysconfig |
| source moved on (neither form found) | exit 1 hard failure — a silently-skipped patch can never ship |

## Design

Same pattern and location as the existing requires-python on-the-fly patch (sed + grep gate); the script adds an assert + exit 1, stricter than a bare grep. Both tracks (PR #112 + this fallback) land on the same final code shape, independent of MLF's merge cadence.

This PR was written in part with the assistance of generative AI.
