### PR TITLE
fix(configs): bump mthreads-musa4.3.6 flagtree 0.6.0→0.6.1 (fexp2 fix)

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -458,7 +458,9 @@ vendors:
       python: "3.10"
       cmake_backend: MUSA
       triton: triton==3.6.0+git89458660
-      flagtree: flagtree==0.6.0+mthreads3.6
+      # 0.6.0→0.6.1: 0.6.0 对 flag_gems pow 内核发出 vendor llc 不可选择的
+      # v2f32 = fexp2（F 路径 SIGABRT）；0.6.1 已验证修复（vllm 0.24.0 §9.3）。
+      flagtree: flagtree==0.6.1+mthreads3.6
       env:
         base:
           MUSA_HOME: /usr/local/musa


### PR DESCRIPTION
## Summary

Bumps mthreads-musa4.3.6 flagtree `0.6.0+mthreads3.6` → `0.6.1+mthreads3.6` in configs.yaml.

**Why**: flagtree 0.6.0+mthreads3.6 emits `LLVM ERROR: Cannot select: v2f32 = fexp2` for the flag_gems pow kernel (`pow.Scalar` → `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`, `tl.exp2`) under the vendor llc (`-march=mtgpu -mcpu=mp_31`), SIGABRTing the vllm 0.24.0 F path on MUSA 4.3.6. Verified on the 4.3.6 container that **0.6.1+mthreads3.6 fixes it**: the same pow kernel compiles fine (op repro `OK [1.0, 1.01358..., 1.02735...]`), serve reaches `Application startup complete`, completions coherent — see `packaging/vllm/docs/report-vllm-0.24.0.md` §9.3.

**Consistency**: mthreads-musa5.2.0 already uses 0.6.1+mthreads3.6; this bump aligns 4.3.6.

## Changes

- `configs.yaml`: mthreads-musa4.3.6 `flagtree: flagtree==0.6.0+mthreads3.6` → `flagtree==0.6.1+mthreads3.6` + rationale comment.

## Follow-up

- Rebuild the mthreads-musa4.3.6 runtime image with the bumped flagtree, then re-verify the F path (currently validated via in-container 0.6.1 swap; the 4.3.6 matrix cell carries `✅*` until then).
- Docs PR #413 covers the vllm verification matrix + report updates.

This PR was written in part with the assistance of generative AI.
