### PR TITLE
docs(vllm): mthreads MUSA 4.3.6 verification (0.24.0) — T path ✅, F path ✅* (flagtree 0.6.1)

### DIFF
--- a/packaging/vllm/docs/report-vllm-0.24.0.md
+++ b/packaging/vllm/docs/report-vllm-0.24.0.md
@@ -517,29 +517,39 @@ OpManager **10 ops / 14 implementations** → attention_backend fallback
   矩阵"Qwen3-4B"约定在此单元格不适用；原始 completions 直给 R1 模型 +
   temperature 0.6 的整段重复回声是模型行为伪影（同 §8.2）。
 
-**F 路径 ❌（双层根因，无应用层修复）**：
+**F 路径 ✅（flagtree 0.6.1；configs 现 pin 0.6.0 需 bump）**：
 
-1. **flag_gems 拦截 pow → flagtree codegen 失败**：`base ** pos_freqs` →
-   `__rpow__` → flag_gems `pow_scalar` → `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`
-   （pow.py:61:34，`tl.exp2`）→ flagtree 0.6.0+mthreads3.6 发出向量化
-   `LLVM ERROR: Cannot select: v2f32 = fexp2` → vendor llc
-   （`/usr/local/musa/bin/llc -march=mtgpu -mcpu=mp_31`）无法选择 → SIGABRT。
-   报错前一行是 `llc` failed with error code -6。
-2. **黑名单排除 pow 后落入损坏的原生 torch 路径**：
-   `VLLM_FL_FLAGOS_BLACKLIST=pow_scalar`（**正确排除名** —— flag_gems
-   `config_filter` 按 Python 函数 `__name__` 匹配，不是 aten schema 名
-   `pow.Scalar`；`enable(unused=["pow"])` 不生效）→ pow 不再被 flag_gems
-   拦截（崩溃位置从 flag_gems pow.py 变为 `torch/_tensor.py:1113` 的
-   `__rpow__`）→ 原生 `torch.pow(other, self)` →
-   `RuntimeError: tensor.device().is_cpu() INTERNAL ASSERT FAILED at
-   pybind_utils.cpp:590` —— torch 2.9.0+musa.4.3.6 无法处理 Python float
-   底数 ** MUSA 张量指数。
+1. **0.6.0 的失败（双层根因，镜像原状）**：
+   a. **flag_gems 拦截 pow → flagtree codegen 失败**：`base ** pos_freqs` →
+      `__rpow__` → flag_gems `pow_scalar` → `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`
+      （pow.py:61:34，`tl.exp2`）→ flagtree 0.6.0+mthreads3.6 发出向量化
+      `LLVM ERROR: Cannot select: v2f32 = fexp2` → vendor llc
+      （`/usr/local/musa/bin/llc -march=mtgpu -mcpu=mp_31`）无法选择 → SIGABRT。
+      报错前一行是 `llc` failed with error code -6。
+   b. **黑名单排除 pow 后落入损坏的原生 torch 路径**：
+      `VLLM_FL_FLAGOS_BLACKLIST=pow_scalar`（**正确排除名** —— flag_gems
+      `config_filter` 按 Python 函数 `__name__` 匹配，不是 aten schema 名
+      `pow.Scalar`；`enable(unused=["pow"])` 不生效）→ pow 不再被 flag_gems
+      拦截（崩溃位置从 flag_gems pow.py 变为 `torch/_tensor.py:1113` 的
+      `__rpow__`）→ 原生 `torch.pow(other, self)` →
+      `RuntimeError: tensor.device().is_cpu() INTERNAL ASSERT FAILED at
+      pybind_utils.cpp:590` —— torch 2.9.0+musa.4.3.6 无法处理 Python float
+      底数 ** MUSA 张量指数。
+2. **0.6.0→0.6.1 实验（2026-08-17）确认修复**：同一容器手动替换 flagtree
+   为 **0.6.1+mthreads3.6**（whl `flagtree-0.6.1+mthreads3.6-cp310-cp310-...`，
+   安装到 `/opt/flagtree061` 后整体替换 `/opt/flagtree`，原 0.6.0 保留在
+   `/opt/flagtree060`）后：
+   - op 级 repro 通过：同一 `base ** pos_freqs` 内核编译成功，输出
+     `OK [1.0, 1.01358..., 1.02735...]`（0.6.0 下同脚本 SIGABRT）；
+   - serve E2E ✅：`Application startup complete`（OpManager 10 ops / 14
+     impls，rms_norm / silu_and_mul 走 `default.flagos`），completions greedy
+     + chat CoT 均连贯；指纹 `vllm-0.24.0-5936039f`（同 T 路径，同容器同插件）。
 
