### PR TITLE
feat(app): app-layer env framework (env.app) + vllm flashinfer gate

### DIFF
--- a/.github/workflows/megatron-app-image.yml
+++ b/.github/workflows/megatron-app-image.yml
@@ -28,9 +28,9 @@ name: Megatron app image
 # runtime's torch/triton/flag_gems matrix cannot be disturbed (the repack
 # facility was removed 2026-08-14).
 #
-# Backend matrix comes from scripts/generate_matrix.py --runtime (same source
-# as runtime-image.yaml). Per-vendor PyPI (flagos_pypi) is searched first;
-# aliyun is the fallback.
+# Backend matrix comes from scripts/generate_matrix.py --app megatron (same
+# runtime fields as runtime-image.yaml plus the per-backend app env vars).
+# Per-vendor PyPI (flagos_pypi) is searched first; aliyun is the fallback.
 
 on:
   workflow_dispatch:
@@ -84,9 +84,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.backend }}" == "all" ]]; then
-            python3 scripts/generate_matrix.py --runtime > matrix.json
+            python3 scripts/generate_matrix.py --app megatron > matrix.json
           else
-            python3 scripts/generate_matrix.py --runtime ${{ inputs.backend }} > matrix.json
+            python3 scripts/generate_matrix.py --app megatron ${{ inputs.backend }} > matrix.json
           fi
           cat matrix.json
           echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
@@ -146,6 +146,7 @@ jobs:
             --build-arg "MEGATRON_VERSION=${{ inputs.megatron_version }}" \
             --build-arg "FLAGOS_PYPI=${{ matrix.flagos_pypi }}" \
             --build-arg "EXTRA_PYPI=${{ matrix.extra_pypi }}" \
+            --build-arg "APP_ENV=${{ matrix.app_env }}" \
             -t "${app_tag}" \
             -f app/megatron/Containerfile .
           echo "Built: ${app_tag}"

--- a/app/megatron/Containerfile
+++ b/app/megatron/Containerfile
@@ -59,6 +59,16 @@ RUN pip install \
   --extra-index-url "${EXTRA_PYPI}" \
   "megatron-core==${MEGATRON_VERSION}"
 
+# --- App env ---------------------------------------------------
+
+# Per-backend app env vars (configs.yaml env.app.{app}): baked into
+# /etc/profile.d/app_env.sh — sourced by the runtime's bash plumbing
+# (BASH_ENV=/etc/bash_env.sh sources /etc/profile.d/*.sh).
+ARG APP_ENV=""
+RUN if [ -n "${APP_ENV}" ]; then \
+      printf '%s\n' "${APP_ENV}" > /etc/profile.d/app_env.sh; \
+    fi
+
 # --- Runtime --------------------------------------------------
 
 WORKDIR /workspace

--- a/app/vllm/Containerfile
+++ b/app/vllm/Containerfile
@@ -32,7 +32,7 @@ FROM ${RUNTIME_IMAGE}
 
 # --- Build arguments ------------------------------------------
 
-ARG VLLM_VERSION=0.20.2
+ARG VLLM_VERSION=0.24.0
 
 # Repacked vllm wheel lives here — searched first.
 ARG FLAGOS_PYPI=""
@@ -50,10 +50,16 @@ ARG VLLM_VENDOR=cuda
 
 # --- Install vllm (repacked wheel) ----------------------------
 
+# The vendor PyPI carries the repacked wheel as vllm-{version}+flagos. The
+# +flagos pin is mandatory: a bare "vllm=={version}" would fall through to
+# the official wheel on the fallback index, whose torch>=2.11.0 requirement
+# would pull torch 2.11 over the runtime's pinned vendor torch (the exact
+# matrix disturbance repack exists to prevent — see
+# packaging/vllm/docs/report-vllm-0.24.0.md §1.2/§4.1).
 RUN pip install \
   --index-url "${FLAGOS_PYPI}" \
   --extra-index-url "${EXTRA_PYPI}" \
-  "vllm==${VLLM_VERSION}"
+  "vllm==${VLLM_VERSION}+flagos"
 
 # --- Install vllm-plugin-FL (source) --------------------------
 
@@ -68,6 +74,16 @@ RUN if [ -n "${PLUGIN_FL_REF}" ]; then \
     && VLLM_VENDOR=${VLLM_VENDOR} pip install --no-build-isolation . \
     && rm -rf /workspace/vllm-plugin-FL ; \
   fi
+
+# --- App env ---------------------------------------------------
+
+# Per-backend app env vars (configs.yaml env.app.{app}): baked into
+# /etc/profile.d/app_env.sh — sourced by the runtime's bash plumbing
+# (BASH_ENV=/etc/bash_env.sh sources /etc/profile.d/*.sh).
+ARG APP_ENV=""
+RUN if [ -n "${APP_ENV}" ]; then \
+      printf '%s\n' "${APP_ENV}" > /etc/profile.d/app_env.sh; \
+    fi
 
 # --- Runtime --------------------------------------------------
 

--- a/configs.yaml
+++ b/configs.yaml
@@ -115,8 +115,9 @@ vendors:
           LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
         app:
           vllm:
