### PR TITLE
fix(runtime): compiler status probes must strip the other side dir

### DIFF
--- a/runtime/zz-compiler.sh
+++ b/runtime/zz-compiler.sh
@@ -60,9 +60,21 @@ _compiler_strip_side_dirs() {
 }
 
 _compiler_import_triton() {
-    # Import triton with the given dir first on PYTHONPATH.
-    PYTHONPATH="${1}${PYTHONPATH:+:}${PYTHONPATH:-}" python3 -c \
-        "import triton; print(triton.__version__)"
+    # Import triton with the given dir first on PYTHONPATH. Strip the other
+    # compiler side dir first — prepending over an active default leaves both
+    # dirs on PYTHONPATH, and entry-point discovery then imports every
+    # declared backend (e.g. mthreads from flagtree vs musa from triton)
+    # against whichever triton tree wins package resolution, which fails when
+    # that backend only exists in the other tree.
+    local cleaned
+    cleaned=$(_compiler_strip_side_dirs)
+    if [ -n "$cleaned" ]; then
+        PYTHONPATH="${1}:${cleaned}" python3 -c \
+            "import triton; print(triton.__version__)"
+    else
+        PYTHONPATH="${1}" python3 -c \
+            "import triton; print(triton.__version__)"
+    fi
 }
 
 compiler() {


### PR DESCRIPTION
## Summary

Bare `compiler` (status display) crashes on dual-compiler backends where the two compiler trees register different Triton backend names. `_compiler_import_triton` prepended the probed side dir onto the already-active PYTHONPATH instead of stripping the other side dir first — so both `/opt/flagtree` and `/opt/triton` end up on PYTHONPATH, and triton's `_discover_backends()` imports every declared backend entry-point against whichever tree wins package resolution. On mthreads, flagtree declares `mthreads = triton.backends.mthreads` while the vendor triton declares `musa = triton.backends.musa`; the `mthreads` module only exists in flagtree's tree → `ModuleNotFoundError: No module named 'triton.backends.mthreads'`.

Switch behavior (`compiler flagtree|triton`) and the default PYTHONPATH export are untouched — only the status-probe helper strips the other dir first, matching the switch path.

## Changes

- **`runtime/zz-compiler.sh`**: `_compiler_import_triton` now strips the other compiler side dir (via `_compiler_strip_side_dirs`) before prepending the probed dir, so each version probe sees exactly one compiler tree.

## Verification

Reproduced the crash in the real image (`vllm-verify-mthreads-musa5.2.0`): bare `compiler` → `ModuleNotFoundError: No module named 'triton.backends.mthreads'`. With the fix sourced in the same container:

- bare `compiler` → `flagtree 3.6.0 (default)` / `triton 3.6.0`, active `flagtree - 3.6.0`
- `compiler triton` → `triton (active) - 3.6.0`, `compiler flagtree` back → OK
- bare `compiler` again with triton active (the reverse-mix case) → OK

This PR was written in part with the assistance of generative AI.