-结论：`self.base ** pos_freqs` 在 4.3.6 上**没有任何编译器路径可用** →
-F = ❌（kunlunxin/sunrise 风格交编译器团队），交付固定 `compiler triton`。
-对比 5.2.0：flagtree **0.6.1**+mthreads3.6 F 路径 ✅（2026-08-16，§8），
-版本差异（0.6.0 vs 0.6.1）是疑似根因 —— 具体是 codegen 变化还是
-vendor 匹配修复待编译器团队确认。
+结论：`self.base ** pos_freqs` 在 flagtree **0.6.1** 下可用 —— 0.6.0→0.6.1
+即修复（不再对 `tl.exp2` 发出 vendor llc 不可选择的 `v2f32 = fexp2`）。
+**configs.yaml 4.3.6 现 pin flagtree==0.6.0（F 路径坏），需 bump 到 0.6.1
+并重建镜像后，单元格才对应交付物。** 5.2.0 自始即 0.6.1（§8，F 路径 ✅），
+两者对齐后 mthreads 平台 F 路径全线一致。
 
 ---
 
@@ -548,9 +558,10 @@ vendor 匹配修复待编译器团队确认。
 - [ ] `setuptools 84.0.0` 不满足 pyproject 中 `<81` 要求 —— 非致命问题，先不动，留意。
 - [ ] 0.24.0 其余后端（hygon、iluvatar、enflame、sunrise、cambricon、
       ascend、kunlunxin 等）的验证 —— mthreads（§8 5.2.0 全通；§9 4.3.6
-      T ✅ / F ❌）；nvidia ✅（§6）
-- [ ] mthreads-musa4.3.6 F 路径：确认 flagtree 0.6.0→0.6.1 差异是否修复
-      `v2f32 = fexp2` codegen，供编译器团队跟进
+      T ✅ / F ✅*，`*` = flagtree 0.6.1 验证、configs 待 bump）；nvidia ✅（§6）
+- [ ] mthreads-musa4.3.6 **configs.yaml flagtree 0.6.0→0.6.1 bump** + 镜像
+      重建 —— 0.6.1 已验证修复 F 路径（§9.3），0.6.0 构建的镜像 F 路径
+      仍不可用，重建后矩阵 `✅*` 才对应交付物
 
 ---
 

--- a/packaging/vllm/docs/report-vllm-0.24.0.md
+++ b/packaging/vllm/docs/report-vllm-0.24.0.md
@@ -479,11 +479,78 @@ MUSA 平台走插件路径（`PlatformFL` → device_type `musa`、dist_backend 
 
 ---
 