-            # vLLM 0.24.0 无条件 import flashinfer（采样器开关默认 True）。
-            # Runtime 不装 flashinfer —— 在 app 层关掉采样器。
+            # vLLM 0.24.0 unconditionally imports flashinfer (sampler switch
+            # defaults to True). The runtime does not ship flashinfer — turn
+            # the sampler off at the app layer.
             VLLM_USE_FLASHINFER_SAMPLER: "0"
       deps:
         - torch==2.10.0+cu128
@@ -140,8 +141,9 @@ vendors:
           LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
         app:
           vllm:
-            # vLLM 0.24.0 无条件 import flashinfer（采样器开关默认 True）。
-            # Runtime 不装 flashinfer —— 在 app 层关掉采样器。
+            # vLLM 0.24.0 unconditionally imports flashinfer (sampler switch
+            # defaults to True). The runtime does not ship flashinfer — turn
+            # the sampler off at the app layer.
             VLLM_USE_FLASHINFER_SAMPLER: "0"
       deps:
         - torch==2.11.0+cu130

--- a/configs.yaml
+++ b/configs.yaml
@@ -51,8 +51,11 @@
 #   "env:"             — environment split by which image consumes it:
 #                          base:        vars baked into flagos-base-{vendor}-{backend}
 #                          runtime:     vars baked into flagos-runtime-{vendor}-{backend}
-#                        base/runtime must mirror EXACTLY what the image sets — the
-#                        source of truth for per-image env documentation.
+#                          app:         per-app vars baked into
+#                                       flagos-app/{app}-{vendor}-{backend}, keyed by
+#                                       app name (vllm / megatron)
+#                        base/runtime/app must mirror EXACTLY what the image sets —
+#                        the source of truth for per-image env documentation.
 #   "deps:"            — Python dependencies (torch stack, etc.).
 #   "hardware:"        — chip models the image targets (rendered as a prerequisite).
 #   "driver:"          — host driver version installed on the node — a prerequisite,
@@ -110,6 +113,11 @@ vendors:
         base:
           PATH: /usr/local/cuda/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
+        app:
+          vllm:
+            # vLLM 0.24.0 无条件 import flashinfer（采样器开关默认 True）。
+            # Runtime 不装 flashinfer —— 在 app 层关掉采样器。
+            VLLM_USE_FLASHINFER_SAMPLER: "0"
       deps:
         - torch==2.10.0+cu128
         - torchaudio==2.10.0+cu128
@@ -130,6 +138,11 @@ vendors:
         base:
           PATH: /usr/local/cuda/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
+        app:
+          vllm:
+            # vLLM 0.24.0 无条件 import flashinfer（采样器开关默认 True）。
+            # Runtime 不装 flashinfer —— 在 app 层关掉采样器。
+            VLLM_USE_FLASHINFER_SAMPLER: "0"
       deps:
         - torch==2.11.0+cu130
         - torchaudio==2.11.0+cu130

--- a/docs/gen_data.py
+++ b/docs/gen_data.py
@@ -302,6 +302,11 @@ def main():
                         "packages": runtime_packages(spec, configs.get("flaggems", "")),
                         "env": env.get("runtime") or {},
                     },
+                    "app": {
+                        # Per-app env vars (configs.yaml env.app.{app}) — consumed
+                        # by generate_matrix.py --app for app image builds.
+                        "env": env.get("app") or {},
+                    },
                 }
             )
 

--- a/packaging/vllm/docs/report-vllm-0.24.0.md
+++ b/packaging/vllm/docs/report-vllm-0.24.0.md
@@ -9,7 +9,9 @@
 > 新的 Wheel 包在安装之后使用各 GPU/NPU 厂家所提供的运行时。
 > 为确保最终生成的软件堆栈有效，需要逐个后端（Backend）地到对应的物理环境执行验证，
 > 确保新的 Wheel 包及其依赖项能够正确安装、vLLM 软件栈可正常启动并执行推理任务。
-> 本文记录 **metax（沐曦）** 后端的验证过程与结果。
+> 本文记录 **metax（沐曦）** 与 **nvidia（英伟达）** 后端的验证过程与结果：
+> - metax 见 §3–§5（MACA SDK 3.7.2.1 / 3.8.1.3 × 双编译器，4 环境全通过）；
+> - nvidia 见 §6（CUDA 12.8 / 13.3 × 双编译器，空模式，全通过）。
 >
 > 类似的工作也在 0.20.2 版本的 vLLM 上开展，相关记录见
 > [`report-vllm-0.20.2.md`](report-vllm-0.20.2.md)。
@@ -18,13 +20,17 @@
 
 ## 0. 结论摘要（TL;DR）
 
-结论：Metax 全线 4 种环境全部验证通过。
+结论：Metax 全线 4 种环境全部验证通过；NVIDIA 2 种 CUDA 环境（×双编译器）全部验证通过。
 
 - 构建 + 重新打包（wheel）：✅ 通过（2026-08-12）
 - SDK（3.7.2.1）× FlagTree：✅ 通过（2026-08-14）
 - SDK（3.7.2.1）× Triton：✅ 通过（2026-08-13）
 - SDK（3.8.1.3）× FlagTree：✅ 通过（2026-08-15）
 - SDK（3.8.1.3）× Triton：✅ 通过（2026-08-15）
