### PR TITLE
docs(megatron): record hygon four-scenario verification findings

### DIFF
--- a/packaging/megatron/docs/megatron-hygon25-e2e.md
+++ b/packaging/megatron/docs/megatron-hygon25-e2e.md
@@ -11,6 +11,15 @@
 
 上表为默认编译器（flagtree）基线。**vendor triton 复跑**（见 §2.1）下两种形态均通过，且不再需要 jit 补丁与 `--disable-jit-fuser`：完整训练服务 loss 9.1295 → 8.8622。
 
+**四场景验证（2026-08-14，全范围 wheel = core+training+legacy+rl+post_training+inference，MLF PR #107 feat/wheel-full-scope）：**
+
+| 场景 | 入口 | 结果 | 备注 |
+|---|---|---|---|
+| training | `pretrain_gpt.py`（vendor triton） | ✅ exit 0 | loss 9.1295 → 8.8622 |
+| rl | `pretrain_gpt.py --perform-rl-step` | ⛔ 平台缺口 | dynamic 推理引擎硬依赖 flash-attn（§6.1） |
+| post_training | post_training driver（surface 全 import + `simple_generate`） | ✅ exit 0 | 输出 shape=(1, 8)；modelopt ad-hoc 装入 venv，未入镜像（§6.3） |
+| inference | `StaticInferenceEngine(legacy=True)`，3 请求 × 8 tokens | ✅ exit 0 | 免 flash-attn / 免 triton（§6.2） |
+
 本报告只记录**可复现的技术发现与缺口**（代码级缺陷、未声明依赖、平台移植性、工具链限制），不含瞬时错误与一次性环境故障。
 
 ## 打包背景
@@ -23,7 +32,7 @@
 - `megatron.training` / `megatron.legacy` / `megatron.inference` / `megatron.post_training` / `megatron.rl` **均不在 wheel 中**。
 - **后果:** 完整训练服务（`pretrain_gpt.py`）依赖 `megatron.training`，无法用 wheel 直接验证——这是报告"完整训练服务"一栏用 repo checkout 的原因，也是 §1.1（`megatron.core` 内部 import `megatron.training` 失败）的直接诱因。
 - **性质:** 非打包实现错误（fork 只是继承了上游的范围），但属于**真实范围缺口**——对"应用镜像 = 单步安装 wheel 即可用"的交付形态而言必须关闭。
-- **方向（待定案）:** 扩大打包范围，把 `megatron.training` / `megatron.legacy` 纳入 wheel（pyproject include 已改，未提交），是否进一步纳入 `megatron.inference` / `megatron.post_training` / `megatron.rl`（全包，应用场景归并进一个 wheel）在决策中。
+- **方向（已落定，2026-08-14）:** 全范围打包（core+training+legacy+rl+post_training+inference）已通过 MLF PR #107（feat/wheel-full-scope）实现，顶层入口文件（`gpt_builders.py` 等）一并纳入 wheel。§6 四场景验证均基于该 wheel。
 
 **Date:** 2026-08-12 ~ 2026-08-13
 **Platform:** hygon25（Hygon BW1000 8× HCU，DTK 26.04），镜像 `flagos-runtime-hygon-dtk26.04:2.1.2`，Python 3.10.20，torch 2.9.0+das.opt1.dtk2604
@@ -123,10 +132,50 @@ DCU 上完整跑通 megatron 训练的最小 flags / 容器配置（逐项均有
 
 ---
 
-## 5. 结论与后续
+## 5. 四场景验证（2026-08-14，全范围 wheel）
 