-## 9. 遗留事项
+## 9. mthreads（MUSA 4.3.6）详细记录
+
+- 节点：`mthreads`（JumpServer → 10.121.38.24），用户 `secure`
+- 容器：`vllm-verify-mthreads-musa4.3.6`，MUSA SDK 4.3.6（torch 2.9.0+musa.4.3.6）
+- venv：`/flagos`（cpython-3.10 —— 与 5.2.0 同为 cp310 wheel）
+- 插件：v0.3.0-dev head（零补丁），editable install 于 `/opt/vllm-plugin-FL`
+- 模型：`/data/DeepSeek-R1-0528-Qwen3-8B-FlagOS`
+- 端口：8031
+
+### 9.1 构建 + 安装
+
+同 §8.1 —— 单步安装 `vllm==0.24.0+flagos`（cp310 wheel，命中 `+flagos`
+wheel，无 torch 侧漏）；`pin_indirect: {xgrammar: "0.2.3"}` 同。
+
+### 9.2 插件基线：v0.3.0-dev 零补丁
+
+同 §8.2 —— v0.3.0-dev head（fbc115d），零补丁。serve 启动链与 5.2.0 一致：
+OpManager **10 ops / 14 implementations** → attention_backend fallback
+`default.flagos` → `vendor.musa` → 权重加载 → `Application startup complete`。
+非致命遥测 fork 报错（`Cannot re-initialize MUSA in forked subprocess`）与
+§8.2 相同，不影响服务。
+
+### 9.3 编译器路径判定
+
+**T 路径 ✅**（vendor triton 3.6.0+git89458660）：
+
+- 触发算子：YaRN rotary-embedding `_compute_inv_freq` 中的
+  `base ** pos_freqs`（base=1000000.0，1024 元素 MUSA float 张量）→
+  flag_gems `pow_scalar` → `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`。
+  该内核在 **vendor triton 下编译通过**（op 级 repro 输出
+  `OK [1.0, 1.01358..., 1.02735...]`）。
+- serve E2E ✅：`Application startup complete`；completions greedy 与
+  chat CoT 均连贯；指纹 `vllm-0.24.0-5936039f`（5.2.0 为
+  `vllm-0.24.0-423da8ca`）。
+- 验证模型为 DeepSeek-R1-0528-Qwen3-8B-FlagOS（mthreads 节点无 Qwen3-4B），
+  矩阵"Qwen3-4B"约定在此单元格不适用；原始 completions 直给 R1 模型 +
+  temperature 0.6 的整段重复回声是模型行为伪影（同 §8.2）。
+
+**F 路径 ❌（双层根因，无应用层修复）**：
+
+1. **flag_gems 拦截 pow → flagtree codegen 失败**：`base ** pos_freqs` →
+   `__rpow__` → flag_gems `pow_scalar` → `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`
+   （pow.py:61:34，`tl.exp2`）→ flagtree 0.6.0+mthreads3.6 发出向量化
+   `LLVM ERROR: Cannot select: v2f32 = fexp2` → vendor llc
+   （`/usr/local/musa/bin/llc -march=mtgpu -mcpu=mp_31`）无法选择 → SIGABRT。
+   报错前一行是 `llc` failed with error code -6。
+2. **黑名单排除 pow 后落入损坏的原生 torch 路径**：
+   `VLLM_FL_FLAGOS_BLACKLIST=pow_scalar`（**正确排除名** —— flag_gems
+   `config_filter` 按 Python 函数 `__name__` 匹配，不是 aten schema 名
+   `pow.Scalar`；`enable(unused=["pow"])` 不生效）→ pow 不再被 flag_gems
+   拦截（崩溃位置从 flag_gems pow.py 变为 `torch/_tensor.py:1113` 的
+   `__rpow__`）→ 原生 `torch.pow(other, self)` →
+   `RuntimeError: tensor.device().is_cpu() INTERNAL ASSERT FAILED at
+   pybind_utils.cpp:590` —— torch 2.9.0+musa.4.3.6 无法处理 Python float
+   底数 ** MUSA 张量指数。
+
+结论：`self.base ** pos_freqs` 在 4.3.6 上**没有任何编译器路径可用** →
+F = ❌（kunlunxin/sunrise 风格交编译器团队），交付固定 `compiler triton`。
+对比 5.2.0：flagtree **0.6.1**+mthreads3.6 F 路径 ✅（2026-08-16，§8），
+版本差异（0.6.0 vs 0.6.1）是疑似根因 —— 具体是 codegen 变化还是
+vendor 匹配修复待编译器团队确认。
+
+---
+
+## 10. 遗留事项
 
 - [ ] `setuptools 84.0.0` 不满足 pyproject 中 `<81` 要求 —— 非致命问题，先不动，留意。
 - [ ] 0.24.0 其余后端（hygon、iluvatar、enflame、sunrise、cambricon、