+- CUDA 12.8 × FlagTree：✅ 通过（2026-08-16，空模式）
+- CUDA 12.8 × Triton：✅ 通过（2026-08-16，空模式）
+- CUDA 13.3 × FlagTree：✅ 通过（2026-08-16，空模式）
+- CUDA 13.3 × Triton：✅ 通过（2026-08-16，空模式）
 
 "通过" 意味着：1） vLLM 服务可以正常启动；2）使用 Qwen3-4B 模型可以执行正常推理服务；
 
@@ -186,7 +192,7 @@ vLLM 顶层的依赖声明相应改成 `==X.Y.Z+flagos`，单步安装时命中�
    修复：改用 `from flag_gems import reshape_and_cache_flash`
    （纯 Python 实现，签名逐参吻合）。
    **同一问题也存在于 0.20.2 版本适配中，已向插件提交 PR #333**。
-   另外，vllm-plugin-FL 的 0.3-dev 分支也不存在此修复（详 §6）。
+   另外，vllm-plugin-FL 的 0.3-dev 分支也不存在此修复（详 §7）。
 
 5. **Triton 3.0.0 编译器拒绝链式布尔操作**：`A or B or C` 语法报
    "chained boolean operators not supported"。
@@ -251,7 +257,74 @@ vLLM 二次启动报 `ValueError: Free memory on device cuda:0 (2.02/63.59 GiB) 
 
 ---
 
-## 6. 版本推进协作问题
+## 6. NVIDIA（CUDA 12.8 / 13.3）详细记录
+
+日期：2026-08-16
+节点：`h20`（H20 GPU，x86_64）
+容器：`vllm024-nv128`（12.8）、`vllm024-nv133`（13.3）
+镜像：`flagos-runtime-nvidia-cuda12.8:2.1.2` / `flagos-runtime-nvidia-cuda13.3:2.1.2`
+模型：Qwen3-4B（`/models/Qwen3-4B`，由 `/data/tqm/models` 挂载）
+参数：`--enforce-eager --dtype bfloat16`，端口 8031/8032
+
+### 6.0 插件基线：v0.3.0-dev
+
+NVIDIA 路径使用 vllm-plugin-FL 的 **`v0.3.0-dev` 分支**（官方 0.24.0 适配线，
+tar.gz 解包到 `/app/vllm-plugin-FL`），与 metax 验证用的 main + 补丁基线不同
+（两分支差异与合并路线见 §7）。在 dev 分支上 **无需任何 monkey-patch**：
+metax 老 SDK 特有的 4 个 `vllm024_compat.py` 补丁（§4.3 问题 3/5/6）在
+torch 2.10/2.11 + CUDA 上不存在对应缺陷。
+
+### 6.1 关键阻塞点与解决
+
+1. **CUDA 平台无条件 import flashinfer**：0.24.0 的 CUDA 平台代码在
+   `flashinfer_sampler_supported()` 中检查环境变量 `VLLM_USE_FLASHINFER_SAMPLER`
+   （默认 True）后就 import flashinfer。Runtime 镜像未装 flashinfer，
+   启动即报 import 错误。
+
+   解决：启动时设置 **`VLLM_USE_FLASHINFER_SAMPLER=0`**（环境变量开关，
+   非代码修改）。日志确认：`FlashInfer top-p/top-k sampling disabled via
+   VLLM_USE_FLASHINFER_SAMPLER=0`。
+
+2. **插件安装必须 `--no-build-isolation`**：pip 构建隔离会独立下载
+   pyproject 声明的构建依赖 —— 其中 `torch>=2.7.1` 从 pypi.org 拉取约 2.4GB，
+   且会**用下载的 torch 构建插件**。这与 repack 的初衷（保护 Runtime 镜像中
+   精心匹配的版本矩阵）直接冲突，绝不允许。
+
+   解决：先盘点 Runtime 环境已有工具链（setuptools 81.0.0、pybind11 3.0.3、
+   ninja 1.13.0 已具备；缺 `wheel`、`scikit-build-core==0.11`、`cmake`），
+   从**厂商 PyPI 索引**（`flagos-pypi-nvidia`）补齐缺失项，再
+   `pip install -e . --no-build-isolation`（约 30 秒完成）。
+
+### 6.2 验证结果
+
+**CUDA 12.8（torch 2.10.0+cu128，python 3.12）**
+
+- flagtree 3.6.0（`/opt/flagtree`，默认）：✅ 启动 + 推理通过（`/tmp/serve-0.24.0.log`）
+- triton 3.6.0（`/opt/triton`）：✅ 启动 + 推理通过（`/tmp/serve-0.24.0-triton.log`）
+- 安装：`pip install vllm==0.24.0+flagos` 单步（`/tmp/pip-vllm024.log`，
+  `Using cached vllm-0.24.0%2Bflagos-cp312-cp312-linux_x86_64.whl (7.8 MB)`）
+
+**CUDA 13.3（torch 2.11.0+cu130，python 3.12）**
+
+- flagtree 3.6.0：✅ 启动 + 推理通过（`/tmp/serve-flagtree-133.log`）
+- triton 3.6.0：✅ 启动 + 推理通过（`/tmp/serve-triton-133.log`）
+- 安装：插件 `--no-build-isolation`（`/tmp/pip-plugin.log`）+ vllm 单步
+  （`/tmp/pip-vllm133.log`）
+
+两种编译器、两个 CUDA 版本的推理输出完全一致：
+`' Paris. The capital of Germany is Berlin. The capital of Italy is Rome.'`
+（finish=length，模型指纹 `vllm-0.24.0-423da8ca`）。
+
+### 6.3 跨 CUDA 版本复用（重要结论）
+
+12.8 与 13.3 同为 python 3.12，**共用一个 cp312 empty wheel**
+（`vllm-0.24.0+flagos-cp312-cp312-linux_x86_64.whl`）。13.3 验证同时回答了
+"相同 cp 版本的 Wheel 是否可跨 CUDA 使用"：**12.8 构建的 wheel 直接在 13.3
+（cu130）上单步安装并运行通过**。是否可跨 OS/架构（如 aarch64）仍待验证。
+
+---
+
+## 7. 版本推进协作问题
 
 vllm-plugin-FL 项目组在 **`v0.3.0-dev`** 分支上展开 vLLM 0.24.0 适配工作。
 在 #252 处与 main 分叉，尚未合入 main。适配主线：
@@ -292,6 +365,9 @@ build-infra 验证用的基线是 main + PR #377，vllm-plugin-FL 的正式适�
 **待定事项：**
 - [ ] **确认 0.24.0 正式发布线**：main（+ 我们补丁）还是 v0.3.0-dev？
       如果以 dev 为基线，§4 的验证要在 dev 分支上重验。
+      **§6 的 NVIDIA 验证已在 dev 基线上完成（空模式、零 patch、双编译器全过）**，
+      证明 dev 分支在 CUDA 上可直接交付；metax 侧则需要确认 3.0.0 编译器问题
+      的 4 个补丁是否 upstream。
 - [ ] `_patch_torch_accelerator` 与 `accelerator_compat.py` 去重：
       保留哪个版本；是否把 reset 的 try/except 兜底 backport 到 dev。
 - [ ] 确认 dev 分支在 triton 3.0.0 路径是否缺问题 3/5/6 的修复（serve 冒烟即知）。
@@ -301,21 +377,34 @@ build-infra 验证用的基线是 main + PR #377，vllm-plugin-FL 的正式适�
 
 ---
 
-## 7. 遗留事项
+## 8. 遗留事项
 
 - [ ] `setuptools 84.0.0` 不满足 pyproject 中 `<81` 要求 —— 非致命问题，先不动，留意。
-- [ ] 0.24.0 其余后端（nvidia、mthreads、hygon、iluvatar、enflame、sunrise 等）的验证
+- [ ] 0.24.0 其余后端（mthreads、hygon、iluvatar、enflame、sunrise、cambricon、
+      ascend、kunlunxin 等）的验证
 
 ---
 
 ## 附录 · 验证命令（容器内）
 
+metax 形式（含 `compiler` 切换 + `VLLM_USE_FLASHINFER_SAMPLER=0`，NVIDIA 通用）：
+
 ```bash