-- **E2E 故事闭环**：wheel（Megatron 打包产物）→ 单步安装（无 `--no-deps`）→ 端到端训练，在 hygon25 上全部实证通过。
-- **打包范围缺口（待定案）**：见"打包背景"——wheel 不含 `megatron.training` 导致完整训练服务无法用 wheel 直接验证；扩大范围（training+legacy 或全包）后需重建 wheel 并以"单步安装 + 直接跑 `pretrain_gpt.py`"（无需 repo checkout）重新验证。
-- **已提交至本 fork（flagos-ai/Megatron-LM-FL）**：§1.1 修复 → PR [#105](https://github.com/flagos-ai/Megatron-LM-FL/pull/105)；§1.2 依赖声明 → PR [#106](https://github.com/flagos-ai/Megatron-LM-FL/pull/106)。
-- **待反馈至本 fork（flagos-ai/Megatron-LM-FL）**：§1.3 jit_fuser import 期绑定时序、§1.4 fused kernel 默认开启的平台假设。
+wheel 打包范围扩大至 core+training+legacy+rl+post_training+inference（MLF PR #107 feat/wheel-full-scope，顶层入口文件一并打包）后，在应用镜像 `megatron-app:hygon-new`（全范围 wheel 单步安装，无 `--no-deps`）上按序验证四场景。共用 DCU 基线 flags（§4）+ `/tmp/jitfix` 补丁（NullTokenizer pad/bos/eod property + torch.compile identity）。
+
+### 5.1 rl 场景：dynamic 推理引擎硬依赖 flash-attn（平台缺口，按决定记录）
+
+**位置:** `megatron/rl/inference/megatron.py:87` 硬编码 `get_dynamic_inference_engine` → dynamic 引擎 `attention.py:943` `assert HAVE_FA3 or is_fa_min_version("2.7.3")` → `import flash_attn` → ModuleNotFoundError（DTK 26.04 无 flash-attn 构建）。
+
+**性质:** 场景级缺口，非依赖面缺口——`megatron.rl` 模块级仅依赖 pydantic + typing_extensions（纯 PyPI），全树 0 处 triton/torch.compile；阻塞点在推理引擎（dynamic 引擎硬依赖 flash-attn），复用 training/core 的编译器链。
+
+**处置:** 按决定记为缺口（不做本地 sdpa fallback patch），待 MLF 侧动态引擎支持非 flash-attn 后端。
+
+**2026-08-16 修正（新镜像 rl-new 实测）：** §5.1 的"DTK 26.04 无 flash-attn 构建"前提**已过时**——repack 修复后的新镜像实际装了 vendor flash_attn `2.8.3+das.opt1.dtk2604.torch290`，但复测在到达该断言之前就被更前置的阻塞挡下（见 §5.4）。且即便到达，仍有两个新发现：`flash_attn.__version__` 在 `__init__.py` 里**硬编码 "2.6.1"**（与 dist-info 的 2.8.3+… 不一致），且包内无 `flash_attn_interface`（无 FA3）→ `attention.py:943` 的 `is_fa_min_version("2.7.3")` 判定仍会失败。平台缺口依旧，只是失败形态多了一层 vendor 包的版本信息问题。
+
+### 5.4 rl 场景复测（2026-08-16，repack 修复后新镜像）：tensorboard 未声明依赖在 import 期前置阻塞
+
+**复测背景:** 新 runtime 镜像 `flagos-runtime-hygon-dtk26.04:2.1.2`（repack 修复 torch 落位 + flash_attn 未声明 pytest 依赖后重跑），完整作用域 wheel `0.17.1+fl.20260814`，容器 rl-new，**默认编译器 flagtree**，刻意不传 `--disable-jit-fuser`（测 mask-doc 开放问题），`--perform-rl-step --skip-train`（无 ckpt，随机初始化 rollout 验证）。
+
+**结果:** `AssertionError: RL cannot run without the megatron.rl package`（`megatron/training/training.py:2744`，运行 #3，06:06:57 rc=1）。
+
+**根因（直接 import 实测）:** `megatron/rl/rl_utils.py:24` 模块级 `from torch.utils.tensorboard import SummaryWriter` → 运行时需要 **tensorboard 包**。runtime 镜像内无此包（`pip list` 实测），全作用域 wheel 的 METADATA 也未声明 → `training.py:60-67` 的 `has_rl_utils` try/except 捕获 ImportError 置 False → 断言。
+
+**性质:** 未声明运行时依赖（同类于 §1.2 psutil）——RL 入口在 import 期即阻塞，**先于** §5.1 的 flash-attn 断言。阻塞链现在是：tensorboard（import 期）→ pydantic（已解决，从 flagrelease minimax 镜像补装）→ flash-attn `__version__` 硬编码（§5.1 修正）。
+
+**处置:** 按"别搞，直接记录"定案，不做镜像内补装。修复方向 = 反馈本 fork（flagos-ai/Megatron-LM-FL）在 `pyproject.toml` 声明 tensorboard（参考 §1.2 psutil 的 PR #106 模式），或镜像层在 configs.yaml 依赖面补上。
+
+### 5.2 inference 场景：legacy 静态引擎路径免 flash-attn / 免 triton
+
+`StaticInferenceEngine(controller, legacy=True)` 保留 `StaticInferenceContext` → `is_static_batching()=True` → attention.py static 分支 `apply_module(core_attention)`（DotProductAttention/sdpa）——**不依赖 flash-attn、不编译 triton kernel**，对 hygon 属编译器无关路径。
+
+**验证:** 3 请求 × 8 tokens（`prompt_tokens` 直接注入 `InferenceRequest`，绕过 NullTokenizer 无 `tokenize()` 的限制），generate 4.2s，exit 0。
+
+**注意:** 非 legacy 路径内部构造 DynamicInferenceContext + DynamicInferenceEngine → 回到 §5.1 的 flash-attn 崩溃路径。
+
+### 5.3 post_training 场景：依赖 modelopt（HARD，vendor 变体）
+
+driver 跑通（post_training surface 全 import + `simple_generate`，输出 shape=(1, 8)，exit 0）。前提：nvidia-modelopt 以 `--no-deps` ad-hoc 装入 runtime venv，**未入镜像**——与其余场景的"单步安装 wheel 即可用"不同，此处是容器现场补装，违反交付目标。modelopt 是唯一有 vendor 变体的 HARD 依赖（configs.yaml 仅 enflame 有 `enflame-modelopt`）；NVIDIA 用 NVIDIA modelopt 可用，其余后端成功率不确定；纳入镜像与否待镜像层决策。
+
+---
+
+## 6. 结论与后续
+
+- **E2E 故事闭环（四场景）**：wheel（Megatron 打包产物）→ 单步安装（无 `--no-deps`）→ 场景入口直跑，在 hygon25 上 training / post_training / inference 全部实证通过（exit 0）；rl 阻塞于平台缺口（§5.1，按决定记录）。训练场景已用全范围 wheel 完成"单步安装 + 直接跑 `pretrain_gpt.py`"（无需 repo checkout）验证。
+- **打包范围缺口（已关闭）**：全范围 wheel（MLF PR #107 feat/wheel-full-scope）实现 core+training+legacy+rl+post_training+inference 打包并含顶层入口文件；PR 合入前其余后端暂不能复用该 wheel 做按序验证。
+- **已提交至本 fork（flagos-ai/Megatron-LM-FL）**：§1.1 修复 → PR [#105](https://github.com/flagos-ai/Megatron-LM-FL/pull/105)；§1.2 依赖声明 → PR [#106](https://github.com/flagos-ai/Megatron-LM-FL/pull/106)；全范围打包 → PR [#107](https://github.com/flagos-ai/Megatron-LM-FL/pull/107)。
+- **待反馈至本 fork（flagos-ai/Megatron-LM-FL）**：§1.3 jit_fuser import 期绑定时序、§1.4 fused kernel 默认开启的平台假设、§5.1 rl dynamic 引擎 flash-attn 硬依赖（平台缺口）。
 - **相关文档**：`packaging/megatron/builder/report-megatron-0.17.1.md`（构建与依赖面；repack facility 已于 2026-08-14 移除，依赖处理不再单独成报告，其要点并入 builder report §1/§3）。

--- a/packaging/megatron/docs/megatron-verification-matrix.md
+++ b/packaging/megatron/docs/megatron-verification-matrix.md
@@ -1,7 +1,7 @@
 # Megatron 场景 × 编译器 × 后端 验证矩阵
 
 > 规划工具，随验证推进更新。每单元格为对应后端 runtime 镜像 + 一步安装 wheel 后，对应场景入口跑通的验证。
-> wheel 打包范围：core+training+legacy+rl+post_training（inference 因上游裸 import 缺陷挂起，见下）。
+> wheel 打包范围：core+training+legacy+rl+post_training+inference（全范围 wheel，MLF PR #107 feat/wheel-full-scope）；hygon 四场景已用该 wheel 验证。
 
 ## 状态图例
 
@@ -28,7 +28,7 @@
 | 寒武纪   | NEUWARE 4.7.2 | ⬜      | —       | ⬜          | —           | ？        | —         | ⛔      | —       |
 | 燧原     | TOPS 1.9.10   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 燧原     | TOPS 1.10.6   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
-| 海光     | DTK 26.04     | ✅      | ❌      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
+| 海光     | DTK 26.04     | ✅      | ❌      | ⛔          | ⛔          | ✅        | ❌        | ✅      | ❌      |
 | 天数智芯 | COREX 4.4.0   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 昆仑芯   | XRE 5.37.1    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 沐曦     | MACA 3.7.2.1  | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
@@ -48,12 +48,14 @@
 ## 已验证/已知事实
 
 - **hygon training**：flagtree 3.6.0 ❌（clang-17 拒 5 个 `-mllvm` flags → 无产物 + 误导性 HSACOError，屏蔽）；vendor triton 3.3.0 ✅（E2E exit 0，loss 9.1295→8.8622）。详见 [[megatron-hygon25-e2e.md]] 与 [[memory/hygon-compiler-mask]]。
-- **inference 阻塞（跨团队协调中）**：`megatron/inference/utils.py` 裸 import `gpt_builders`/`mamba_builders`/`model_provider`——这三个模块是 **repo 根顶层入口文件**（gpt_builders.py、mamba_builders.py、model_provider.py，repo checkout 靠 cwd=根 的 sys.path 找到），**不在 `megatron/` 包内**，wheel 打包忽略它们 → 安装模式下 `import megatron.inference.utils` ImportError。此场景不可打包、不可镜像。
-  - **归属**：上游 **core_v0.17.0** 自己的代码（fork #34 忠实同步，逐字相同），非 fork 偏离。上游修复时点：0.17.0/0.17.1 = 3 处裸 import；0.18.0/0.18.2 = 2 处（mamba 修了）；main = 0（全部收敛进 `megatron/training/models/`）。
-  - **需要 MLF 团队决策**：① resync v0.18.0（代价 = 从 0.17.0 追三代，且 fork 有 22 个 core 文件 cur_platform 替换 + 15 个 FlagScale 专属字段需重放）；② 顶层文件收敛进 megatron 包（~150 行，inference/utils.py 改包内导入，入口脚本不动）。**决定前此场景挂起**。
-  - **结构性问题（关联决策4）**：mlf 的"顶层文件作入口"模式本身不支持 wheel 包发布——入口脚本（pretrain_gpt.py 等）与其依赖（gpt_builders.py 等）全在 repo 根，不在 `megatron/` 包内。即便把入口脚本 COPY 进镜像层，其 import 路径仍需包内化。这正是决策②要解决的同一件事。
+- **inference 裸 import 阻塞（已由全范围 wheel 关闭）**：`megatron/inference/utils.py` 依赖的 `gpt_builders`/`mamba_builders`/`model_provider` 是 **repo 根顶层入口文件**（不在 `megatron/` 包内）——core-only wheel（0.17.1+flagos）打包时被忽略，安装后 `import megatron.inference.utils` 即 ImportError。MLF PR #107（feat/wheel-full-scope）把顶层入口文件一并打包，hygon 已用该 wheel 验证推理场景跑通（见下）。
+  - **归属**：上游 **core_v0.17.0** 自己的代码（fork #34 忠实同步），非 fork 偏离。上游修复时点：0.17.0/0.17.1 = 3 处裸 import；0.18.0/0.18.2 = 2 处；main = 0（全部收敛进 `megatron/training/models/`）。
+  - **状态**：全范围 wheel 从打包侧关闭阻塞，其余后端推理列仍 ⛔ —— 需 PR #107 合入后按序验证。结构性问题（决策4 关联："顶层文件作入口"模式不支持 wheel 包发布）仍然成立，但不阻塞交付。
+- **hygon inference**：`StaticInferenceEngine(legacy=True)` 路径 E2E 跑通（3 请求 × 8 tokens，exit 0）。legacy 静态批处理走 `apply_module(core_attention)`（DotProductAttention/sdpa），**不依赖 flash-attn、不编译 triton kernel**——对 hygon 属编译器无关路径（推理(T)=✅；推理(F)=❌ 仍因 flagtree 屏蔽）。
+- **hygon RL（平台缺口，已记录）**：`megatron/rl/inference/megatron.py:87` 硬编码 `get_dynamic_inference_engine` → dynamic 引擎 `attention.py:943` `assert HAVE_FA3 or is_fa_min_version("2.7.3")` → `import flash_attn` 失败（DTK 26.04 无 flash-attn 构建）。**已按决定记为缺口**（不做本地 sdpa fallback patch），待 MLF 侧动态引擎支持非 flash-attn 后端。
+- **hygon post_training**：driver 跑通（post_training surface 全 import + `simple_generate`，exit 0）。前提是 nvidia-modelopt 已 ad-hoc 装入 runtime venv（`--no-deps`，**未入镜像**——违反"单步安装即可用"目标，modelopt 纳入与否待镜像层决策）。
 - **post_training 依赖**：modelopt 是唯一有 vendor 变体的 HARD 依赖（configs.yaml 仅 enflame 有 `enflame-modelopt`）；tqdm 纯 PyPI。NVIDIA 用 NVIDIA modelopt 可用；其余后端成功率不确定。
-- **rl 依赖**：模块级仅 pydantic + typing_extensions（纯 PyPI）；全树 0 处 triton/torch.compile，复用 training/core 的编译器链。
+- **rl 依赖**：模块级仅 pydantic + typing_extensions（纯 PyPI）；全树 0 处 triton/torch.compile，复用 training/core 的编译器链。**注意**：rl 场景阻塞不在依赖面而在推理引擎——dynamic 引擎硬依赖 flash-attn（见 hygon RL 缺口），属场景级缺口，非依赖面缺口。
 
 ## 编译器层已知问题（来源 vllm 验证，megatron 需实测——不归并）
 
@@ -65,4 +67,4 @@
 1. **training 场景**：先验双编译器后端（编译器链风险已知存在——hygon 教训），后验单编译器后端。每后端 = runtime 镜像 + wheel 单步安装 + pretrain_gpt.py 小规模跑通。
 2. **rl 场景**：依赖面干净，验证成本与 training 相当；同镜像按用途补 pydantic/typing_extensions。
 3. **post_training 场景**：仅 NVIDIA 先行，其余后端等 modelopt 可用性结论。
-4. **inference 场景**：挂起，等 MLF 团队决策（resync v0.18.0 / 顶层文件收敛进包）后重新评估。
+4. **inference 场景**：hygon 已用全范围 wheel（PR #107）验证 ✅（static legacy 路径）；其余后端待 PR 合入后按序验证。

--- a/packaging/megatron/docs/memory/hygon-compiler-mask.md
+++ b/packaging/megatron/docs/memory/hygon-compiler-mask.md
@@ -5,14 +5,14 @@ metadata:
   type: project
 ---
 
-# 编译器 mask 表（hygon DTK 26.04，2026-08-13 实测）
+# 编译器 mask 表（hygon DTK 26.04，2026-08-13 实测；flagtree 结论 2026-08-16 修正）
 
 ## mask 表
 
 | 编译器 | 版本 | HCU kernel 编译 | 结论 |
 |---|---|---|---|
-| flagtree | 3.6.0 | ✗ `make_amdgcn()` 调 clang-17 子进程，7 个 HCU `-mllvm` flags 中 5 个被拒 → clang 静默退出 0 但无产物 → 误导性 `HSACOError("File operation failed: ...")` | **屏蔽** |
-| vendor triton | 3.3.0 | ✓ `make_amdgcn()` 用 `llvm.translate_to_asm()` 直接出码，无 clang 子进程 → 正常产出 `.amdgcn` | **交付** |
+| flagtree | 3.6.0 | ⚠️ 旧容器 clang-17 失败 → **2026-08-16 新镜像实测通过**（见 §3.5.1 机制） | **可用**（修正"屏蔽"结论） |
+| vendor triton | 3.3.0 | ✓ `make_amdgcn()` 用 `llvm.translate_to_asm()` 直接出码，无 clang 子进程 → 正常产出 `.amdgcn` | **交付**（已被 3.5.1 取代） |
 
 ## 归并规则（用户定案）
 
@@ -25,11 +25,43 @@ metadata:
 - 运行时镜像**同时带** flagtree 和 triton 两套，`compiler` 函数（BASH_ENV 内置）切换：`compiler triton`。
 - 无 `compiler` 函数时手动切换：
   `export PYTHONPATH="/opt/triton:$(printf %s "${PYTHONPATH}" | tr ':' '\n' | grep -v '^/opt/flagtree' | paste -sd: -)"`
-- **现状缺口**：hygon DTK 26.04 runtime 镜像的**默认编译器是 flagtree（坏的）**——需在 runtime 镜像层修正（默认改 vendor triton 或移除 flagtree）。属 runtime 仓库工作。
+- **现状缺口**：hygon DTK 26.04 runtime 镜像的**默认编译器是 flagtree**，但 torch 落位 bug（torch 只在 /opt/triton）让 `compiler flagtree` 环境 import torch 失败——**修复 = repack triton 3.5.1 wheel 去掉 torch 依赖**（用户定案），两编译器环境即都可用。属 runtime/repack 交付工作。不再需要"默认改 vendor triton / 移除 flagtree"。
 
 ## 对 megatron 参数的影响
 
-- flagtree 下需要 `--disable-jit-fuser`（或 jit 旁路）规避 §1.3 import 期绑定 + 无法编译 HCU；
+- flagtree 下的旧结论：需要 `--disable-jit-fuser` 规避 §1.3 import 期绑定 + 无法编译 HCU。**"无法编译 HCU"已证伪**（2026-08-16 flag_gems 全过）；`--disable-jit-fuser` 是否仍需，待新镜像 flagtree 环境 E2E 复测确认（RL(GRPO) 场景下一步）。
+  - **2026-08-16 RL 复测进度：** rl-new 容器（repack 修复后新镜像）已启动 RL(GRPO) E2E（flagtree 默认，刻意不传 `--disable-jit-fuser`），但**先被 tensorboard 未声明依赖在 import 期阻塞**（`megatron/rl/rl_utils.py:24` → `has_rl_utils=False` → 断言，详见 [[megatron-hygon25-e2e]] §5.4），尚未到达 jit-fuser warmup 阶段 → **mask-doc 问题仍未回答**。tensorboard 补上后，下一预期阻塞是 flash-attn `__version__` 硬编码 "2.6.1"（§5.1 修正）。
 - vendor triton 下**不需要**——`--disable-jit-fuser`、jit.py 补丁都去掉，E2E 复跑 exit 0（loss 9.1295→8.8622）。
 
 详见 [[megatron-verification-state]]。
+
+## 追加：triton 3.5.1（clang-18 修正版结论，2026-08-16 实测）
+
+| 编译器 | 版本 | HCU kernel 编译 | 结论 |
+|---|---|---|---|
+| vendor triton | 3.5.1 (`+das.opt1.dtk2604.torch290`) | ✓ **DTK LLVM 包 clang-18**（PR #403，`/opt/dtk-26.04/aillvm/bin/clang-18`）下 p8 + mmac 全过 | 3.5.1 **可以工作**，修正早前"否决"结论 |
+| flagtree | 3.6.0 | ✓ 同款 aillvm/clang-18 机制（`compiler_hcu.py` 里**同一段 dtk 特判**），**2026-08-16 实测 flag_gems.mm / addmm / mm-bf16 全 OK**（max_abs_diff=0.0） | **可用**（修正"屏蔽"） |
+
+### 2026-08-16 flagtree 修正（为什么之前判"屏蔽"错了）
+
+- flagtree 3.6.0 的 `triton/backends/hcu/compiler_hcu.py` **与 triton 3.5.1 有同一段 dtk 特判**：`llvm_subdir = "aillvm" if rocm_path.name == "dtk" else "llvm"`（275-278 行），`path_to_rocm_clang()` 默认 `llvm_path/bin/clang-18` → `/opt/dtk/aillvm/bin/clang-18`（302-319 行）。
+- 早前"clang-17 子进程被拒"结论来自**旧容器**（无 DTK LLVM 包）；PR #403 的 dtk_llvm.run 之后 flagtree 与 triton 3.5.1 **同源同机制**，都自动找到 clang-18。
+- **实测**（容器 rl-3.5.1，`PYTHONPATH=/opt/flagtree:/opt/triton`，bash -lc）：`flag_gems.mm` fp32 OK(0.0)、`addmm` OK(0.0)、`mm` bf16 OK(0.0)。flag_gems 5.3.4。
+- 早前手写 mm kernel（/tmp/mm_test.py）max_abs_diff=52.96 **是 kernel 自身 bug**（k-loop 指针更新/mask 写法），不是编译器问题——用 flag_gems 规范 op 复测即全 0。
+- **flagtree 唯一真实障碍 = torch 落位 bug**（见下）：`compiler flagtree`（默认）时 `No module named 'torch'`，是 triton repack 的镜像层问题，不是 flagtree 编译问题。
+
+### 3.5.1 机制（clang-18 修正）
+
+- 3.5.1 hcu 后端在 `triton/backends/amd/compiler_hcu.py`，`make_amdgcn()` 调**外部 clang 子进程**；`path_to_rocm_llvm()` 里 **dtk 特判**：`llvm_subdir = "aillvm" if rocm_path.name == "dtk" else "llvm"`。
+  - 但 **ROCM_PATH=/opt/dtk** 是符号链接（→ /opt/dtk-26.04），`Path.name` = "dtk" → 走 aillvm 分支 → **自动找到 clang-18**（无需手动 export，clang-17 回退只在 aillvm 缺失时发生）。
+  - 早前 HSACOError 是**旧容器**（无 dtk_llvm.run / 手动 export 覆盖）的产物；新镜像（含 #403）**无 env、无 export，直接 RESULT_OK**。
+- **torch 落位 bug（新发现，镜像层问题）**：`pip install --target /opt/triton triton-3.5.1...torch290` 把 torch 捎进 /opt/triton；之后 DEPS 装 `torch==2.9.0+das.opt1.dtk2604` 带 `PYTHONPATH=/opt/triton`，pip 判定 torch 已满足 → **site-packages 无 torch**。后果：
+  - `compiler triton`：torch ✅（借 /opt/triton/torch）+ triton 3.5.1 ✅ + add kernel **RESULT_OK True**。
+  - `compiler flagtree`（默认）：`No module named 'torch'` ❌。
+  - **修复方向（用户定案）**：repack triton 3.5.1 wheel，**去掉 torch 依赖**（triton 声明了 torch 依赖才被捎带）；DEPS 的 torch 由此真正进 site-packages，两编译器环境皆可用。属 runtime/repack 交付工作。
+- configs.yaml hygon.dtk26.04 现在写的是 `triton==3.5.1+das.opt1.dtk2604.torch290`（PR #404 升级，3.3.0 已弃用）；`flagtree==0.6.1+hcu3.6` 仍在配置里。
+
+### vendor 包问题（2026-08-16，已修复）
+
+- **flash_attn**（`flash_attn==2.8.3+das.opt1.dtk2604.torch290`）厂商 wheel 的依赖声明里**带了不该有的 pytest**（未声明的 pytest 依赖）→ pip 装 flash_attn 时把 pytest 一并装进 site-packages（实测 `/flagos/lib/python3.10/site-packages/pytest-9.1.1.dist-info` 存在，DEPS 未显式列 pytest）。**已通过重新打包（repack 剥离 pytest 依赖）修复**。
+- 与 triton repack 同属一个交付动作：vendor 包问题统一靠 repack 修，不靠镜像内补丁。


### PR DESCRIPTION
## Summary

Records the hygon25 four-scenario verification done with the full-scope megatron-core wheel (MLF PR #107: core+training+legacy+rl+post_training+inference, top-level entry files packaged). Updates the e2e report, the verification matrix, and the compiler-mask memory doc.

## What changed

- **megatron-hygon25-e2e.md** — new §5 "四场景验证": training / rl / post_training / inference results on the full-scope wheel; updated §6 conclusions.
- **megatron-verification-matrix.md** — hygon cells filled for rl (blocked, platform gap), inference (✅ static legacy path), post_training (✅ with caveat); inference bare-import blocker marked closed by the full-scope wheel.
- **memory/hygon-compiler-mask.md** — flagtree 3.6.0 "blocked" conclusion corrected to "usable" (same aillvm/clang-18 mechanism as triton 3.5.1, verified on the new image); RL retest progress (tensorboard blocks before the flash-attn assert).

## Findings recorded

- **rl blocked on a platform gap**: `megatron/rl/inference/megatron.py:87` hard-codes the dynamic inference engine, which asserts flash-attn ≥ 2.7.3 at `attention.py:943`. Recorded as a gap per decision, no local patch.
- **tensorboard is an undeclared runtime dep** (same class as the psutil gap §1.2): `megatron/rl/rl_utils.py:24` imports `SummaryWriter` at module level, so RL entry dies at import time before reaching the flash-attn assert. Proposed fix: declare tensorboard in the MLF fork's pyproject (mirroring PR #106) or add it to configs.yaml deps.
- **Vendor flash_attn version info broken**: `__version__` hardcoded "2.6.1" while dist-info says 2.8.3+das.opt1.dtk2604.torch290; no FA3 (`flash_attn_interface` absent).
- **Compiler mask correction**: flagtree 3.6.0 is usable on the repacked image — the earlier "blocked" verdict came from an old container without the DTK LLVM package.

Docs-only, no code changes.

This PR was written in part with the assistance of generative AI.