-      ascend、kunlunxin 等）的验证 —— mthreads ✅（§8）；nvidia ✅（§6）
+      ascend、kunlunxin 等）的验证 —— mthreads（§8 5.2.0 全通；§9 4.3.6
+      T ✅ / F ❌）；nvidia ✅（§6）
+- [ ] mthreads-musa4.3.6 F 路径：确认 flagtree 0.6.0→0.6.1 差异是否修复
+      `v2f32 = fexp2` codegen，供编译器团队跟进
 
 ---
 

--- a/packaging/vllm/docs/vllm-verification-matrix.md
+++ b/packaging/vllm/docs/vllm-verification-matrix.md
@@ -35,7 +35,7 @@
 | 昆仑芯 | XRE 5.37.1 | ⛔ | ⛔ | ⬜ | ⬜ |
 | 沐曦 | MACA 3.7.2.1 | ⬜ | ✅ | ✅ | ✅ |
 | 沐曦 | MACA 3.8.1.3 | ⬜ | ⬜ | ✅ | ✅ |
-| 摩尔线程 | MUSA 4.3.6 | ⬜ | ⬜ | ⬜ | ⬜ |
+| 摩尔线程 | MUSA 4.3.6 | ⬜ | ⬜ | ✅ | ❌ |
 | 摩尔线程 | MUSA 5.2.0 | — | ✅ | ✅ | ✅ |
 | 进迭时空 | SPACEMIT | ⬜ | — | ⬜ | — |
 | 曦望 | TANGRT 1.2.0 | ✅ | ❌ | ⬜ | ⬜ |
@@ -120,6 +120,23 @@
   不清除已在 PYTHONPATH 的另一个 side dir，导致 entry-point 混叠
   （flagtree 声明 `mthreads` backend、/opt/triton 声明 `musa`），
   切换路径本身干净。已修 `runtime/zz-compiler.sh`（PR #411）。
+- **mthreads-musa4.3.6**（2026-08-17，v0.3.0-dev 零补丁，python 3.10）：
+  **T 路径 ✅** —— `compiler triton` → vendor triton 3.6.0+git89458660，
+  同一 pow 内核编译通过，serve 到 `Application startup complete`、推理连贯，
+  指纹 `vllm-0.24.0-5936039f`（5.2.0 为 `vllm-0.24.0-423da8ca`）。
+  验证模型同为 DeepSeek-R1-0528-Qwen3-8B-FlagOS（矩阵"Qwen3-4B"约定
+  在此单元格不适用，同 §8）。
+  **F 路径 ❌（无应用层绕行，交编译器团队）**：双层根因 ——
+  (a) flag_gems 拦截 `pow.Scalar` 后，flagtree 0.6.0+mthreads3.6 对
+  `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`（`tl.exp2`）发出向量化
+  `v2f32 = fexp2`，vendor llc（`-march=mtgpu -mcpu=mp_31`）`Cannot select`
+  → SIGABRT；(b) 黑名单排除 pow（`VLLM_FL_FLAGOS_BLACKLIST=pow_scalar`，
+  已验证生效）后落入原生 torch `__rpow__`/`torch.pow` ——
+  torch 2.9.0+musa.4.3.6 对 Python float 底数 ** MUSA 张量指数
+  `INTERNAL ASSERT device().is_cpu()` 崩溃。YaRN rotary `base ** pos_freqs`
+  在 4.3.6 上无任何编译器路径可用；交付固定 `compiler triton`。
+  对比：5.2.0 的 flagtree 0.6.1+mthreads3.6 通过 F 验证，版本差异
+  （0.6.0 vs 0.6.1）是疑似根因，详见 `report-vllm-0.24.0.md` §9。
 
 **跨版本事实**
 