-cd /app/vllm-plugin-FL && PYTHONPATH=/opt/triton:/opt/flagtree \
+cd /app/vllm-plugin-FL && compiler flagtree && VLLM_USE_FLASHINFER_SAMPLER=0 \
   nohup /flagos/bin/python -m vllm.entrypoints.openai.api_server \
-  --model /data/models/Qwen/Qwen3-4B --port 8031 --enforce-eager --dtype bfloat16 \
-  > /tmp/serve-0.24.0.log 2>&1 &
+  --model /models/Qwen3-4B --port 8031 --enforce-eager --dtype bfloat16 \
+  > /tmp/serve.log 2>&1 &
 
 curl -s localhost:8031/v1/completions -H 'Content-Type: application/json' \
-  -d '{"model":"/data/models/Qwen/Qwen3-4B","prompt":"The capital of France is","max_tokens":16,"temperature":0}'
+  -d '{"model":"/models/Qwen3-4B","prompt":"The capital of France is","max_tokens":16,"temperature":0}'
+```
+
+NVIDIA 插件安装（必须 `--no-build-isolation`，缺失工具链从厂商 PyPI 补齐）：
+
+```bash
+/flagos/bin/pip install --no-cache-dir wheel scikit-build-core==0.11 cmake \
+  -i https://resource.flagos.net/repository/flagos-pypi-nvidia/simple/ \
+  --extra-index-url https://mirrors.aliyun.com/pypi/simple
+cd /app/vllm-plugin-FL && /flagos/bin/pip install -e . --no-build-isolation
+/flagos/bin/pip install vllm==0.24.0+flagos
 ```

--- a/packaging/vllm/docs/report-vllm-0.24.0.md
+++ b/packaging/vllm/docs/report-vllm-0.24.0.md
@@ -23,10 +23,10 @@
 结论：Metax 全线 4 种环境全部验证通过；NVIDIA 2 种 CUDA 环境（×双编译器）全部验证通过。
 
 - 构建 + 重新打包（wheel）：✅ 通过（2026-08-12）
-- SDK（3.7.2.1）× FlagTree：✅ 通过（2026-08-14）
-- SDK（3.7.2.1）× Triton：✅ 通过（2026-08-13）
-- SDK（3.8.1.3）× FlagTree：✅ 通过（2026-08-15）
-- SDK（3.8.1.3）× Triton：✅ 通过（2026-08-15）
+- MACA（3.7.2.1）× FlagTree：✅ 通过（2026-08-14）
+- MACA（3.7.2.1）× Triton：✅ 通过（2026-08-13）
+- MACA（3.8.1.3）× FlagTree：✅ 通过（2026-08-15）
+- MACA（3.8.1.3）× Triton：✅ 通过（2026-08-15）
 - CUDA 12.8 × FlagTree：✅ 通过（2026-08-16，空模式）
 - CUDA 12.8 × Triton：✅ 通过（2026-08-16，空模式）
 - CUDA 13.3 × FlagTree：✅ 通过（2026-08-16，空模式）
@@ -261,7 +261,6 @@ vLLM 二次启动报 `ValueError: Free memory on device cuda:0 (2.02/63.59 GiB) 
 
 日期：2026-08-16
 节点：`h20`（H20 GPU，x86_64）
-容器：`vllm024-nv128`（12.8）、`vllm024-nv133`（13.3）
 镜像：`flagos-runtime-nvidia-cuda12.8:2.1.2` / `flagos-runtime-nvidia-cuda13.3:2.1.2`
 模型：Qwen3-4B（`/models/Qwen3-4B`，由 `/data/tqm/models` 挂载）
 参数：`--enforce-eager --dtype bfloat16`，端口 8031/8032
@@ -269,10 +268,8 @@ vLLM 二次启动报 `ValueError: Free memory on device cuda:0 (2.02/63.59 GiB) 
 ### 6.0 插件基线：v0.3.0-dev
 
 NVIDIA 路径使用 vllm-plugin-FL 的 **`v0.3.0-dev` 分支**（官方 0.24.0 适配线，
-tar.gz 解包到 `/app/vllm-plugin-FL`），与 metax 验证用的 main + 补丁基线不同
-（两分支差异与合并路线见 §7）。在 dev 分支上 **无需任何 monkey-patch**：
-metax 老 SDK 特有的 4 个 `vllm024_compat.py` 补丁（§4.3 问题 3/5/6）在
-torch 2.10/2.11 + CUDA 上不存在对应缺陷。
+tar.gz 解包到 `/app/vllm-plugin-FL`；与 main 分支的差异与合并路线见 §7），
+在 dev 分支上 **无需任何 monkey-patch**。
 
 ### 6.1 关键阻塞点与解决
 
@@ -295,21 +292,24 @@ torch 2.10/2.11 + CUDA 上不存在对应缺陷。
    从**厂商 PyPI 索引**（`flagos-pypi-nvidia`）补齐缺失项，再
    `pip install -e . --no-build-isolation`（约 30 秒完成）。
 
+   长期方案：随 §7 合并路线将插件以 **wheel 形式发布**后，源安装路径整体消失
+   —— 预编译 wheel 不需要任何构建工具链，无需把 `wheel`/`scikit-build-core`/
+   `cmake` 常驻进共享 Runtime 镜像（它们只为单步源安装临时补齐）。
+
 ### 6.2 验证结果
 
 **CUDA 12.8（torch 2.10.0+cu128，python 3.12）**
 
-- flagtree 3.6.0（`/opt/flagtree`，默认）：✅ 启动 + 推理通过（`/tmp/serve-0.24.0.log`）
-- triton 3.6.0（`/opt/triton`）：✅ 启动 + 推理通过（`/tmp/serve-0.24.0-triton.log`）
-- 安装：`pip install vllm==0.24.0+flagos` 单步（`/tmp/pip-vllm024.log`，
-  `Using cached vllm-0.24.0%2Bflagos-cp312-cp312-linux_x86_64.whl (7.8 MB)`）
+- flagtree 3.6.0（`/opt/flagtree`，默认）：✅ 启动 + 推理通过
+- triton 3.6.0（`/opt/triton`）：✅ 启动 + 推理通过
+- 安装：`pip install vllm==0.24.0+flagos` 单步（`Using cached
+  vllm-0.24.0%2Bflagos-cp312-cp312-linux_x86_64.whl (7.8 MB)`，无新下载）
 
 **CUDA 13.3（torch 2.11.0+cu130，python 3.12）**
 
-- flagtree 3.6.0：✅ 启动 + 推理通过（`/tmp/serve-flagtree-133.log`）
-- triton 3.6.0：✅ 启动 + 推理通过（`/tmp/serve-triton-133.log`）
-- 安装：插件 `--no-build-isolation`（`/tmp/pip-plugin.log`）+ vllm 单步
-  （`/tmp/pip-vllm133.log`）
+- flagtree 3.6.0：✅ 启动 + 推理通过
+- triton 3.6.0：✅ 启动 + 推理通过
+- 安装：插件 `--no-build-isolation` + vllm 单步
 
 两种编译器、两个 CUDA 版本的推理输出完全一致：
 `' Paris. The capital of Germany is Berlin. The capital of Italy is Rome.'`
@@ -399,7 +399,8 @@ curl -s localhost:8031/v1/completions -H 'Content-Type: application/json' \
   -d '{"model":"/models/Qwen3-4B","prompt":"The capital of France is","max_tokens":16,"temperature":0}'
 ```
 