@@ -136,6 +153,10 @@
   （TritonSDNN pass 链 / XTDK 后端断言），应用层无法绕过。
 - **sunrise**：flagtree flash-attn decode 挂死，已交 FlagTree 团队；
   交付固定走官方 Triton。
+- **mthreads-musa4.3.6 F 路径**：flagtree 0.6.0+mthreads3.6 对 pow 内核
+  发出 vendor llc 不可选择的 `v2f32 = fexp2`；黑名单排除后原生 torch pow
+  （torch 2.9.0+musa.4.3.6）亦损坏。已交编译器团队，交付固定走
+  `compiler triton`（T 路径已验证 ✅）。
 - **iluvatar**：推理乱码根因在厂商工具链过旧（torch 2.7.1），非编译器层问题。
 - **enflame**：策略性不用 flagtree（不信任），走 vendor triton + native FLASH_ATTN。
 
@@ -144,7 +165,8 @@
 1. **0.24.0 nvidia-cuda12.8 先行**（参考实现）：确认 0.24.0 在 flagtree 下的基线行为。
 2. **3.10 / 3.11 后端先补构建**：0.24.0 empty wheel 与 CPython 绑定，
    验证前需按后端 Python 版本构建对应 wheel。
-3. **双编译器后端逐一对两编译器验证**：metax 已全通；mthreads 已全通
-   （F/T 双路径），hygon、enflame、sunrise 等按风险排序推进。
+3. **双编译器后端逐一对两编译器验证**：metax 已全通；mthreads 5.2.0 已全通
+   （F/T 双路径）、4.3.6 T 路径 ✅ / F 路径 ❌（见上）；hygon、enflame、
+   sunrise 等按风险排序推进。
 4. **单编译器后端**（cambricon、spacemit、thead）：只需验证可用的一列。
 5. **kunlunxin / iluvatar**：等待上游修复后再列入验证队列。

--- a/packaging/vllm/docs/vllm-verification-matrix.md
+++ b/packaging/vllm/docs/vllm-verification-matrix.md
@@ -17,6 +17,7 @@
 | — | 该后端无此编译器 |
 
 列名后缀：T = Triton 编译器，F = FlagTree 编译器。
+`*` = 单元格存在前置条件（flagtree 版本），见事实 bullet 与报告 §9。
 
 ## 矩阵
 
@@ -35,7 +36,7 @@
 | 昆仑芯 | XRE 5.37.1 | ⛔ | ⛔ | ⬜ | ⬜ |
 | 沐曦 | MACA 3.7.2.1 | ⬜ | ✅ | ✅ | ✅ |
 | 沐曦 | MACA 3.8.1.3 | ⬜ | ⬜ | ✅ | ✅ |
-| 摩尔线程 | MUSA 4.3.6 | ⬜ | ⬜ | ✅ | ❌ |
+| 摩尔线程 | MUSA 4.3.6 | ⬜ | ⬜ | ✅ | ✅* |
 | 摩尔线程 | MUSA 5.2.0 | — | ✅ | ✅ | ✅ |
 | 进迭时空 | SPACEMIT | ⬜ | — | ⬜ | — |
 | 曦望 | TANGRT 1.2.0 | ✅ | ❌ | ⬜ | ⬜ |
@@ -126,17 +127,16 @@
   指纹 `vllm-0.24.0-5936039f`（5.2.0 为 `vllm-0.24.0-423da8ca`）。
   验证模型同为 DeepSeek-R1-0528-Qwen3-8B-FlagOS（矩阵"Qwen3-4B"约定
   在此单元格不适用，同 §8）。
-  **F 路径 ❌（无应用层绕行，交编译器团队）**：双层根因 ——
-  (a) flag_gems 拦截 `pow.Scalar` 后，flagtree 0.6.0+mthreads3.6 对
-  `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`（`tl.exp2`）发出向量化
-  `v2f32 = fexp2`，vendor llc（`-march=mtgpu -mcpu=mp_31`）`Cannot select`
-  → SIGABRT；(b) 黑名单排除 pow（`VLLM_FL_FLAGOS_BLACKLIST=pow_scalar`，
-  已验证生效）后落入原生 torch `__rpow__`/`torch.pow` ——
-  torch 2.9.0+musa.4.3.6 对 Python float 底数 ** MUSA 张量指数
-  `INTERNAL ASSERT device().is_cpu()` 崩溃。YaRN rotary `base ** pos_freqs`
-  在 4.3.6 上无任何编译器路径可用；交付固定 `compiler triton`。
-  对比：5.2.0 的 flagtree 0.6.1+mthreads3.6 通过 F 验证，版本差异
-  （0.6.0 vs 0.6.1）是疑似根因，详见 `report-vllm-0.24.0.md` §9。
+  **F 路径 ✅*（flagtree 0.6.1，2026-08-17 实验确认）**：同一容器手动替换
+  flagtree 0.6.0 → **0.6.1+mthreads3.6** 后，同一 pow 内核（flag_gems
+  `pow_scalar` → `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`，`tl.exp2`）
+  编译通过 —— 0.6.0 下报 `LLVM ERROR: Cannot select: v2f32 = fexp2`
+  （vendor llc `-march=mtgpu -mcpu=mp_31`）SIGABRT，0.6.1 下无此问题；
+  serve 到 `Application startup complete`、completions greedy + chat CoT 均
+  连贯（op 级 repro `OK [1.0, 1.01358..., 1.02735...]`）。
+  **`*` 前提：configs.yaml 4.3.6 现 pin flagtree==0.6.0**（F 路径坏），
+  需 bump 到 0.6.1 后重建镜像，单元格才对应交付物；0.6.0→0.6.1 差异即
+  根因（见 `report-vllm-0.24.0.md` §9）。
 
 **跨版本事实**
 
@@ -153,10 +153,10 @@
   （TritonSDNN pass 链 / XTDK 后端断言），应用层无法绕过。
 - **sunrise**：flagtree flash-attn decode 挂死，已交 FlagTree 团队；
   交付固定走官方 Triton。
-- **mthreads-musa4.3.6 F 路径**：flagtree 0.6.0+mthreads3.6 对 pow 内核
-  发出 vendor llc 不可选择的 `v2f32 = fexp2`；黑名单排除后原生 torch pow
-  （torch 2.9.0+musa.4.3.6）亦损坏。已交编译器团队，交付固定走
-  `compiler triton`（T 路径已验证 ✅）。
+- **mthreads-musa4.3.6**：flagtree **0.6.0** 对 pow 内核发出 vendor llc
+  不可选择的 `v2f32 = fexp2`；黑名单排除后原生 torch pow
+  （torch 2.9.0+musa.4.3.6）亦损坏。**0.6.1 已验证修复**（F 路径 ✅*）；
+  阻塞项转为 configs.yaml 4.3.6 flagtree 0.6.0→0.6.1 bump + 镜像重建。
 - **iluvatar**：推理乱码根因在厂商工具链过旧（torch 2.7.1），非编译器层问题。
 - **enflame**：策略性不用 flagtree（不信任），走 vendor triton + native FLASH_ATTN。
 
@@ -166,7 +166,7 @@
 2. **3.10 / 3.11 后端先补构建**：0.24.0 empty wheel 与 CPython 绑定，
    验证前需按后端 Python 版本构建对应 wheel。
 3. **双编译器后端逐一对两编译器验证**：metax 已全通；mthreads 5.2.0 已全通