-NVIDIA 插件安装（必须 `--no-build-isolation`，缺失工具链从厂商 PyPI 补齐）：
+NVIDIA 插件安装 —— 仅当前源安装路径需要（必须 `--no-build-isolation`，缺失工具链
+从厂商 PyPI 补齐）；插件以 wheel 形式发布后（§7 合并路线），此块整体省略：
 
 ```bash
 /flagos/bin/pip install --no-cache-dir wheel scikit-build-core==0.11 cmake \

--- a/packaging/vllm/docs/vllm-verification-matrix.md
+++ b/packaging/vllm/docs/vllm-verification-matrix.md
@@ -88,9 +88,9 @@
 **0.24.0（截至 2026-08-16）**
 
 - **nvidia-cuda12.8** ✅（2026-08-16，空模式双编译器）：flagtree 3.6.0 ✅、
-  triton 3.6.0 ✅（`/opt/triton`），均 Qwen3-4B E2E，指纹 `vllm-0.24.0-423da8ca`。
+  triton 3.6.0 ✅（`/opt/triton`），均通过 Qwen3-4B E2E 验证，指纹 `vllm-0.24.0-423da8ca`。
 - **nvidia-cuda13.3** ✅（2026-08-16，空模式双编译器）：flagtree 3.6.0 ✅、
-  triton 3.6.0 ✅，均 Qwen3-4B E2E，指纹 `vllm-0.24.0-423da8ca`。
+  triton 3.6.0 ✅，均通过 Qwen3-4B E2E 验证，指纹 `vllm-0.24.0-423da8ca`。
   同时验证了 **cp312 empty wheel 跨 CUDA 复用**：12.8（torch 2.10.0+cu128）构建的
   同一 Wheel 直接在 13.3（torch 2.11.0+cu130）上安装运行。
 - **NVIDIA 路径统一要点**（详见 `report-vllm-0.24.0.md` §6）：

--- a/packaging/vllm/docs/vllm-verification-matrix.md
+++ b/packaging/vllm/docs/vllm-verification-matrix.md
@@ -22,8 +22,8 @@
 
 | 厂商 | 后端 | 0.20.2(T) | 0.20.2(F) | 0.24.0(T) | 0.24.0(F) |
 |---|---|---|---|---|---|
-| 英伟达 | CUDA 12.8 | ⬜ | ✅ | ⬜ | ⬜ |
-| 英伟达 | CUDA 13.3 | ⬜ | ⬜ | ⬜ | ⬜ |
+| 英伟达 | CUDA 12.8 | ⬜ | ✅ | ✅ | ✅ |
+| 英伟达 | CUDA 13.3 | ⬜ | ⬜ | ✅ | ✅ |
 | 昇腾 | CANN 8.5.0 | ⬜ | ⬜ | ⬜ | ⬜ |
 | 昇腾 | CANN 9.0.0 | ⬜ | ✅ | ⬜ | ⬜ |
 | 寒武纪 | NEUWARE 4.4.3 | ⬜ | — | ⬜ | — |
@@ -85,8 +85,18 @@
   triton 3.0.0（XTDK LLVM19 空 SetVector 断言）。应用层无法绕过，已交编译器团队，
   详见 [kunlunxin-xpu-triton-attention-compiler-bug.md](kunlunxin-xpu-triton-attention-compiler-bug.md)。
 
-**0.24.0（截至 2026-08-15）**
+**0.24.0（截至 2026-08-16）**
 
+- **nvidia-cuda12.8** ✅（2026-08-16，空模式双编译器）：flagtree 3.6.0 ✅、
+  triton 3.6.0 ✅（`/opt/triton`），均 Qwen3-4B E2E，指纹 `vllm-0.24.0-423da8ca`。
+- **nvidia-cuda13.3** ✅（2026-08-16，空模式双编译器）：flagtree 3.6.0 ✅、
+  triton 3.6.0 ✅，均 Qwen3-4B E2E，指纹 `vllm-0.24.0-423da8ca`。
+  同时验证了 **cp312 empty wheel 跨 CUDA 复用**：12.8（torch 2.10.0+cu128）构建的
+  同一 Wheel 直接在 13.3（torch 2.11.0+cu130）上安装运行。
+- **NVIDIA 路径统一要点**（详见 `report-vllm-0.24.0.md` §6）：
+  插件基线 **v0.3.0-dev**；CUDA 平台无条件 import flashinfer，
+  需环境变量 `VLLM_USE_FLASHINFER_SAMPLER=0` 关闭采样器；
+  插件安装必须 `--no-build-isolation`（构建隔离会从 pypi.org 下载 torch≈2.4GB）。
 - **metax 四环境全 ✅**（2026-08-13~15）：MACA 3.7.2.1
   （triton 3.0.0 / flagtree 0.6.1+metax3.6）× 两编译器、MACA 3.8.1.3
   （triton 3.6.0 / flagtree 0.6.1+metax3.6）× 两编译器。
@@ -95,13 +105,16 @@
 - **triton 3.0.0 需 4 个 monkey-patch**（`vllm024_compat.py`，老 SDK 特有）：
   `_load_ptr` constexpr 解包、`_penalties_kernel` 链式布尔加括号、
   `get_top_k_top_p` 与 `pool` 的 UVA CPU 索引 + 移回设备；新 SDK（triton 3.6.0）无需。
-- **0.24.0 其余后端待验证**：nvidia, mthreads, hygon, iluvatar, enflame, sunrise,
+- **0.24.0 其余后端待验证**：mthreads, hygon, iluvatar, enflame, sunrise,
   cambricon, ascend, kunlunxin 等。
 
 **跨版本事实**
 
 - 0.24.0 empty wheel 绑定 `cp312-cp312-linux_x86_64`，
   0.20.2 是 `py3-none-any`（纯 Python，可跨 cp 复用）。
+- **cp312 wheel 跨 CUDA 版本可复用**（实测）：cuda12.8 构建的 `vllm-0.24.0+flagos`
+  wheel 在 cuda13.3（torch 2.11.0+cu130）上单步安装运行 ✅。
+  是否可跨 OS/架构（如 aarch64）仍待验证。
 - 所有适配补丁收敛在 vllm-plugin-FL 插件侧，不修改官方 vLLM。
 
 ## 已知问题 / 阻塞

--- a/scripts/generate_matrix.py
+++ b/scripts/generate_matrix.py
@@ -24,9 +24,13 @@ Usage:
     python scripts/generate_matrix.py nvidia-cuda12.8         # base: subset
     python scripts/generate_matrix.py --runtime                # runtime: all
     python scripts/generate_matrix.py --runtime nvidia-cuda12.8  # runtime: subset
+    python scripts/generate_matrix.py --app vllm nvidia-cuda12.8 # app: subset
+    python scripts/generate_matrix.py --app megatron           # app: all
 
 --runtime mode pre-computes all docker build args so self-hosted
-runners don't need Python/pyyaml installed.
+runners don't need Python/pyyaml installed.  --app mode is the
+same superset plus the per-backend app-layer env vars
+(configs.yaml env.app.{app}) serialized as "KEY=value\n...".
 """
 
 import argparse
@@ -74,11 +78,21 @@ def _base_matrix(runners: dict, selected: list[str]) -> dict:
     return {"include": [{"name": n, "runson": runson_for(n, runners)} for n in selected]}
 
 
-def _runtime_matrix(configs: dict, runners: dict, repo_root: Path, selected: list[str]) -> dict:
+def _runtime_matrix(
+    configs: dict,
+    runners: dict,
+    repo_root: Path,
+    selected: list[str],
+    app: str | None = None,
+) -> dict:
     """Extended matrix for runtime builds: includes all docker build args.
 
     All values come from configs.yaml + build-config.yml.  No git tag
     dependency — the version is read directly from configs.yaml ``version:``.
+
+    When ``app`` is given, the matrix is the same superset plus the
+    per-backend app env vars from configs.yaml env.app.{app}, serialized
+    as "KEY=value\\n..." (same format as runtime_env) under ``app_env``.
     """
     build_config = load_yaml(repo_root / ".github" / "build-config.yml")
     registry = build_config.get("registry") or {}
@@ -119,7 +133,15 @@ def _runtime_matrix(configs: dict, runners: dict, repo_root: Path, selected: lis
             f"{k}={v}" for k, v in (runtime_env or {}).items()
         )
 
-        include.append({
+        # Per-backend app env vars for one app — same serialization as runtime_env
+        app_env_lines = ""
+        if app is not None:
+            app_env = ((backend_info.get("env") or {}).get("app") or {}).get(app, {})
+            app_env_lines = "\n".join(
+                f"{k}={v}" for k, v in (app_env or {}).items()
+            )
+
+        entry = {
             "name": name,
             "version": stack_version,
             "runson": runson_for(name, runners),
@@ -138,7 +160,12 @@ def _runtime_matrix(configs: dict, runners: dict, repo_root: Path, selected: lis
                 backend_info.get("triton_post_install", [])
             ) if isinstance(backend_info.get("triton_post_install"), list) else "",
             "runtime_env": runtime_env_lines,
-        })
+        }
+        # App build matrix = runtime fields + app env; --runtime keeps no
+        # app_env key so runtime-image.yml output is unchanged.
+        if app is not None:
+            entry["app_env"] = app_env_lines
+        include.append(entry)
 
     return {"include": include}
 
@@ -152,6 +179,11 @@ def main():
     parser.add_argument(
         "--runtime", action="store_true",
         help="Generate runtime build matrix (includes docker build args)",
+    )
+    parser.add_argument(
+        "--app", metavar="APP",
+        help="Generate app build matrix for the named app (vllm / megatron): "
+             "runtime matrix fields + per-backend env.app.{APP} as app_env",
     )
     parser.add_argument(
         "backends", nargs="*",
@@ -185,7 +217,9 @@ def main():
     else:
         selected = [name for name, has_file in all_backends if has_file]
 
-    if args.runtime:
+    if args.app:
+        matrix = _runtime_matrix(configs, runners, repo_root, selected, app=args.app)
+    elif args.runtime:
         matrix = _runtime_matrix(configs, runners, repo_root, selected)
     else:
         matrix = _base_matrix(runners, selected)

--- a/scripts/generate_matrix.py
+++ b/scripts/generate_matrix.py
@@ -25,7 +25,7 @@ Usage:
     python scripts/generate_matrix.py --runtime                # runtime: all
     python scripts/generate_matrix.py --runtime nvidia-cuda12.8  # runtime: subset
     python scripts/generate_matrix.py --app vllm nvidia-cuda12.8 # app: subset
-    python scripts/generate_matrix.py --app megatron           # app: all
+    python scripts/generate_matrix.py --app megatron           # app: all backends
 
 --runtime mode pre-computes all docker build args so self-hosted
 runners don't need Python/pyyaml installed.  --app mode is the


### PR DESCRIPTION
## Problem

vLLM 0.24.0 imports flashinfer unconditionally on CUDA (the sampler toggle
`VLLM_USE_FLASHINFER_SAMPLER` defaults to True). The runtime image does not
ship flashinfer — adding it to the shared runtime would disturb the
torch/triton/flag_gems version matrix that megatron also consumes. The NVIDIA
backend therefore only needs one app-layer env var to disable the sampler.

That exposed a framework gap: per-backend **app-layer** env vars had no home
and no delivery channel. This PR extends the existing runtime env pattern
(configs.yaml `env.runtime` → serialized build arg → `/etc/profile.d/runtime_env.sh`)
to the **app layer**, so other apps and other backends follow the same pattern.

## Design

`env:` in configs.yaml gains a third dimension, `app:`, keyed by **app name**
(vllm / megatron). Per-app vars must not leak into other app images, and
"other apps follow this pattern" requires each app to own its env block.

```
configs.yaml  env.app.vllm.VLLM_USE_FLASHINFER_SAMPLER: "0"  (nvidia-cuda12.8/13.3)
   → scripts/generate_matrix.py --app vllm  →  matrix gets app_env: "VLLM_USE_FLASHINFER_SAMPLER=0"
   → docker build --build-arg APP_ENV="VLLM_USE_FLASHINFER_SAMPLER=0"
   → app/vllm/Containerfile: printf > /etc/profile.d/app_env.sh
   → baked into flagos-app/vllm-{name}:{version}; the runtime's bash plumbing
     (BASH_ENV=/etc/bash_env.sh sources /etc/profile.d/*.sh) makes it active in every shell
```

## Changes

- **configs.yaml** — document the `app:` dimension; add
  `env.app.vllm.VLLM_USE_FLASHINFER_SAMPLER: "0"` for nvidia-cuda12.8/13.3
- **app/{vllm,megatron}/Containerfile** — `APP_ENV` build arg written to
  `/etc/profile.d/app_env.sh` (same pattern as runtime/Containerfile; `$`
  stays unexpanded at write time)
- **scripts/generate_matrix.py** — new `--app <name>` mode = runtime matrix +
  `app_env`; `--runtime` output unchanged (regression byte-identical)
- **.github/workflows/megatron-app-image.yml** — matrix via `--app megatron`,
  build passes `APP_ENV`
- **docs/gen_data.py** — carry `env.app` into docs/data/images.yaml
- **app/vllm/Containerfile** — default VLLM_VERSION 0.20.2 → 0.24.0 and force
  the `vllm=={version}+flagos` pin

## Key fix: the vllm 0.20.2 default is a torch-pull trap

Node testing showed that a bare `vllm==0.20.2` single-step install resolves to
the newest torch on the aliyun fallback index (**torch 2.11.0+cu130, 531 MB**)
because flagos-pypi-nvidia doesn't carry torch and the mirror doesn't know the
runtime's torch 2.10.0+cu128 pin — overwriting the carefully matched matrix,
exactly what repack exists to prevent. Fix: default VLLM_VERSION 0.24.0 +
mandatory `+flagos` pin (the repacked wheel's torch-touching deps all carry
stripped torch declarations; the runtime's vendor torch satisfies `torch>=2.6.0`,
so the install is inert).

## Verification (all passed)

- `--app vllm nvidia-cuda12.8` → `app_env: "VLLM_USE_FLASHINFER_SAMPLER=0"`
- `--app megatron` → `app_env: ""` (inert)
- `--runtime` regression → byte-identical
- `docs/gen_data.py` → 17 backends, app.env only on nvidia 12.8/13.3
- Node build (h20, nvidia-cuda12.8): vllm 0.24.0+flagos installs with **no
  torch download**, torch in image stays `2.10.0+cu128`
- Container run: `echo $VLLM_USE_FLASHINFER_SAMPLER` → `0` (bash plumbing works)

This PR was written in part with the assistance of generative AI.