-   （F/T 双路径）、4.3.6 T 路径 ✅ / F 路径 ❌（见上）；hygon、enflame、
-   sunrise 等按风险排序推进。
+   （F/T 双路径）、4.3.6 T 路径 ✅ / F 路径 ✅*（flagtree 0.6.1，见上）；
+   hygon、enflame、sunrise 等按风险排序推进。
 4. **单编译器后端**（cambricon、spacemit、thead）：只需验证可用的一列。
 5. **kunlunxin / iluvatar**：等待上游修复后再列入验证队列。


### PR DESCRIPTION
## Summary

Records the mthreads **MUSA 4.3.6** 0.24.0 verification (v0.3.0-dev, zero patches), completing the mthreads platform in the matrix:

- **T path** ✅ (2026-08-17): `compiler triton` → vendor triton 3.6.0+git89458660 — the same pow kernel (flag_gems `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`, from YaRN rotary `base ** pos_freqs`) compiles fine, serve reaches `Application startup complete`, inference coherent. Fingerprint `vllm-0.24.0-5936039f`. Verified on DeepSeek-R1-0528-Qwen3-8B-FlagOS — the matrix's "Qwen3-4B" convention doesn't apply to this cell (see `report-vllm-0.24.0.md` §9).
- **F path** ✅* (2026-08-17, flagtree **0.6.1**): the suspected 0.6.0→0.6.1 root cause is **confirmed fixed by experiment** — the same pow kernel that SIGABRTs under 0.6.0+mthreads3.6 (`LLVM ERROR: Cannot select: v2f32 = fexp2` → vendor llc `-march=mtgpu -mcpu=mp_31`) compiles fine under 0.6.1+mthreads3.6 (op-level repro `OK [1.0, 1.01358..., 1.02735...]`), serve reaches `Application startup complete`, completions greedy + chat CoT coherent. **`*` precondition**: configs.yaml currently pins 4.3.6 to flagtree==0.6.0 (broken F path); it must be bumped to 0.6.1 + image rebuilt before the cell matches the deliverable. The 0.6.0 two-layer root cause (fexp2 `Cannot select`; blacklist fall-through to broken native torch pow `INTERNAL ASSERT device().is_cpu()`) is preserved as evidence in the report §9.3.

## Changes

- **`packaging/vllm/docs/vllm-verification-matrix.md`**: MUSA 4.3.6 0.24.0(T) ⬜ → ✅, 0.24.0(F) ⬜ → ❌ → **✅*** (asterisk legend added); new 4.3.6 facts bullet (T-path pass + F-path 0.6.1 fix confirmation + `*` configs-bump precondition); blocker note updated (0.6.1 verified fixed; blocker becomes the configs bump + rebuild); verification-order item 3 updated (4.3.6 T ✅ / F ✅*).
- **`packaging/vllm/docs/report-vllm-0.24.0.md`**: §9.3 F path rewritten — 0.6.0 two-layer failure kept as evidence, 0.6.1 experiment record added (op repro pass, serve E2E, fingerprint); §10 遗留事项 updated (0.6.0→0.6.1 confirmed fixed → configs bump + rebuild todo).

Docs only — no code changes. configs.yaml flagtree bump is deliberately NOT in this PR (code change, separate PR).

## Verification

- Op-level repro: same pow kernel compiles under vendor triton AND under flagtree 0.6.1 (`OK [1.0, 1.01358..., 1.02735...]`); crashes only under flagtree 0.6.0 (fexp2 `Cannot select`).
- Exclude-name probe (0.6.0 evidence): `enable(unused=["pow"])` does NOT intercept (still fexp2 crash); `enable(unused=["pow_scalar"])` does intercept but falls to the broken native torch path (INTERNAL ASSERT at pybind_utils.cpp:590).
- Serve on the 4.3.6 container: T path `compiler triton` → `Application startup complete`; F path on flagtree 0.6.1 (swapped in-container) → `Application startup complete`, completions greedy + chat CoT coherent; F path on 0.6.0 → EngineCore SIGABRT at the pow kernel.

This PR was written in part with the assistance of generative AI.
