### PR TITLE
docs(megatron): reorganize hygon25 e2e report as three-layer template

### DIFF
--- a/packaging/megatron/docs/megatron-hygon25-e2e.md
+++ b/packaging/megatron/docs/megatron-hygon25-e2e.md
@@ -1,189 +1,400 @@
-# megatron-core（Megatron-LM-FL fork）hygon25 端到端验证 — 技术发现与缺口
+# Megatron-LM-FL hygon25 E2E 验证报告
 
-## Status
+**验证环境:** hygon25（Hygon BW1000 8× HCU，DTK 26.04），runtime 镜像
+`flagos-runtime-hygon-dtk26.04:2.1.2`，Python 3.10.20，torch
+2.9.0+das.opt1.dtk2604。
+**安装形态:** Megatron 打包（`packaging/megatron/builder/`）产出的
+`megatron-core` wheel，`pip install`（无 `--no-deps`）。
+**验证周期:** 2026-08-12 ~ 2026-08-17。
 
-**两个训练入口均在 hygon25（DTK 26.04）上通过端到端验证（exit 0）：**
+**术语约定:** 本报告涉及两级仓库——代码来源的上游 = NVIDIA 的
+ADLR/Megatron-LM（megatron 代码的原始出处，fork 通过同步 PR 引入）；
+提交 PR / 反馈缺陷的目标 = 本 fork flagos-ai/Megatron-LM-FL。下文"上游"
+均按此区分：涉及代码继承时为 ADLR/Megatron-LM，涉及提交与反馈时为
+flagos-ai/Megatron-LM-FL。
 
-| 验证形态 | 内容 | 结果 |
+**缩写:** TE = TransformerEngine；THD = 打包序列（THD）格式；FA = flash
+attention。
+
+本报告只记录**可复现的技术发现与缺口**（代码级缺陷、未声明依赖、
+平台移植性、工具链限制），不含瞬时错误与一次性环境故障。
+
+## 0. Summary
+
+**结论：** 四个场景全部打通。training / post_training / inference 由全范围
+wheel 单步安装直跑，均 exit 0；rl 场景耗时最长——未声明依赖与厂商包问题逐一解决后，全链路首次跑通 exit 0。
+
+| 场景 | 状态 | 一句话事实 |
 |---|---|---|
-| wheel-only 训练循环 | `examples/run_simple_mcore_train_loop.py`（仅依赖 wheel 内的 megatron.core），TP=2，5 iter，mock data，含 checkpoint 保存/加载 | ✅ exit 0 |
-| 完整训练服务 | `pretrain_gpt.py`（megatron.training + repo checkout），5 iter，mock data | ✅ exit 0，loss 9.1310 → 8.6514 |
+| training | ✅ 通过 | 全范围 wheel 单步安装直跑 `pretrain_gpt.py`，exit 0 |
+| rl | ✅ 通过 | 全链路 exit 0；前提 = 补装未声明依赖（§5.1）+ vendor TE（§5.4） |
+| post_training | ✅ 通过 | driver 全 import + `simple_generate`，exit 0；前提 = ad-hoc 装 modelopt（§1.3.3） |
+| inference | ✅ 通过 | `StaticInferenceEngine(legacy=True)`，3 请求 × 8 tokens，exit 0 |
 
-上表为默认编译器（flagtree）基线。**vendor triton 复跑**（见 §2.1）下两种形态均通过，且不再需要 jit 补丁与 `--disable-jit-fuser`：完整训练服务 loss 9.1295 → 8.8622。
+**教训清单**：
 
-**四场景验证（2026-08-14，全范围 wheel = core+training+legacy+rl+post_training+inference，MLF PR #107 feat/wheel-full-scope）：**
+1. **打包范围必须覆盖 entry point 与顶层脚本**——否则完整服务无法单步安装即用。已由全范围打包关闭（§1.1，PR #107）。
+2. **未声明运行时依赖是主要耗时项**——psutil / tensorboard / wandb 等被实际使用却未声明（§1.2、§5.1）。psutil 已补声明（PR #106）；RL 清单待反馈。
+3. **vendor 包不可信，问题分四类**——元数据、包间版本失配、平台覆盖、源码杂质；逐包 repack 修正并记录（§1.3）。
+4. **平台移植性默认值**——fused kernel 默认开启、jit_fuser import 期绑定，
+   非 CUDA 平台需显式关闭（§1.4）。待反馈。
+5. **工具链按平台验证**——flagtree 无法编译 HCU kernel，默认编译器是错误默认（§1.5）。已屏蔽，默认改 vendor triton。
+6. **venv 缺 python3-config** 使数据集构建 import 期挂（§2.1）。已落地
+   sysconfig 兜底 + PR #112。
+7. **datasets/pyarrow 版本对不兼容**——5.0.1 写、≤25 读崩（§5.2）。已规避；
+   CI 需固定实测版本对。
+8. **tokenizer 无 eos** 使轨迹准备 TypeError（§5.3）。数据层声明即解决。
+9. **RL 训练 forward 强制 TE**——local 不支持 THD 打包序列（§5.4）。hygon
+   已跑通；无 vendor TE 平台待反馈。
+10. **flash_attn 版本串三处不一致**致 dynamic 引擎断言失败（§5.5）。repack
+    三处字符串一致即解决。
+11. **modelopt 未入镜像**，post_training 靠 ad-hoc 补装，违反交付目标（§1.3.3）。纳入镜像与否待决策。
 
-| 场景 | 入口 | 结果 | 备注 |
-|---|---|---|---|
-| training | `pretrain_gpt.py`（vendor triton） | ✅ exit 0 | loss 9.1295 → 8.8622 |
-| rl | `pretrain_gpt.py --perform-rl-step` | ⛔ 平台缺口 | dynamic 推理引擎硬依赖 flash-attn（§6.1） |
-| post_training | post_training driver（surface 全 import + `simple_generate`） | ✅ exit 0 | 输出 shape=(1, 8)；modelopt ad-hoc 装入 venv，未入镜像（§6.3） |
-| inference | `StaticInferenceEngine(legacy=True)`，3 请求 × 8 tokens | ✅ exit 0 | 免 flash-attn / 免 triton（§6.2） |
+## 1. 全局性问题
 
-本报告只记录**可复现的技术发现与缺口**（代码级缺陷、未声明依赖、平台移植性、工具链限制），不含瞬时错误与一次性环境故障。
+### 1.1 打包范围不完整（entry point / 顶层脚本）
 
-## 打包背景
+- **现象:** wheel 打包范围继承上游，仅含 `megatron.core` 与
+  `megatron.plugin`，`megatron.training` / `legacy` / `inference` /
+  `post_training` / `rl` 与顶层入口（`pretrain_gpt.py` 等）均不在其中——
+  完整训练服务无法"单步安装 wheel 即用"，必须 repo checkout；且
+  `megatron.core` 内部路径触发 `from megatron.training import get_args`
+  （`megatron/plugin/utils.py:30`，import 在 try/except 之外）时直接抛
+  `ModuleNotFoundError`——wheel-only 的数据集构建必然触发。
+- **原因:** include 范围继承自 NVIDIA 上游 ADLR/Megatron-LM 的
+  `pyproject.toml`（同步 PR #34 引入 0.17.0 后未改动），fork 未检查入口是否随包。
+- **解决方案:** 全范围打包（core+training+legacy+rl+post_training+inference），
+  顶层入口文件（`gpt_builders` / `mamba_builders` / `model_provider` /
+  `pretrain_gpt` / `pretrain_bert` / `pretrain_mamba` / `pretrain_t5` /
+  `pretrain_vlm` / `train_rl`）一并纳入 wheel（MLF PR #107
+  feat/wheel-full-scope）。§2~§5 四场景验证均基于该 wheel。
+- **注意事项:** `examples/` 目录不打进 wheel（测试环境文件，如
+  `examples/rl/environments/countdown/`，需单独拷贝）；wheel 自带编译扩展
+  `helpers_cpp*.so` 位于 site-packages，而 `compile_helpers()` 在**源码树**
+  中查找——"repo checkout + 已安装 wheel"的混用形态需先把 `.so` 植入源码树，
+  对 app 镜像无影响，单步安装即完整。
+  打包范围的后续演进要检查入口文件是否仍随包。
+- **现在状态:** 已关闭（PR #107）。PR 合入前其余后端暂不能复用该 wheel 做按序验证。
 
-**当前 wheel 打包范围继承上游，不含训练包——这是本报告若干发现的根因。**
+### 1.2 未声明运行时依赖（NVIDIA 上游代码缺口）
 
-**"上游"所指（本报告约定，避免歧义）：** 本报告涉及两级仓库——**代码来源的上游 = NVIDIA 的 ADLR/Megatron-LM**（megatron 代码的原始出处，fork 通过同步 PR 引入）；**提交 PR / 反馈缺陷的目标 = 本 fork flagos-ai/Megatron-LM-FL**（build-infra 工作直接面向的仓库）。下文"上游"均按此区分：涉及代码继承时为 ADLR/Megatron-LM，涉及提交与反馈时为 flagos-ai/Megatron-LM-FL。
+**METADATA 声明的依赖面 ≠ 真实运行时依赖面。**
 
-- 打包入口是仓库根 `pyproject.toml` 的 `[tool.setuptools.packages.find]`，include 范围**继承自 NVIDIA 上游 ADLR/Megatron-LM**（fork 通过同步 PR #34 "Synchronization with Megatron-LM Core 0.17.0" 引入上游 0.17.0 后未改动），仅含 `megatron.core` 与 `megatron.plugin` 两个包。
-- `megatron.training` / `megatron.legacy` / `megatron.inference` / `megatron.post_training` / `megatron.rl` **均不在 wheel 中**。
-- **后果:** 完整训练服务（`pretrain_gpt.py`）依赖 `megatron.training`，无法用 wheel 直接验证——这是报告"完整训练服务"一栏用 repo checkout 的原因，也是 §1.1（`megatron.core` 内部 import `megatron.training` 失败）的直接诱因。
-- **性质:** 非打包实现错误（fork 只是继承了上游的范围），但属于**真实范围缺口**——对"应用镜像 = 单步安装 wheel 即可用"的交付形态而言必须关闭。
-- **方向（已落定，2026-08-14）:** 全范围打包（core+training+legacy+rl+post_training+inference）已通过 MLF PR #107（feat/wheel-full-scope）实现，顶层入口文件（`gpt_builders.py` 等）一并纳入 wheel。§6 四场景验证均基于该 wheel。
+- **现象:** 依赖被实际使用却未声明，import 期 try/except 吞错或直接崩。
+- **实例（非 RL 场景）:** psutil——异步 checkpoint 的
+  `FileSystemWriter` worker 线程实际调用 `_process_memory()`，却既不在 wheel
+  METADATA 的 `Requires-Dist`（仅 `torch>=2.6.0` / `numpy` /
+  `packaging>=24.2` + optional extras）也不在 runtime 镜像内；触发即抛
+  `RuntimeError("psutil is not installed, ...")`。
+- **解决方案:** 反馈本 fork 在 `pyproject.toml` 补声明（psutil → PR #106）；
+  build-infra 侧在 runtime 依赖面兜底。
+- **现在状态:** psutil 已提交（PR #106）。RL 场景的依赖缺口清单见 §5.1
+  （tensorboard / wandb / httpx 等一组，待反馈）。
 
-**Date:** 2026-08-12 ~ 2026-08-13
-**Platform:** hygon25（Hygon BW1000 8× HCU，DTK 26.04），镜像 `flagos-runtime-hygon-dtk26.04:2.1.2`，Python 3.10.20，torch 2.9.0+das.opt1.dtk2604
-**安装形态:** Megatron 打包（`packaging/megatron/builder/`）产出的 `megatron-core==0.17.1+flagos` wheel，`pip install`（无 `--no-deps`）
+### 1.3 vendor 包问题（逐包归纳全部修改）
 
----
+vendor 包（`flagos-pypi-{vendor}` 上我们掌控、可 repack）的问题分四类：
+**元数据不可信、包间版本失配、平台覆盖不全、源码杂质**。四类问题逐包归纳，供其他平台照做；今后其他 vendor 包的修正在此追加。
 
-## 1. 代码级缺口
+#### 1.3.1 flash_attn 2.8.3+das.opt1.dtk2604.torch290
 
-### 1.1 megatron.core 内不可用的 import：`megatron.training`（已修复，PR #105 已提交）
+- **现象:** RL dynamic 引擎版本断言失败（要求 ≥2.7.3，见 §5.5）。
+- **修改归纳（repack 共 4 处）:**
+  1. `__init__.py` `__version__`：硬编码 `"2.6.1"` → `2.8.3`
+  2. `version.py` `version` 字段：`2.6.1` → `2.8.3`（连同 git_hash /
+     git_branch / abi / dtk / torch_version / hcu_version 等元数据校正）
+  3. dist-info METADATA `Version`：→ `2.8.3+das.opt1.dtk2604.torch290`
+  4. 源码中无意义的 `import pytest`（import 即报错）→ 移除
+- **注意事项:** 版本值出现在 3 处（`__init__.py` / `version.py` /
+  dist-info METADATA），repack 时**三处都要改并保持一致**——漏改任一处，
+  `get_fa_version_str()`（源码 `__version__` 优先，importlib.metadata
+  fallback）仍会读到不一致版本。版本校验以 wheel 实际为准，源码
+  `__version__` 不可信。
+- **现在状态:** 已修正（三处一致 = 2.8.3），§5.5 断言实证通过。
 
-**位置:** `megatron/plugin/utils.py:30` — `is_built_on_zero_rank()`
+#### 1.3.2 transformer_engine 2.10.0+das.opt1.dtk2604.torch290
 
-**缺陷:** `from megatron.training import get_args` 位于 try/except 之外（代码注释本身即承认 "We should not depend on get_args in megatron core, the args belong to training."）。`megatron.training` **不在 wheel 中**（wheel 只打包 `megatron.core`），因此任何仅使用 wheel 的消费方在 `megatron.core` 内部路径触发此函数时，import 直接抛 `ModuleNotFoundError`，且 try/except（注释 "for unit tests"）形同虚设。
+- **现象:** `import transformer_engine.pytorch` 报错（缺 pandas）；triton 量化模块调用报错（参数无法识别）。
+- **修改归纳（repack 共 3 项）:**
+  1. **pandas 补声明:** Requires-Dist 漏 pandas（现声明：torch==2.9.0、
+     importlib-metadata>=1.0、einops、pydantic、packaging），而 triton 量化模块（
+     `pytorch/triton/blockwise_int8_gemm_nt*.py`、`per_token_group_quant.py`）
+     import pandas → 补 `pandas>=2.0,<3`，带版本约束防公共 index 漂移（窗口由
+     runtime python 3.10 + numpy 1.26.4 限定）。
+  2. **enable_mmacfuse 剥参:** TE 2.10.0 为 ROCm/HCU 适配加入的参数，传给
+     triton `Config`——flagtree 3.6.0 与 vendor triton 3.5.1 的 Config 签名均不接受（厂商各包之间的版本失配）→ repack 时剥离。
+  3. **FA 版本检测剥 local version:** TE 内部检测 flash_attn 版本时，版本串的
+     local version（`+das.opt1.dtk2604.torch290`）干扰比较 → 检测时剥离。
+- **验证:** repack 后从 hygon index 单步安装即完全可用（import +
+  LayerNorm/Linear + DPA thd/fp16 FA 后端均通过）。
+- **注意事项:** 安装侧修复后正常装 TE（带 aliyun extra index）即自动拉
+  pandas，无需在 configs.yaml 单独治理。
+- **现在状态:** 已闭环交付。RL 用 TE 方向已定（§5.4）。
 
-**影响路径（实测）:** `megatron/core/datasets/blended_megatron_dataset_builder.py:19` 模块级导入 `is_built_on_zero_rank`，在 392/407/535/551 四处调用 → wheel-only 的数据集构建路径必然触发。
+#### 1.3.3 modelopt（平台覆盖不全）
 
-**修复:** 将 import 移入 try 块（1 行改动）。已在 wheel、repo 副本、本地仓库三处应用，并经 wheel-only 训练循环重跑验证（exit 0）。
+- **现象:** post_training 场景依赖 modelopt（HARD 依赖）。
+- **原因:** 仅 enflame 有 vendor 变体（`enflame-modelopt`）；NVIDIA 用
+  NVIDIA modelopt 可用，其余后端成功率不确定。
+- **处置:** `--no-deps` ad-hoc 装入 runtime venv，**未入镜像**——与其余场景的"单步安装 wheel 即可用"不同，违反交付目标。
+- **现在状态:** 纳入镜像与否待镜像层决策。
 
-### 1.2 未声明的运行时依赖：psutil（NVIDIA 上游代码缺口）
+### 1.4 平台移植性默认值（fused kernel / jit_fuser）
 
-**位置:** `megatron/core/dist_checkpointing/strategies/filesystem_async.py:42-47, 674-676`
+- **fused kernel 默认开启且依赖 CUDA-only 扩展:** `masked_softmax_fusion`
+  默认开启（`--no-masked-softmax-fusion` 为 store_false 开关），而 fused
+  softmax 路径 `get_batch_per_block()` 内 `import
+  scaled_masked_softmax_cuda`（CUDA-only 编译扩展，DCU 上不存在）——非 CUDA
+  平台必须显式传 `--no-masked-softmax-fusion`，否则 `ModuleNotFoundError`。
+  megatron 默认假设其 fused kernel 一定可用；对非 CUDA 平台这些默认值需要逐一显式关闭——平台移植性的普遍缺口，非 hygon 独有。
+- **jit_fuser 在模块 import 期绑定 `torch.compile`:** `enable_jit_fuser()`
+  在**模块 import 时即执行**（`megatron/core/jit.py:16-33`），把全局
+  `jit_fuser` 绑定为 `torch.compile`；`--disable-jit-fuser` 在 args 解析之后才翻转全局，**晚于装饰器生效点**，无法阻止训练 warmup 期的
+  `torch.compile`。DCU 上 warmup 期触发 triton HCU 编译（配合 §1.5 flagtree
+  不可用）→ HSACOError。修复方向：`jit_fuser` 改为惰性装饰（或
+  `enable_jit_fuser` 默认 no-op，由训练入口显式开启）。
+- **现在状态:** 待反馈本 fork。
 
-**缺陷:** psutil 通过 `try/except ImportError` 导入并置 `HAVE_PSUTIL` 标志；异步 `FileSystemWriter` 的 worker 线程调用 `_process_memory()`（line 674），在 `HAVE_PSUTIL=False` 时抛
-`RuntimeError("psutil is not installed, ...")`。即：**psutil 被实际使用，却既不在 wheel METADATA 的 `Requires-Dist` 中，也不在 runtime 镜像内**（均实测确认）。wheel 的 `Requires-Dist` 仅 `torch>=2.6.0` / `numpy` / `packaging>=24.2` + optional extras。
+### 1.5 工具链：flagtree 无法编译 HCU kernel，vendor triton 可用
 
-**触发条件（实测）:** 任何 wheel-only 消费方在 checkpoint 保存时使用异步策略即触发（`Worker failure: ... psutil is not installed`）。修复方式是额外 `pip install psutil`（7.2.2）——但这是对 "单步安装即可用" 目标的破坏，属真实的 wheel 依赖缺口。已提交至本 fork（flagos-ai/Megatron-LM-FL，PR #106：把 psutil 纳入 `pyproject.toml` 的 `dependencies`）。
-
-### 1.3 `jit_fuser` 在模块 import 期绑定 `torch.compile`，`--disable-jit-fuser` 无法拦截（时序缺陷）
-
-**位置:** `megatron/core/jit.py:16-33`
-
-**缺陷:** `enable_jit_fuser()` 在**模块 import 时即执行**（line 33 模块级调用），把全局 `jit_fuser` 绑定为 `torch.compile`；`bias_gelu`/`bias_swiglu` 的 `@jit_fuser` 装饰在 import 期随之生效。`--disable-jit-fuser` 在 args 解析之后才调用 `disable_jit_fuser()` 翻转全局，**晚于装饰器生效点**，无法阻止训练 warmup 期的 `torch.compile` 执行。
-
-**DCU 上的后果:** warmup 期 `torch.compile` 触发 triton HCU 编译，而本镜像的 clang 无法编译 HCU kernel（见 §2.1）→ HSACOError。任何依赖 `--disable-jit-fuser` 的 DCU 使用方都会踩到。修复方向：`jit_fuser` 改为惰性装饰（或 `enable_jit_fuser` 默认 no-op，由训练入口显式开启），而非 import 期绑定。
-
-### 1.4 masked softmax fusion 默认开启且依赖 CUDA-only 扩展（平台移植性缺口）
-
-**位置:** `megatron/core/fusions/fused_softmax.py:346-360`
-
-**缺陷:** fused softmax 路径的 `get_batch_per_block()` 内 `import scaled_masked_softmax_cuda`（CUDA-only 编译扩展，DCU 上不存在）。而 `masked_softmax_fusion` 默认开启（`--no-masked-softmax-fusion` 为 store_false 开关），因此 DCU 上**必须显式传 `--no-masked-softmax-fusion`**，否则 `ModuleNotFoundError: No module named 'scaled_masked_softmax_cuda'`。
-
-**性质:** megatron 默认假设其 fused kernel 一定可用；对非 CUDA 平台，这些默认值需要逐一显式关闭——平台移植性的普遍缺口，非 hygon 独有。
-
----
-
-## 2. 工具链 / 环境缺口（可复现）
-
-### 2.1 编译器可用性：flagtree 无法编译 HCU kernel，vendor triton 可用（编译器 mask 表）
-
-**结论：** 运行时镜像默认的 flagtree 编译器在 hygon（DTK 26.04）上**不可用**；vendor triton（`compiler triton` 切换至 `/opt/triton`）**可用**。
+- **结论:** 运行时镜像默认的 flagtree 编译器在 hygon（DTK 26.04）上
+  **不可用**；vendor triton（`compiler triton` 切换至 `/opt/triton`）
+  **可用**。
 
 | 编译器 | 版本 | HCU kernel 编译 | 结论 |
 |---|---|---|---|
-| flagtree | 3.6.0 | ✗ `make_amdgcn()` 调 clang-17 子进程，7 个 HCU `-mllvm` flags 中 5 个被拒 → clang 静默退出 0 但无产物 → 误导性 `HSACOError("File operation failed: ...")` | **屏蔽** |
-| vendor triton | 3.3.0 | ✓ `make_amdgcn()` 用 `llvm.translate_to_asm()` 直接出码，无 clang 子进程 → 正常产出 `.amdgcn` | **交付** |
+| flagtree | 3.6.0 | ✗ `-mllvm` flags 被拒 → clang 无产物 → 误导性 `HSACOError` | **屏蔽** |
+| vendor triton | 3.5.1 | ✓ `make_amdgcn()` 用 `llvm.translate_to_asm()` 直接出码，无 clang 子进程 → 正常产出 `.amdgcn` | **交付** |
 
-- **性质:** flagtree 特有缺陷（`_get_clang_args()` 空字符串 clang-arg + 镜像 clang 不接受 `-mllvm` flags），非平台通用问题；vendor triton 路径不经过 clang。
-- **验证面:** 按平台验证规则，每个后端 × 两个编译器都要验证；不能用的编译器在交付镜像中屏蔽（不设为默认/不装）。
-- **影响:** flagtree 作为 hygon runtime 镜像的默认编译器属错误默认，需在 runtime 镜像层修正（默认改为 vendor triton 或移除 flagtree）。
-- **验证时手动切换方法（镜像内置 `compiler` 函数，来自 BASH_ENV）：** `compiler triton`；无该函数时：`export PYTHONPATH="/opt/triton:$(printf %s "${PYTHONPATH}" | tr ':' '\n' | grep -v '^/opt/flagtree' | paste -sd: -)"`。
+- **性质:** flagtree 特有缺陷（`_get_clang_args()` 空字符串 clang-arg + 镜像
+  clang 不接受 `-mllvm` flags），非平台通用问题；vendor triton 路径不经过
+  clang。
+- **影响:** flagtree 作为 hygon runtime 镜像的默认编译器属**错误默认**，需在
+  runtime 镜像层修正（默认改为 vendor triton 或移除 flagtree）。
+- **验证面:** 每个后端 × 两个编译器都要验证；不能用的编译器在交付镜像中屏蔽（不设为默认/不装）。镜像内置 `compiler` 函数（来自 BASH_ENV）切换：
+  `compiler triton`；无该函数时手动剔除 `PYTHONPATH` 中的 `/opt/flagtree`
+  并把 `/opt/triton` 置前。
+- **现在状态:** 已记录，镜像层待修正。
 
-### 2.2 `helpers_cpp*.so` 的查找契约：wheel 与源码树混用
+### 1.6 环境：DTK 已内置，无需 source env.sh
 
-- wheel 的编译扩展 `helpers_cpp*.so` 位于 site-packages；而 `compile_helpers()`（FlagScale patch）在**源码树**中查找该 `.so`。
-- 因此 "repo checkout + 已安装 wheel" 的验证形态（完整训练服务）需先把 wheel 内的 `.so` 植入源码树。
-- 对 app 镜像**无影响**（wheel 自带 `.so`，单步安装即完整）；此缺口只影响仓库与 wheel 混用的验证/开发路径。
+- runtime 镜像已内置 DTK 环境：经 bash 运行的命令（含非交互）可直接
+  `import torch`（实测：容器内非登录 `bash -c '/flagos/bin/python -c "import
+  torch"'` 直接成功，torch 2.9.0）。
+- **注意事项:** 直接 `docker exec <容器> /flagos/bin/python ...` 即可；**不要额外加 `source /opt/dtk-26.04/env.sh`**。
 
-### 2.4 venv 缺 `python3-config`（2026-08-16 实测）
+## 2. training
 
-**发现（运行 #2，06:04:18 rc=1）：** venv `/flagos/bin` **缺 `python3-config` 符号链接**。`compile_helpers()`（`megatron/core/datasets/utils.py`，带 FlagScale 来源标注的 fork 补丁）执行 `subprocess.check_output(["python3-config", "--extension-suffix"])` 抛 `FileNotFoundError: 'python3-config'`，`pretrain_gpt.py` 在数据集构建 import 期即挂。该函数只在 wheel 已带预构建 `helpers_cpp{ext_suffix}.so` 时提前 return 跳过 make——但仍需 python3-config 算后缀。uv 托管的 Python 在 `/root/.local/share/uv/python/cpython-3.10-linux-x86_64-gnu/bin/` 下自带该二进制。修复（仅诊断用软链，非交付方案）：`ln -sf .../python3-config /flagos/bin/python3-config`，`--extension-suffix` 实测输出 `.cpython-310-x86_64-linux-gnu.so`。
+**结论:** 全范围 wheel 单步安装直跑 `pretrain_gpt.py`，exit 0（无需 repo
+checkout；`megatron.training` 已在 wheel 中，§1.1）。
 
-**对交付的启示（已落地，2026-08-16）：** 修复方向 = `compile_helpers()` 改用 `sysconfig.get_config_var("EXT_SUFFIX")`（标准库，任何 Python 环境都有），替代 `subprocess.check_output(["python3-config", ...])`。
-- **准备一（PR 已提交）：** flagos-ai/Megatron-LM-FL PR [#112](https://github.com/flagos-ai/Megatron-LM-FL/pull/112)（与 psutil PR #106 / tensorboard 同类的上游修复）。
-- **准备二（build-infra 兜底，已落地）：** wheel 是 build-infra 自产（`packaging/megatron/builder/Containerfile`），沿用现有 on-the-fly patch + grep gate 模式（同文件 requires-python 补丁）新增 `packaging/megatron/builder/patch-compile-helpers-sysconfig.py`，在 wheel 构建时对 checkout 打同样的 sysconfig 补丁。脚本幂等且自 gate：已是 sysconfig 形式 → no-op（PR #112 合并后自动跳过）；仍是 python3-config 形式 → 就地替换；源码演进（两种形式都找不到）→ exit 1 硬失败，补丁不可能静默失效。三状态逻辑已本地验证（对 origin/main 的 utils.py 实测 patch / no-op / 演进三例全过）。两路最终都落成同一段代码形态，不依赖 MLF merge 节奏。诊断软链（`/flagos/bin/python3-config` → uv python）仅容器现场用，非交付方案。
-
-### 2.3 DTK 环境注入：镜像已内置
-
-- 运行时镜像已内置 DTK 环境：经 bash 运行的命令（含非交互）可直接 `import torch`，无需手动 `source /opt/dtk-26.04/env.sh`（实测：容器内非登录 `bash -c '/flagos/bin/python -c "import torch"'` 直接成功，torch 2.9.0）。
-- **注意事项：** 进程不经 bash 直接启动（如 `docker exec` 直接执行 python）时 DTK 环境缺失 → `libgalaxyhip.so.5` 报错；此时需显式 `source /opt/dtk-26.04/env.sh`。E2E 脚本采用该防御写法。
-
----
-
-## 3. 依赖面结论
-
-**METADATA 声明的依赖面 ≠ 真实运行时依赖面。** psutil（§1.2）被异步 checkpoint 策略实际使用但未声明——任何 wheel-only 消费方保存 checkpoint 即缺。对依赖处理（repack）而言，除 torch 外还需把 psutil 纳入运行时依赖检查（或反馈至本 fork flagos-ai/Megatron-LM-FL 补声明）。
-
----
-
-## 4. 可复现的运行参数基线
-
-DCU 上完整跑通 megatron 训练的最小 flags / 容器配置（逐项均有失败→修复的实证）：
+**可复现运行参数基线**（DCU 上完整跑通 megatron 训练的最小 flags / 容器配置；rl 场景引用，并在 §5 中给出 RL 特有参数）：
 
 | 参数 / 配置 | 原因 |
 |---|---|
 | `--no-masked-softmax-fusion` | §1.4：fused 路径 import CUDA-only 扩展 |
-| `--disable-jit-fuser` | **仅 flagtree 编译器下需要**（§1.3 + §2.1）；vendor triton 下已不需要（复跑验证） |
+| `--disable-jit-fuser` | **仅 flagtree 编译器下需要**（§1.4 + §1.5）；vendor triton 下已不需要 |
 | `--no-persist-layer-norm` / `--no-gradient-accumulation-fusion` | 相应 fused kernel 在 DCU 上不可用的显式关闭 |
-| `--attention-backend unfused` | DCU 上无 fused attention 后端 |
-| `--transformer-impl local` | 不依赖 TransformerEngine（DCU 无对应构建） |
+| `--attention-backend unfused` | 仅 local 训练线需要；RL（TE）线不传（§5.4） |
+| `--transformer-impl` | 训练用 `local`；RL 必须 `transformer_engine`（§5.4） |
 | `--shm-size=8g`（docker run） | torch multiprocessing 需大于容器默认 64MB 共享内存 |
-| `source /opt/dtk-26.04/env.sh`（防御性；经 bash 运行非必需） | §2.3：镜像已内置 DTK 环境；仅非 bash 直启进程需显式 source |
 
-**可复现配方:** `/tmp/hygon25-megatron-e2e.sh`（节点上执行，两阶段：wheel-only 训练循环 / 完整训练服务）。
+### 2.1 venv 缺 python3-config（2026-08-16 实测）
 
----
+- **现象:** venv `/flagos/bin` 缺 `python3-config` 符号链接。
+  `compile_helpers()`（`megatron/core/datasets/utils.py`，带 FlagScale 来源标注的
+  fork 补丁）执行 `subprocess.check_output(["python3-config",
+  "--extension-suffix"])` 抛 `FileNotFoundError: 'python3-config'`，
+  `pretrain_gpt.py` 在数据集构建 import 期即挂。该函数只在 wheel 已带预构建
+  `helpers_cpp{ext_suffix}.so` 时提前 return 跳过 make——但仍需
+  python3-config 算后缀。
+- **原因:** uv 托管的 Python 自带该二进制（不在 venv 路径），venv 未链接。
+- **解决方案:** `compile_helpers()` 改用 `sysconfig.get_config_var("EXT_SUFFIX")`
+  （标准库，任何 Python 环境都有），替代 `subprocess.check_output([...])`。
+  两路落地、最终落成同一段代码形态，不依赖 MLF merge 节奏：
+  - **MLF 侧（PR 已提交）:** PR #112（与 psutil PR #106 同类的上游修复）。
+  - **build-infra 侧（已落地）:** wheel 是 build-infra 自产，沿用现有
+    on-the-fly patch + grep gate 模式新增
+    `packaging/megatron/builder/patch-compile-helpers-sysconfig.py`，在 wheel
+    构建时对 checkout 打同样的 sysconfig 补丁。脚本幂等且自 gate：已是
+    sysconfig 形式 → no-op（PR #112 合并后自动跳过）；仍是 python3-config
+    形式 → 就地替换；源码演进（两种形式都找不到）→ exit 1 硬失败，补丁不可能静默失效。
+- **现在状态:** 已落地（build-infra 兜底）；PR #112 待合并。
 
-## 5. 四场景验证（2026-08-14，全范围 wheel）
+## 3. post_training
 
-wheel 打包范围扩大至 core+training+legacy+rl+post_training+inference（MLF PR #107 feat/wheel-full-scope，顶层入口文件一并打包）后，在应用镜像 `megatron-app:hygon-new`（全范围 wheel 单步安装，无 `--no-deps`）上按序验证四场景。共用 DCU 基线 flags（§4）+ `/tmp/jitfix` 补丁（NullTokenizer pad/bos/eod property + torch.compile identity）。
+**结论:** driver 跑通（post_training surface 全 import + `simple_generate`，
+输出 shape=(1, 8)，exit 0）。
 
-### 5.1 rl 场景：dynamic 推理引擎硬依赖 flash-attn（平台缺口，按决定记录）
+- **前提:** nvidia-modelopt 以 `--no-deps` ad-hoc 装入 runtime venv，**未入镜像**——与其余场景的"单步安装 wheel 即可用"不同，违反交付目标（§1.3.3）。
+- **注意:** modelopt 是唯一有 vendor 变体的 HARD 依赖；其余后端成功率不确定（§1.3.3）。
 
-**位置:** `megatron/rl/inference/megatron.py:87` 硬编码 `get_dynamic_inference_engine` → dynamic 引擎 `attention.py:943` `assert HAVE_FA3 or is_fa_min_version("2.7.3")` → `import flash_attn` → ModuleNotFoundError（DTK 26.04 无 flash-attn 构建）。
+## 4. inference
 
-**性质:** 场景级缺口，非依赖面缺口——`megatron.rl` 模块级仅依赖 pydantic + typing_extensions（纯 PyPI），全树 0 处 triton/torch.compile；阻塞点在推理引擎（dynamic 引擎硬依赖 flash-attn），复用 training/core 的编译器链。
+**结论:** `StaticInferenceEngine(controller, legacy=True)`，3 请求 × 8 tokens
+（`prompt_tokens` 直接注入 `InferenceRequest`，绕过 NullTokenizer 无
+`tokenize()` 的限制），generate 4.2s，exit 0。
 
-**处置:** 按决定记为缺口（不做本地 sdpa fallback patch），待 MLF 侧动态引擎支持非 flash-attn 后端。
+- **正面经验:** legacy 静态引擎路径保留 `StaticInferenceContext` →
+  `is_static_batching()=True` → attention.py static 分支
+  `apply_module(core_attention)`（DotProductAttention/sdpa）——**不依赖
+  flash-attn、不编译 triton kernel**，对 hygon 属编译器无关路径。
+- **注意:** 非 legacy 路径内部构造 DynamicInferenceContext +
+  DynamicInferenceEngine → 回到 §5.5 的 flash-attn 依赖。
 
-**2026-08-16 修正（新镜像 rl-new 实测）：** §5.1 的"DTK 26.04 无 flash-attn 构建"前提**已过时**——repack 修复后的新镜像实际装了 vendor flash_attn `2.8.3+das.opt1.dtk2604.torch290`，但复测在到达该断言之前就被更前置的阻塞挡下（见 §5.4）。且即便到达，仍有两个新发现：`flash_attn.__version__` 在 `__init__.py` 里**硬编码 "2.6.1"**（与 dist-info 的 2.8.3+… 不一致），且包内无 `flash_attn_interface`（无 FA3）→ `attention.py:943` 的 `is_fa_min_version("2.7.3")` 判定仍会失败。平台缺口依旧，只是失败形态多了一层 vendor 包的版本信息问题。
+## 5. rl
 
-### 5.4 rl 场景复测（2026-08-16，repack 修复后新镜像）：tensorboard 未声明依赖在 import 期前置阻塞
+**结论:** 全链路首次跑通（exit 0）：tokenizer → NCCL 初始化 → TE 模型构建 →
+dynamic 引擎（cuda graph 构建）→ text-gen server → "Collecting rollouts,
+Iteration 0..." → PAD/EOD 日志 → `compute_logprobs_batch` TE forward → 2 个训练迭代 →
+`[exiting program at iteration 2]`，0 Traceback，"Inference
+Coordinator: shut down successfully"。rl 四步（rollout → logprob → 训练 →
+退出）首次在 hygon25 全通。
+**前提:** 补装 §5.1 未声明依赖（测试用途，aliyun）+ §5.4 vendor TE。
+**配方相应改动:** `--transformer-impl local → transformer_engine`、删
+`--attention-backend unfused`（local 时代 DCU 基线）。
 
-**复测背景:** 新 runtime 镜像 `flagos-runtime-hygon-dtk26.04:2.1.2`（repack 修复 torch 落位 + flash_attn 未声明 pytest 依赖后重跑），完整作用域 wheel `0.17.1+fl.20260814`，容器 rl-new，**默认编译器 flagtree**，刻意不传 `--disable-jit-fuser`（测 mask-doc 开放问题），`--perform-rl-step --skip-train`（无 ckpt，随机初始化 rollout 验证）。
+**RL 特有可复现参数**（参数组合类教训，实测验证）:
 
-**结果:** `AssertionError: RL cannot run without the megatron.rl package`（`megatron/training/training.py:2744`，运行 #3，06:06:57 rc=1）。
+| 参数 / 配置 | 原因 |
+|---|---|
+| `--inference-max-seq-length` ≥ prompt 长度 + 期望生成长度 | 小于 prompt 长度时 `tokens_to_generate` 为负，dynamic 引擎拒绝全部请求 |
+| `--inference-dynamic-batching-max-tokens` 高于 max_requests | 覆盖引擎默认上限，否则 max_tokens ≥ max_requests 断言失败 |
+| `--transformer-impl transformer_engine` | §5.4：RL 训练 forward 强制 TE，local 走不通 |
+| tokenizer 数据层补 eos | §5.3：无 eos 时 `prepare_trajectories` 抛 TypeError |
 
-**根因（直接 import 实测）:** `megatron/rl/rl_utils.py:24` 模块级 `from torch.utils.tensorboard import SummaryWriter` → 运行时需要 **tensorboard 包**。runtime 镜像内无此包（`pip list` 实测），全作用域 wheel 的 METADATA 也未声明 → `training.py:60-67` 的 `has_rl_utils` try/except 捕获 ImportError 置 False → 断言。
+### 5.1 未声明依赖（主要耗时项）
 
-**性质:** 未声明运行时依赖（同类于 §1.2 psutil）——RL 入口在 import 期即阻塞，**先于** §5.1 的 flash-attn 断言。阻塞链现在是：tensorboard（import 期）→ pydantic（已解决，从 flagrelease minimax 镜像补装）→ flash-attn `__version__` 硬编码（§5.1 修正）。
+**tensorboard 实例:** `megatron/rl/rl_utils.py:24` 模块级
+`from torch.utils.tensorboard import SummaryWriter` → 运行时需要 tensorboard
+包；runtime 镜像与全作用域 wheel 的 METADATA 均未声明 → `training.py:60-67`
+的 `has_rl_utils` try/except 捕获 ImportError 置 False → `training.py:2744`
+断言 `RL cannot run without the megatron.rl package`（rc=1）。
 
-**处置:** 按"别搞，直接记录"定案，不做镜像内补装。修复方向 = 反馈本 fork（flagos-ai/Megatron-LM-FL）在 `pyproject.toml` 声明 tensorboard（参考 §1.2 psutil 的 PR #106 模式），或镜像层在 configs.yaml 依赖面补上。
+**依赖面缺口清单**（import 链逐层探测，对照 pyproject 声明）:
+`megatron/rl` 的模块级第三方依赖与 pyproject 声明有系统性偏差——不止
+tensorboard 一个，而是一组，偏离方式分三种：
 
-### 5.2 inference 场景：legacy 静态引擎路径免 flash-attn / 免 triton
+| 依赖 | 使用位置（模块级 import） | pyproject 声明 | 偏离方式 |
+|---|---|---|---|
+| tensorboard | `rl_utils.py:24` `torch.utils.tensorboard` | **未声明** | 完全未声明 |
+| wandb | `rl_utils.py:92` `from wandb import wandb_run` | 仅 `training` extra（`mlm` 是其废弃副本） | 声明在 training extra，`rl` extra 没带 |
+| httpx | `inference/megatron.py:6` | **未声明** | 完全未声明 |
+| tqdm | `agent/reward_only_agent.py:7` `tqdm.asyncio` | `dev`/`lts` extra | 声明在 dev/lts extra，`rl` extra 没带 |
+| openai[aiohttp] | `inference/megatron.py:8` | `dev` extra | 声明在 dev extra，`rl` extra 没带 |
+| uvicorn | `server/agent/fastapi_env_server.py:12`、`server/inference/inference_interface_server.py:12` | **未声明** | 完全未声明 |
+| fastapi | `server/agent/fastapi_env_server.py:9` 等 | `dev` extra | 声明在 dev extra，`rl` extra 没带 |
+| datasets | `agent/huggingface_dataset_agent.py:3` | `dev` extra | 声明在 dev extra，`rl` extra 没带 |
+| transformers | `tokenizer/huggingface_tokenizer.py`（`AutoTokenizer`） | 仅 `training` extra | 声明在 training extra，`rl` extra 没带 |
+| pyzmq | `core/inference/engines/dynamic_engine.py:76-80`（`import zmq` → `HAVE_ZMQ`） | **未声明** | 完全未声明 |
+| msgpack | `core/inference/engines/dynamic_engine.py:481`（`assert HAVE_MSGPACK`） | **未声明** | 完全未声明 |
+| quart | `core/inference/engines/text_generation_server.py:58`（Quart 不可用） | `dev` extra | 声明在 dev extra，`rl` extra 没带 |
+| hypercorn | text_generation_server 同路径（Quart 的 ASGI server） | `dev` extra | 声明在 dev extra，`rl` extra 没带 |
 
-`StaticInferenceEngine(controller, legacy=True)` 保留 `StaticInferenceContext` → `is_static_batching()=True` → attention.py static 分支 `apply_module(core_attention)`（DotProductAttention/sdpa）——**不依赖 flash-attn、不编译 triton kernel**，对 hygon 属编译器无关路径。
+（numpy / yaml / typing_extensions 为运行时基础，runtime 镜像已含，不属缺口。）
 
-**验证:** 3 请求 × 8 tokens（`prompt_tokens` 直接注入 `InferenceRequest`，绕过 NullTokenizer 无 `tokenize()` 的限制），generate 4.2s，exit 0。
+**关键点:**
 
-**注意:** 非 legacy 路径内部构造 DynamicInferenceContext + DynamicInferenceEngine → 回到 §5.1 的 flash-attn 崩溃路径。
+- **wandb 比 tensorboard 更隐蔽:** tensorboard 是"完全没声明"，wandb 是
+  "声明了但挂在 `training` extra 上"——`rl` extra（`pydantic==2.12.5` +
+  `tensorboard==2.19.0`，MLF 分支 `feat/rl-optdeps-verify` 3824c85b8）与
+  `training` extra 互不包含，装 `[rl]` 仍缺 wandb。
+- **性质:** 与 §1.2 psutil 同类——NVIDIA 上游代码的未声明运行时依赖，本
+  fork 继承。修复方向 = 反馈本 fork 把 RL 实际用到的依赖收进 `rl` extra
+  （wandb/tqdm/openai[aiohttp]/httpx/uvicorn/fastapi/datasets），或
+  build-infra 侧在 runtime configs.yaml 依赖面兜底。
+- **版本基准（2026-08-16 定）:** 容器内手补包只允许测试用途；版本以 MLF pin
+  为准（tensorboard 2.19.0 / pydantic 2.12.5），已把容器实测版（2.21.0 /
+  2.13.4）降回。公共包安装一律走 aliyun 镜像（pypi.org 慢）。
+- **现在状态:** 待反馈本 fork（RL 依赖 extra 声明偏差）。
 
-### 5.3 post_training 场景：依赖 modelopt（HARD，vendor 变体）
+### 5.2 datasets / pyarrow 版本兼容缺陷（2026-08-17 实测）
 
-driver 跑通（post_training surface 全 import + `simple_generate`，输出 shape=(1, 8)，exit 0）。前提：nvidia-modelopt 以 `--no-deps` ad-hoc 装入 runtime venv，**未入镜像**——与其余场景的"单步安装 wheel 即可用"不同，此处是容器现场补装，违反交付目标。modelopt 是唯一有 vendor 变体的 HARD 依赖（configs.yaml 仅 enflame 有 `enflame-modelopt`）；NVIDIA 用 NVIDIA modelopt 可用，其余后端成功率不确定；纳入镜像与否待镜像层决策。
+- **现象:** datasets 5.0.1 `save_to_disk` 产物无法被
+  `load_dataset("arrow")` 重读——
+  IPC stream 尾部带零长消息终止符（`ff ff ff ff 00 00 00 00`），
+  pyarrow ≤25 的 stream 迭代误读为 538970747
+  字节长度前缀（`ArrowInvalid: Expected to read 538970747 metadata bytes` →
+  回退 `Not an Arrow file`）。
+- **非数据损坏:** 小文件同复现；`pa.ipc.new_file`（ARROW1 footer）与
+  `pa.ipc.new_stream`（纯流）两种手工写法均验证可被 load_dataset 读取；
+  pyarrow 降级亦不修（同版本写+读也挂）。
+- **解决方案:** 容器内以 `pa.ipc.new_stream` 手工重写数据集（全量
+  490364 行），round-trip 验证通过。
+- **对 CI 的意义:** MLF grpo 测试的预生成 artifact 若用同一
+  (datasets 5.0.1, pyarrow ≤25) 组合生成会踩同坑——CI 需固定经过实测的
+  (datasets, pyarrow) 版本对。
+- **现在状态:** 已规避；CI 版本对待定。
 
----
+### 5.3 tokenizer 无 eos
 
-## 6. 结论与后续
+- **现象:** gpt2 tokenizer 无 eos token → 包装器 `eod` property 返回 None →
+  `prepare_trajectories`（`rl_utils.py:1085`）在日志行
+  `detokenize([tokenizer.eod])` 处 TypeError（`int() argument ... not
+  'NoneType'`）。
+- **解决方案（数据层修复即可，无需改 megatron core）:**
+  `tokenizer_config.json` 声明 `bos/eos/unk = "<|endoftext|>"`，包装器
+  `add_special_tokens` 的 copy-back 循环（`huggingface_tokenizer.py:208-209`）
+  把底层 HF tokenizer 的 eos 传播到包装器 → `eod` = 50256
+  （`<|endoftext|>`）。实测：tokenizer 检查输出 `eod: 50256`；运行日志
+  `Tokenizer EOD: '<|endoftext|> (50256)'`。qwen3 系 tokenizer 天然带 eos，
+  不需此处理。
+- **附带发现:** `eos_id`（`huggingface_tokenizer.py:310-312`）缺 None 守卫。
+- **现在状态:** 已解决。
 
-- **E2E 故事闭环（四场景）**：wheel（Megatron 打包产物）→ 单步安装（无 `--no-deps`）→ 场景入口直跑，在 hygon25 上 training / post_training / inference 全部实证通过（exit 0）；rl 阻塞于平台缺口（§5.1，按决定记录）。训练场景已用全范围 wheel 完成"单步安装 + 直接跑 `pretrain_gpt.py`"（无需 repo checkout）验证。
-- **打包范围缺口（已关闭）**：全范围 wheel（MLF PR #107 feat/wheel-full-scope）实现 core+training+legacy+rl+post_training+inference 打包并含顶层入口文件；PR 合入前其余后端暂不能复用该 wheel 做按序验证。
-- **已提交至本 fork（flagos-ai/Megatron-LM-FL）**：§1.1 修复 → PR [#105](https://github.com/flagos-ai/Megatron-LM-FL/pull/105)；§1.2 依赖声明 → PR [#106](https://github.com/flagos-ai/Megatron-LM-FL/pull/106)；全范围打包 → PR [#107](https://github.com/flagos-ai/Megatron-LM-FL/pull/107)。
-- **待反馈至本 fork（flagos-ai/Megatron-LM-FL）**：§1.3 jit_fuser import 期绑定时序、§1.4 fused kernel 默认开启的平台假设、§5.1 rl dynamic 引擎 flash-attn 硬依赖（平台缺口）。
-- **相关文档**：`packaging/megatron/builder/report-megatron-0.17.1.md`（构建与依赖面；repack facility 已于 2026-08-14 移除，依赖处理不再单独成报告，其要点并入 builder report §1/§3）。
+### 5.4 RL 训练 forward 必须 TE（local 不支持 THD 打包序列）
+
+- **现象:** `get_logprobs`（`rl_utils.py:666-679`）**无条件**构造打包序列（THD）格式的 `packed_seq_params`（即使 `sequence_packing=False`，为 CUDA
+  graph 签名一致性）→ 传给模型 → local `DotProductAttention` 断言 "Packed
+  sequence is not supported by DotProductAttention. Please use
+  TEDotProductAttention instead."（`dot_product_attention.py:158-161`）。
+- **原因:** RL 训练 forward 需要 `--transformer-impl transformer_engine`
+  （`te` 为非法值；CI qwen3 grpo 从不传 `--transformer-impl`，默认 TE → CI
+  从未覆盖 local 的 RL 训练 forward）。DCU 有 vendor TE
+  `2.10.0+das.opt1.dtk2604.torch290`（§1.3.2）。
+- **平台依赖警告:** 并不是所有后端都有厂商提供的 TE——无 vendor TE 的平台要么等 MLF 支持 local 的 THD 打包序列训练 forward，要么平台侧自行构建/
+  适配 TE。
+- **现在状态:** hygon 已跑通（vendor TE repack 后单步安装即用，§1.3.2）；
+  无 vendor TE 平台待反馈。
+
+### 5.5 flash_attn：RL dynamic 引擎硬依赖 ≥2.7.3
+
+- **现象:** RL 场景的动态推理引擎（`megatron/rl/inference/megatron.py:87`
+  硬编码 `get_dynamic_inference_engine` → dynamic 引擎
+  `attention.py:943` `assert HAVE_FA3 or is_fa_min_version("2.7.3")`）硬依赖
+  flash-attn ≥ 2.7.3（无 FA3 时）。
+- **根因与修复:** vendor flash_attn wheel 版本字符串三处不一致，致
+  `is_fa_min_version("2.7.3")` 误判为 False——
+  repack 修正三处字符串一致后断言通过（完整修改归纳见 §1.3.1）。
+- **实证:** 修复后 `flash_attn.__version__` = `"2.8.3"` →
+  `is_fa_min_version("2.7.3")` 通过（无需 FA3），dynamic 引擎断言实证通过。
+- **现在状态:** 不再是阻塞（hygon 已由 vendor flash_attn 2.8.3 满足）；无
+  vendor flash_attn 的平台需先做同样检查。
+
+## 6. 跟踪事项
+
+**已提交至本 fork（flagos-ai/Megatron-LM-FL）:**
+- PR [#105](https://github.com/flagos-ai/Megatron-LM-FL/pull/105)——
+  §1.1 `megatron.training` import 修复
+- PR [#106](https://github.com/flagos-ai/Megatron-LM-FL/pull/106)——§1.2
+  psutil 依赖声明
+- PR [#107](https://github.com/flagos-ai/Megatron-LM-FL/pull/107)——§1.1
+  全范围打包
+- PR [#112](https://github.com/flagos-ai/Megatron-LM-FL/pull/112)——§2.1
+  python3-config → sysconfig
+
+**待反馈至本 fork:**
+- §1.4 jit_fuser import 期绑定时序、fused kernel 默认开启的平台假设
+- §5.1 RL 依赖 extra 声明偏差（tensorboard/wandb/httpx/tqdm/openai/uvicorn/
+  fastapi/datasets/transformers/pyzmq/msgpack/quart/hypercorn 实际使用与
+  `rl` extra 不符）
+- §5.4 local impl 不支持 THD 打包序列训练 forward（RL 训练 forward 被迫依赖
+  TE）；无 vendor TE 平台的适配路径
+
+**待决策:**
+- §1.3.3 modelopt 纳入镜像与否
+- §5.2 (datasets, pyarrow) 实测版本对固化到 CI
+- §1.5 flagtree 在 hygon runtime 镜像中的默认位置（屏蔽/移除）
+
+**相关文档:** `packaging/megatron/builder/report-megatron-0.17.1.md`（构建与依赖面；
+依赖处理并入其 §1/§3）。

--- a/packaging/megatron/docs/memory/MEMORY.md
+++ b/packaging/megatron/docs/memory/MEMORY.md
@@ -3,5 +3,6 @@
 - [megatron-verification-state.md](megatron-verification-state.md) — 验证阶段状态快照：已定决策、待决事项、文件状态、任务
 - [hygon-compiler-mask.md](hygon-compiler-mask.md) — 编译器 mask 表（flagtree 屏蔽/triton 交付）+ 归并规则
 - [work-constraints.md](work-constraints.md) — 用户工作约束：报告规范、操作纪律、PR 规范、术语约定
+- [rl-verify-worklog.md](rl-verify-worklog.md) — RL E2E 验证工作日志（2026-08-16 起，每步一记：TE/pandas 缺口、RL 启动进度）
 
 > 记忆存放位置（2026-08-13 用户指定）：`build-infra/packaging/megatron/docs/memory/`，与其他 agent 的记忆隔离。

--- a/packaging/megatron/docs/memory/rl-verify-worklog.md
+++ b/packaging/megatron/docs/memory/rl-verify-worklog.md
@@ -1,0 +1,191 @@
+---
+name: rl-verify-worklog
+description: RL E2E 验证工作日志——每工作一步记一笔（2026-08-16 用户指定：记录放 packaging/megatron/docs/memory/，不放 agent 个人 memory）
+metadata:
+  type: project
+---
+
+# RL E2E 验证工作日志
+
+## 最终目标（2026-08-16 用户重申）
+
+**可重复构建的、稳定的、可交付的、基于 MLF 的堆栈（镜像）。**
+
+- 一切验证发现最终都要**固化到构建流程**：configs.yaml deps / runtime Containerfile / wheel extras。
+- 不在容器内打补丁、不做一次性探索——凡是"构建流程复现不出来"的结论都不算数。
+- 当前 RL E2E 验证的产出 = **MLF 堆栈依赖清单**（每个依赖：从哪个 index 来、什么版本、如何声明）。
+
+## 记录方式（2026-08-16 用户定）
+
+- **memory 是现场记录**（用户不看）；用户消费的产物是**最终的、可供借鉴的报告 markdown**。
+- 每个验证结论最终都要沉淀成报告（如 packaging/megatron/docs/ 下的报告），memory 只是过程草稿。
+- 报告标准：可直接借鉴（结论 + 怎么做 + 坑），不是流水账。
+- **所有卡点，只要不是误操作，都要写入 markdown 报告**——技术障碍是报告的核心内容。
+- **自己做过的所有探索，都要记入 memory**——探索过程不进报告（报告只留结论），但必须留痕在 memory，可追溯。
+- **误操作不入报告，也不留 memory**——做错了 A、后来发现是误操作，没人在意，自己也要尽快忘掉。**删掉无意义的 memory 对保持思路清晰很重要**（定期清理）。
+- **容器内可以探索，但探索不等于完工（2026-08-16 用户补充定）**：后面遇到类似的问题（vendor 依赖漏/错等），**都不可以轻易放过**。容器内可以做**所有探索性的修复**，但**修复之后不能在容器里认为完工**——最终落脚点仍然以**可重复的流程、制品**为准（configs.yaml deps / runtime Containerfile / wheel extras / vendor repack）。探索结论必须固化到构建流程才算数。
+- **容器内手动补包只允许用于测试目的（2026-08-16 用户定）**：补包的价值 = 暴露"构建流程没声明"的缺口；回过头来每个缺口都要固化到可重复流程。跑不跑通本身不重要。
+
+## 2026-08-16 重开（rl-v4 为新一轮起点）
+
+上一轮（rl-v2/rl-v3）RL 验证记录全部作废，干扰严重，已清除。以 rl-v4 起的新一轮实测为准。
+
+**背景（TE repack 已闭环交付，一句话）：** transformer_engine 2.10.0+das.opt1.dtk2604.torch290 经三项 vendor repack 修正（pandas 补声明 / enable_mmacfuse 剥参 / FA 版本检测剥 local version），从 hygon index 单步安装即完全可用（import + LayerNorm/Linear + DPA thd/fp16 FA 后端均通过）。RL 用 TE 方向已定。
+
+**版本策略（用户 2026-08-16 定）：** 先装最新版本并锁定（pin 死），出问题再说。MLF 已 pin 的（pydantic==2.12.5 / tensorboard==2.19.0）对齐；fastapi 满足 `~=0.50` 取最新 0.x；其余无约束包（tqdm/httpx/uvicorn/datasets/openai[aiohttp]/wandb）装 aliyun 最新稳定版并锁定。将来固化构建流程时以这些锁定版本为准。
+
+**apex（2026-08-16 用户定）：** hygon vendor apex wheel `apex-1.7.0+das.opt1.dtk2604.torch290-cp310-cp310-manylinux_2_28_x86_64.whl`（DTK 26.04 + torch 2.9.0 对齐，与 TE/torch vendor 变体同系）。**要纳入 runtime 镜像**（hygon 构建流程依赖，走 vendor PyPI `flagos-pypi-hygon`，不直接在容器内装——不可重复）。configs.yaml 里 hygon 段当前无 apex 声明（kunlunxin/metax 有）→ 待办：把 apex 加进 hygon runtime deps 并上传 index。
+
+**wheel 自含性（2026-08-17 确认）：** MLF pyproject 的 `py-modules` 把仓库根顶层入口文件打进 wheel：`gpt_builders / mamba_builders / model_provider / pretrain_gpt / pretrain_bert / pretrain_mamba / pretrain_t5 / pretrain_vlm / train_rl`（pyproject.toml:15-25）。wheel 安装后 `python -m pretrain_gpt` / `from gpt_builders import gpt_builder` / `train_rl.py` 直接落在 site-packages（`/flagos/lib/python3.10/site-packages/train_rl.py` 实测在），无需 repo checkout。**但 `examples/` 目录不打进 wheel**——`examples/rl/environments/countdown/`（countdown_agent.py / countdown.py）是仓库测试环境文件，不在 site-packages。跑 countdown agent 需单独拷这两个文件（已拷到容器 /tmp/rl4-countdown/）。
+
+## 2026-08-16 继续（rl-v4 实测记录续）
+
+**版本基准（用户定）：容器内手补包是"胡闹"，降回 MLF pin。** tensorboard/pydantic 已从容器实测版（2.21.0/2.13.4）降回 MLF `rl` extra pin（2.19.0/2.12.5）。→ 将来固化到构建流程时以 MLF pin 为准。
+
+**公共包镜像（用户定）：一律走 aliyun** `pip install -i https://mirrors.aliyun.com/pypi/simple/`，pypi.org 慢；vendor 包仍走 vendor index。已记 agent memory（pip-aliyun-mirror.md）。
+
+**RL 模块 import 链探测**（`from megatron.rl import rl_utils`，逐层暴露）：
+- 已装补齐：tqdm（reward_only_agent 需要；pyproject 在 dev/lts extra）
+- **缺口 2：httpx** —— `megatron/rl/inference/megatron.py:6` 模块级 import，pyproject 未声明
+- **缺口 3：wandb** —— `megatron/rl/rl_utils.py:92` 模块级无条件 `from wandb import wandb_run`；pyproject 仅在**废弃的 mlm extra** 声明 wandb，`rl` extra 没带（缺口 1 tensorboard 的姊妹：模块级硬依赖未声明）
+- 其余 RL 第三方依赖一览（对照 pyproject）：openai[aiohttp]、uvicorn、fastapi、datasets（仅 dev extra / 未声明），numpy/yaml/torch.utils.tensorboard 为运行时基础
+- **下一步**：装齐剩余公共包（httpx/openai/uvicorn/fastapi/wandb/datasets，aliyun）→ 跑 train_rl.py 完整 import 链
+
+## 2026-08-17 实测：train_rl.py 跑通到 RL 步（rl-v4 容器）
+
+**RL 场景运行形态（架构确认）：**
+- 入口 = wheel 内 py-module：`python -m train_rl`（/flagos/lib/python3.10/site-packages/train_rl.py 实测存在）。train_rl.py 自建 MinimalDataset（`pretrain(None, ...)`），**无需 --data-path / --mock-data**。
+- **env server 不需要单独起进程**：`get_agent`（rl_utils.py:424）→ `WeightedMultiTask.from_config` **进程内直接实例化 agent**（fastapi_env_server.py 的 `--env-config` standalone 模式是远程部署形态，CI 测试是进程内）。
+- **countdown agent 装载方式**：`import_class`（megatron/rl/__init__.py）支持 `.py:` 文件路径形式（`/path/countdown_agent.py:CountdownAgent`，spec_from_file_location，module 名固定 acemath_agent）。**注意：`.py:` 形式是顶层 module → countdown_agent.py 里的 `from .countdown import compute_score` 相对导入会炸**，需 sed 改绝对导入 `from countdown import compute_score` + PYTHONPATH 指到文件目录（容器内已改）。
+- **countdown dataset**：CountdownAgent.get_dataset 断言 `len(dataset) > TRAIN_SIZE(327680)+TEST_SIZE(1024)` → 之前 save_to_disk 的 4096 行不够，已重新 save_to_disk 全量 490364 行（HF cache 命中，秒级）到 /tmp/rl-env/countdown-tasks-3to4（覆盖旧损坏目录，旧的 state.json 是 lock 残留会炸 arrow 读取）。
+- **tokenizer**：gpt2 经代理下载到 /tmp/rl-env/gpt2-tokenizer（tokenizer.json/vocab.json/merges.txt 等 4 文件），HF cache 里只有部分文件（只有 vocab.json），snapshot_download 补全。
+- 容器内准备文件：/tmp/rl4-countdown/{countdown_agent.py,countdown.py}、/tmp/rl4-env-config.yaml（`.py:` 形式 + dataset_file=/tmp/rl-env/countdown-tasks-3to4 + split=train）、/tmp/run.sh（train_rl 命令）。
+
+**train_rl.py 命令要点（2026-08-17 实测构造）：**
+- 模型极小化：--num-layers 2 --hidden-size 64 --ffn-hidden-size 256 --num-attention-heads 4 --seq-length 128 --inference-max-seq-length 64
+- CI 借参数：--perform-rl-step --grpo-group-size 2 --grpo-prompts-per-step 2 --grpo-iterations 1 --grpo-clamp-eps-lower/upper 0.2/0.2 --grpo-kl-beta 0.0 --grpo-entropy-term-weight 0.0 --langrl-env-config --rl-partial-rollouts --refit-method gloo --rl-inference-tensor-model-parallel-size 1 --rl-inference-pipeline-model-parallel-size 1 --inference-dynamic-batching-num-cuda-graphs 1 --inference-dynamic-batching-buffer-size-gb 20 --calculate-per-token-loss --untie-embeddings-and-output-weights
+- DCU 基线：--no-masked-softmax-fusion --attention-backend unfused --transformer-impl local --bf16
+- 未用 CI 的 --finetune/--use-checkpoint-args（无 ckpt 加载）
+- 结果日志 /tmp/rl4-train.log（容器内）
+
+## 2026-08-17 第三轮启动：两个新阻塞 + 跑到 NCCL init
+
+**阻塞 D（transformers，真实缺口）：** `HuggingFaceTokenizer` 路径 `AutoTokenizer.from_pretrained` 抛 NameError（`AutoTokenizer` 未定义）→ 容器无 transformers。pyproject 里 transformers 只在 **training extra**（pyproject.toml:91），`rl` extra 没带 → 真实缺口。另有代码缺陷：`huggingface_tokenizer.py` 模块级 `HAVE_TRANSFORMERS` 标志算了但从未使用 → 报错是 NameError 而非干净的提示。容器内 aliyun 补装 transformers 5.15.0 + tokenizers 0.22.2（仅测试用途）。报告 §5.5 依赖表 + 待办需补。
+
+**阻塞 E（python3-config，已知问题 §2.4 在 rl-v4 复现）：** `megatron/training/initialize.py:191 _compile_dependencies → core/datasets/utils.py:30 compile_helpers()` `subprocess.check_output(["python3-config","--extension-suffix"])` → FileNotFoundError。venv `/flagos/bin` 缺 python3-config。**关键确认：wheel 内 `helpers_cpp.cpython-310-x86_64-linux-gnu.so` 已存在**（编译扩展自带），所以补上 python3-config 后 compile_helpers 会提前 return 跳过 make——symlink 即完全解锁。诊断软链（仅测试用途）：`ln -sf /root/.local/share/uv/python/cpython-3.10-linux-x86_64-gnu/bin/python3-config /flagos/bin/python3-config`，`--extension-suffix` 实测输出与 wheel 内 .so 同名。**固化路径已存在但未生效：** build-infra builder 的 `patch-compile-helpers-sysconfig.py`（sysconfig 替代 python3-config，PR #112 同款）在下一次 wheel 重建时自动打上；rl-v4 当前 wheel（20260814 构建）早于该补丁 → 换新 wheel 后此阻塞自动消失。
+
+**第三轮启动（含 MASTER_ADDR 四 env + python3-config symlink）进度：** tokenizer 初始化通过（padded vocab 50257→50304）→ RerunStateMachine → TP=1/PP=1 initialized → NCCL ProcessGroup init（W0816 Guessing device ID...）。下一步看：模型构建 → env agent 装载 → §5.1 flash-attn 断言。
+
+## 2026-08-17 第四轮：阻塞 F（max_tokens >= max_requests 断言，参数组合问题）
+
+**阻塞 F（dynamic_context 断言，非依赖缺口）：** 第三轮跑到 RL rollout 数据准备即崩：`megatron/core/inference/contexts/dynamic_context.py:527-530` `assert max_tokens >= max_requests`（"to have consistency between cuda graph sizes and the block table size"）。
+
+- **max_tokens=16384 = DEFAULT_MAX_TOKENS**（dynamic_context.py:236/524：`inference_config.max_tokens or DEFAULT_MAX_TOKENS`）——run.sh 没传 `--inference-dynamic-batching-max-tokens`。
+- **max_requests=163836 = KV block 数派生的上限**（508 行 `kv_block_allocator.total_count - 1`，再 `//tp_size*tp_size`、`//4*4` 取整）：20GB buffer（`--inference-dynamic-batching-buffer-size-gb 20`）÷ 极小模型每 block 字节（2 层 hidden 64，block_size_tokens=256）→ ~16.3 万个 block。模型越小 block 越多，断言越容易炸——CI 用 36 层 qwen3-8b + seq 1024，每 block 大得多，不炸。
+- **阻塞链**：MASTER_ADDR ✅ → python3-config ✅（诊断 symlink）→ transformers ✅（真实缺口）→ NCCL ✅ → flash-attn 版本断言 ✅（repack 的 __version__ 修正生效，§3.1.1）→ **⛔ F 此处**。
+- **处置（参数组合，CLI 可解）：** run.sh 显式加 `--inference-dynamic-batching-max-tokens 262144`（覆盖 DEFAULT_MAX_TOKENS，高于 max_requests 163836）。不动 buffer/block 计算，只抬高 max_tokens 上限。另一个等价选择是 `--inference-dynamic-batching-max-requests` 压到 16384 以下或调小 buffer，未取。
+
+**路径确认（为挑 fix 读的代码，不留报告）：** `rl_utils.py:1577 get_grpo_data_iterator → get_environment_rollouts(model, inference_model, optimizer, grpo_prompts_per_step=2, grpo_group_size)` → DynamicInferenceContext.__init__。CLI override 从 `megatron/inference/utils.py:340-341` 进 InferenceConfig（`--inference-dynamic-batching-max-requests` arguments.py:1869 / `--inference-dynamic-batching-max-tokens` arguments.py:1874，均默认 None）。`get_rollout_generator`（rl_utils.py:458-477）per-request `max_tokens = args.inference_max_seq_length`（=64，是每请求生成长度，与 context max_tokens 无关）。`rl_parallel_generation_tasks` 默认 512（arguments.py:463 else 分支，与 CI 相同）。
+
+## 2026-08-17 第四轮实测续：阻塞 G（pyzmq + msgpack，真实缺口 ×2）
+
+**max_tokens override 生效**：DynamicInferenceContext 正常分配（active buffer 20 GB / 163839 blocks），断言 F 通过。模型构建、env agent 装载、rollout 收集全部走到。
+
+**阻塞 G（InferenceCoordinator 硬依赖 pyzmq + msgpack，均未声明）：** rollout 启动即崩：
+- `megatron/rl/inference/megatron.py:100 launch → dynamic_engine.py:477 start_listening_to_data_parallel_coordinator`：`assert HAVE_ZMQ`（dynamic_engine.py:76-80 try/except import zmq 置标志）→ `AssertionError: please install the pyzmq library to use InferenceCoordinator`。
+- 同函数 481 行紧接着 `assert HAVE_MSGPACK`（messagepack）——**msgpack 也是同一路径的硬依赖**，装完 pyzmq 必踩。
+- **pyproject 声明检查：pyzmq、msgpack 均无**（本地仓库 pyproject.toml grep 0 命中）→ 真实缺口，与 tensorboard/httpx/wandb 同类。
+- 容器内 aliyun 补装（仅测试用途）：pyzmq 27.1.0、msgpack 1.2.1。版本未 pin——将来固化到构建流程时以 aliyun 最新稳定版为准（或 MLF rl extra 声明）。
+- **待办**：报告 §5.5 依赖表补 pyzmq/msgpack 两行 + build-infra configs.yaml deps 声明（与其余 RL 公共包一起）。
+
+## 2026-08-17 收尾：阻塞 H（arrow 往返）与 I（quart）双破
+
+**阻塞 H（datasets/pyarrow 版本兼容缺陷，非数据损坏）：** `load_dataset("arrow")` 读 datasets 5.0.1 `save_to_disk` 产物报 `ArrowInvalid: Expected to read 538970747 metadata bytes, but only read 243` → 回退 `pa.ipc.open_file` 报 `Not an Arrow file` → DatasetGenerationError。
+
+- **根因（probe 四探证实）**：datasets 5.0.1 save_to_disk 写的 IPC stream 尾部带**零长消息终止符** `ff ff ff ff 00 00 00 00`（continuation + 0 长度），pyarrow 25.0.1 的 stream 迭代（arrow builder 逐批读）把它误读为 538970747 字节长度前缀。**不是文件截断/损坏**——3 行 800 字节小文件同样复现，大文件头部（continuation + 432B schema）与数据段（19.7MB）结构完全正常。
+- **probe 四探结果**：① 独立 `pa.ipc.open_stream` 构造成功（lazy，未迭代时误导）但 open_file FAIL；② `pa.ipc.new_file`（ARROW1 footer 格式）产物 → load_dataset OK；③ `pa.ipc.new_stream`（纯流，无零长终止符）产物 → load_dataset OK；④ datasets 自身 save_to_disk → load_dataset FAIL。
+- **pyarrow 降级尝试无效**：aliyun 无 21.0.2，装 21.0.0 后 probe ④ 仍 FAIL（同版本写+读也挂）→ 不是写/读版本错配，是 datasets 5.0.1 writer 与 arrow builder reader 的配对缺陷。
+- **处置（测试用途，已生效）**：不再用 save_to_disk，改用 `pa.ipc.new_stream` 手工写 `data-00000-of-00001.arrow`（probe ③ 验证可读），全量 490364 行重写到 /tmp/rl-env/countdown-tasks-3to4，`load_dataset("arrow")` 验证 OK（sample {'target': 98, 'nums': [44, 19, 35]}）。
+- **对构建流程的意义**：pyarrow 不在 configs.yaml 治理面（datasets 的传递依赖）；但 MLF CI 的 artifact 生成（tests 里 `dataset_file: /mnt/artifacts/...` 预生成）若用同一套 datasets 5.0.1 + pyarrow ≤25 组合会踩同坑 → 报告 §5.5 记一条，建议 CI 固定经过实测的 (datasets, pyarrow) 组合。
+
+**阻塞 I（quart + hypercorn，真实缺口 ×2）：** rollout 起 text-gen replicas 时 4× `RuntimeError: Web backend framework (Quart) not available`（text_generation_server.py:58）。
+
+- pyproject 声明检查：quart（pyproject.toml:132）、hypercorn（:130）均在 **dev extra**，`rl` extra 没带 → 与 transformers（training extra）同类，"声明错位"变体（声明了但挂在别的 extra）。
+- 容器内 aliyun 补装（仅测试用途）：quart + hypercorn，`from quart import Quart` OK。
+- **待办**：报告 §5.5 依赖表补 quart/hypercorn 两行 + build-infra configs.yaml deps 声明（与其余 RL 公共包一起）。
+
+## 2026-08-17 第六轮：阻塞 K（rollout 长度断言，参数组合问题）
+
+**阻塞 K（非依赖缺口）：** run 8（J 修复后）rollout 收集成功但 GRPO 数据准备即崩——`rl_utils.py:791` `assert (len(turn_traj) == seq_len) or (turn_traj[-1] == tokenizer.eod)`，`AssertionError: Rollout is not the correct length: 112 6763`（112=实际长度，6763=末 token id，非 EOD）。
+
+- **根因**：无 ckpt 随机初始化模型生成的是胡话，**几乎不吐 EOD**；rollout 长度只能靠引擎截断凑。run 8 `--inference-max-seq-length 112 < --seq-length 128` → 引擎 112 处截断 → `len(turn_traj)=112 ≠ 128` 且末 token 非 EOD → 断言两条件全不满足。
+- **CI 对照**：CI grpo 全部 `--seq-length == --inference-max-seq-length`（1024=1024），且模型是训练过的会正常吐 EOD——CI 从不触发这条断言，是 CI 没覆盖的边界。
+- **处置**：`--inference-max-seq-length 128`（= seq-length）。**结论写进报告基线：无 ckpt 随机初始化 + 无 EOD 的 rollout，inference-max-seq-length 必须 == seq-length**（引擎截断成为唯一长度来源）。
+- 阻塞 K 与 F/J 同类（参数组合），非依赖缺口。run 9 已带修复重跑。
+
+## 2026-08-17 第五轮：阻塞 J（inference-max-seq-length 小于 prompt 长度，参数组合问题）
+
+**阻塞 J（非依赖缺口）：** run 7（H/I 双破后首个完整 rollout）在 `Collecting rollouts, Iteration 0` 即崩——text-gen 4 replicas 全部 `MaxSequenceLengthOverflowError`，`Prompt Tokens: 86 / Tokens to generate: -22 / Max sequence length: 64`。dynamic 引擎拒绝全部请求（dynamic_engine.py:823 每请求一个 UserWarning），rollout gather 全失败后 server 关闭。
+
+- **根因**：per-request `max_tokens = args.inference_max_seq_length`（=64，run.sh 沿用 CI 的推理最大生成长度），countdown prompt 本身 84–86 tokens > 64 → `tokens_to_generate = max_seq_length - prompt_tokens` 为负数 → 引擎拒绝。**与阻塞 F 同类（参数组合），非依赖缺口。**
+- **CI 对照**：`gpt_grpo_basic_function/model_config.yaml` 用 `--seq-length 1024 --inference-max-seq-length 1024`（两者相等，8b 模型 prompt 短得多）。本 recipe 2 层小模型 seq-length 128，prompt 反而长（countdown 数字序列）。
+- **处置**：`--inference-max-seq-length 64 → 112`（>86 prompt + ~26 生成余量），run 8 已带修复重跑。教训写进报告可复现参数基线：**小模型 + 长 prompt 环境（countdown）时 inference-max-seq-length 必须 ≥ prompt 长度 + 期望生成长度**。
+
+## 2026-08-16 新一轮实测记录（rl-v4）
+
+- megatron wheel `0.17.1+fl.20260814.gba22f6b673f3` 已在 rl-v4（hygon index 上有 3 个 cp310 wheel）。
+- **缺口 1：tensorboard** —— `megatron/rl/rl_utils.py:24` 模块级 `from torch.utils.tensorboard import SummaryWriter`，wheel METADATA 未声明 → 单步安装后 RL 入口 import 期阻塞（报告 §5.4 已记，性质同 §1.2 psutil）。
+- MLF 分支 `feat/rl-optdeps-verify` HEAD `3824c85b8` 已在 pyproject.toml 声明 `rl` extra：`pydantic==2.12.5` + `tensorboard==2.19.0`；**但未合入 main → 无 wheel 可装**（CI 从 main 构建）。
+- **对 MLF 只有建议权，没有决定权**（用户 2026-08-16 定）：推进主动权在 build-infra 侧——依赖面在**我们自己的构建栈**声明（runtime configs.yaml deps / wheel 构建流程），不依赖 MLF 合入；MLF 侧 PR 保持开放供采纳。
+
+## 2026-08-17 第七轮（run 10）：阻塞 L 已解，新阻塞 M（gpt2 无 EOD 元数据）
+
+**阻塞 L（参数组合，已解）：** `prepare_trajectories`（rl_utils.py:1055-1071）`ValueError("No pad token found in tokenizer vocabulary")` —— gpt2 vocab（50257）里没有 `<|finetune_right_pad_id|>` / `<SPECIAL_999>`（DEFAULT_PAD_TOKENS 全缺），且 HF pad_token/eos_token/bos_token 全 None。
+
+- **CLI 解法（已生效）**：run.sh 加 `--tokenizer-special-tokens '<|finetune_right_pad_id|>'` → `build_tokenizer` 经 `additional_special_tokens` 把 token 加进 vocab（实测 50257→50258）→ prepare_trajectories 的 vocab 检查命中 → `tokenizer._tokenizer.pad_token = pad_token` 设置成功。**注意 shell 必须加引号**（`<|...|>` 含管道符，裸写会 syntax error）。
+- **性质**：参数组合问题，非依赖缺口。但对 MLF 是代码级发现：prepare_trajectories 对无 pad tokenizer 无兜底（直接 raise）。
+
+**阻塞 M（当前，未解）：** pad 设置成功后崩在 **log 语句**：rl_utils.py:1085 `tokenizer.detokenize([tokenizer.eod])` → gpt2 无 eos_token → `eod` property 返回 None（huggingface_tokenizer.py:315-320）→ `ids_to_text([None])` → transformers `convert_ids_to_tokens` `TypeError: int() argument must be ... not 'NoneType'`。
+
+- **根因链**：gpt2 tokenizer 三缺（pad/eos/bos 全 None）→ pad 补上了，EOD 没补 → prepare_trajectories 的 debug 日志（1080-1086 行 PAD/EOD 各一条 detokenize）直接炸。
+- **明天方向（未动手）**：
+  - 方案 a（推荐，参数层）：tokenizer 换带 eos 的（qwen 系），或经 `--tokenizer-special-tokens` 同时补 `<|endoftext|>` 做 eos？——**注意**：`additional_special_tokens` 加的是特殊 token，HF eos_token 属性仍是 None，`eod` property 仍返回 None，光加 vocab 不够；需要确认是否有 CLI 路径能设 eos_token（`--tokenizer-...` 参数面，build_tokenizer 未传 eos_token，见下）。
+  - 方案 b（代码层，记录给 MLF）：`detokenize`/`eod` 对 None 的兜底；或 prepare_trajectories 日志判 None。容器内只做测试性验证，结论固化到报告/PR。
+- **代码确认（本地仓库）**：huggingface_tokenizer.py `eod` property（315 行）`if eos_token is None: return None`；`eos_id`（310 行）无 None 检查直接 `tokens_to_ids([None])`（更脆）。build_tokenizer.py 不传 eos_token 给 HF 包装类。
+- **日志位置**：/tmp/rl4-train.log 4251-4261 行。run 10 进程已退出（ran out，无残留）。
+
+## 2026-08-17 第八轮（run 11-13）：阻塞 M 数据层解 + 阻塞 N（TE 必需）→ **RL E2E 全链路首次跑通（run 13, exit 0）**
+
+**阻塞 M（已解，纯数据层，无 megatron core 改动）：** 用户质疑"改 megatron core 思路不对" → 重读代码发现包装类 `HuggingFaceTokenizer.add_special_tokens` 有**拷贝回环**（huggingface_tokenizer.py:208-209：`for k in self.tokenizer.SPECIAL_TOKENS_ATTRIBUTES: setattr(self, k, getattr(self.tokenizer, k, None))`，在 __init__ 末尾执行）→ `self.eos_token = eos_token`（None kwarg）会被底层 HF tokenizer 的 eos_token 覆盖。**因此只需数据层修复：** tokenizer_config.json 声明 `bos_token/eos_token/unk_token = "<|endoftext|>"`（容器 /tmp/rl-env/gpt2-tokenizer/tokenizer_config.json，仅测试用途）→ HF AutoTokenizer 报 eos → 拷贝回环传播到包装类。
+
+- **容器内验证（rl4-tokcheck.py）**：`type: GPTTokenizer / HuggingFaceTokenizer`，`inner eos_token: '<|endoftext|>'`，`inner eos_id: 50256`，`tok.eod: 50256`，`tok.eos_id: 50256`，`tok.pad_id: None`，`tok.bos_id: 50256`，`vocab_size: 50258`（pad 已加入），`eod detokenize: '<|endoftext|>'`。✅
+- **run 11 实测确认**：日志 2185-2186 行 `Tokenizer PAD: '<|finetune_right_pad_id|> (50257)'` / `Tokenizer EOD: '<|endoftext|> (50256)'` —— 正是 run 10 崩溃点（rl_utils.py:1085 detokenize），完全通过。**未改任何 megatron core 代码。** 用户判断正确。
+- **固化的意义**：这是**数据集/tokenizer 配方要求**——gpt2 系（无 eos 元数据）需 tokenizer_config.json 声明 eos/bos/unk；qwen3 系天然带 eos，无需处理（CI 永不踩 M）。
+- **代码级发现（降级为 minor，供 MLF）**：`eos_id`（huggingface_tokenizer.py:310-312）无 None 检查直接 `tokens_to_ids([None])`（比 eod 更脆）；build_tokenizer.py 不传 eos/bos/pad kwarg（包装类靠拷贝回环自愈）。
+
+**阻塞 N（参数组合，已解）：** run 11 过 M 后崩在 GRPO 数据准备：`dot_product_attention.py:158 AssertionError: Packed sequence is not supported by DotProductAttention. Please use TEDotProductAttention instead.`
+
+- **根因**：`get_logprobs`（rl_utils.py:666-679）为 CUDA graph signature 一致**无条件构造 thd 格式 packed_seq_params**（sequence_packing=False 时也构造单序列 thd），传给 model → **local impl 的 DotProductAttention 断言炸**。RL 训练 forward 强制 thd packed → 只有 `TEDotProductAttention`（TE）支持。
+- **run.sh 参数错误**：`--transformer-impl te` 非法（choices: local/transformer_engine/inference_optimized）→ run 12 参数解析即退。
+- **处置（已生效，run 13）**：`--transformer-impl transformer_engine` + 去掉 `--attention-backend unfused`（local 时代 DCU 基线，TE 线不需要）。TE 2.10.0+das.opt1.dtk2604.torch290 import 验证 OK（container 内 `import transformer_engine as te`）。
+- **CI 对照**：CI qwen3-8b 不传 transformer-impl → 默认 transformer_engine → 天然不炸；CI 从没覆盖 local impl 的 RL 训练 forward。**结论：RL 训练 forward 必须 TE，local 走不通——与"RL 用 TE 方向已定"一致。**
+- **平台依赖警示（用户 2026-08-17 强调）**：TE 不安装跑不起来是**另一个问题**，要记下来——**并不是所有后端都有厂商提供的 TE**。hygon 有 vendor TE repack（已闭环交付），但其他无 vendor TE 的平台走 RL 训练 forward 会卡在这里（要么 MLF 支持 local 的 thd packed，要么平台自建 TE）。
+
+**run 13 = RL E2E 全链路首次跑通（exit 0）：** tokenizer 初始化 → NCCL → 模型构建（TE）→ env agent 装载 → rollout 收集 → prepare_trajectories（PAD/EOD 日志正常）→ **compute_logprobs_batch TE forward 训练（run 11 崩溃点）** → 2 次训练迭代 → `[exiting program at iteration 2]`，0 Traceback，text-gen 前端干净关闭（"Inference Coordinator: shut down successfully"）。日志 /tmp/rl4-train.log（2026-08-17 11:34-11:36）。**RL 场景在 hygon 全链可跑。**
+
+**补充复核（flash-attn 断言实证通过）：** run 13 过后对 §5.1 的动态引擎 flash-attn 断言做容器内实测——`flash_attn.__version__` = `"2.8.3"`（`__init__.py` 首行），`get_fa_version()` = 2.8.3 ≥ 2.7.3 → `is_fa_min_version("2.7.3")` = True，`HAVE_FA3` = False（无 flash_attn_3/flashattn_hopper）但 or 分支满足。**§5.1 上文记的"__version__ 硬编码 2.6.1"来自更早容器/轮子状态，在当前已验证容器不成立（已实证 2.8.3）**。报告 §5.1/§5.6 已按此修正：动态引擎 flash-attn 断言不再是 RL 阻塞，阻塞链止于 TE 要求。
+
+## 待办/开放问题
+
+- [ ] **阻塞 M 已解（2026-08-17，run 11 确认）**：数据层修复（tokenizer_config.json 声明 eos/bos/unk）+ 包装类拷贝回环（huggingface_tokenizer.py:208-209）→ eod=50256 正常。gpt2 系 tokenizer 配方要求写进报告；`eos_id` 无 None 兜底是 MLF minor 发现。**已关闭**
+- [ ] **阻塞 N 已解（2026-08-17，run 13 确认）**：RL 训练 forward 强制 thd packed → **必须 `--transformer-impl transformer_engine`**，local 走不通；`--attention-backend unfused` 移除。**平台依赖警示（用户定）：不是所有后端都有厂商 TE** —— 无 vendor TE 平台需 MLF 支持 local 的 thd packed 或平台自建 TE，写入报告。**已关闭**
+- [ ] **阻塞 L 已解记录**：`--tokenizer-special-tokens '<|finetune_right_pad_id|>'`（必加引号）是 gpt2 无 pad 场景的 CLI 解法；prepare_trajectories 无 pad 兜底是 MLF 代码发现（rl_utils.py:1055-1071）
+- [ ] **quart + hypercorn 缺口固化**（2026-08-17 实测，阻塞 I）：text_generation_server.py:58 硬依赖 quart，pyproject 声明在 dev extra（pyproject.toml:132/130），`rl` extra 没带 → build-infra 侧 configs.yaml deps 声明（含进 RL 公共包组）
+- [ ] **datasets/pyarrow 组合验证**（2026-08-17 实测，阻塞 H）：datasets 5.0.1 save_to_disk → load_dataset("arrow") 往返在 pyarrow ≤25 下损坏（零长终止符误读）；容器内已用 pa.ipc.new_stream 手工重写绕过。MLF CI 的 artifact 生成须验证 (datasets, pyarrow) 组合；若 MLF 侧 pin datasets 需连带测 pyarrow
+- [ ] **transformers 缺口固化**（2026-08-17 实测）：HuggingFaceTokenizer 需要 transformers，pyproject 仅 training extra 有，`rl` extra 没带（pyproject.toml:91）→ build-infra 侧 configs.yaml deps 或 MLF rl extra 声明；另有代码缺陷 HAVE_TRANSFORMERS 未使用（huggingface_tokenizer.py）
+- [ ] **pyzmq + msgpack 缺口固化**（2026-08-17 实测，阻塞 G）：InferenceCoordinator 路径硬依赖（dynamic_engine.py:477/481），pyproject 均未声明 → build-infra 侧 configs.yaml deps 声明（含进 RL 公共包组）
+- [ ] **python3-config 已固化，等 wheel 重建生效**：builder 的 patch-compile-helpers-sysconfig.py 已就位（PR #112 同款），rl-v4 的 20260814 wheel 早于补丁；下次 wheel 重建后此阻塞自动消失（重装新 wheel 验证）
+- [ ] **apex 纳入 hygon runtime 镜像**（用户定）：上传 wheel 到 `flagos-pypi-hygon` + configs.yaml hygon deps 加 `apex==1.7.0+das.opt1.dtk2604.torch290` → 构建流程可重复安装
+- [ ] tensorboard 缺口固化到可重复流程（build-infra 侧声明，版本对齐 MLF pin 2.19.0？）
+- [ ] RL 完整接入 TE 实测（rl-v4 继续），逐段暴露并固化依赖缺口
+- [ ] MLF 侧 PR（feat/rl-optdeps-verify）保持开放，供 MLF 采纳


### PR DESCRIPTION
将 `packaging/megatron/docs/megatron-hygon25-e2e.md` 重组为可复用的三层报告模板，作为后续平台验证报告的结构范本。

**结构变化：**
- §0 Summary —— 结论 + 四场景状态表 + 教训清单（每条一两句，指向引用章节）
- §1 全局性问题 —— 打包范围 / 未声明依赖 / vendor 包问题（flash_attn、transformer_engine、modelopt 逐包归纳全部修改）/ 平台移植性默认值 / 工具链 / 环境
- §2~§5 分场景 —— training（含运行参数基线表）/ post_training / inference / rl（最后，最长）
- §6 跟踪事项 —— 已提交 PR / 待反馈 / 待决策（从 Summary 移出）

**每条问题按统一模板**：现象 → 原因 → 解决方案 → 注意事项 → 现在状态。

**配套：** 新增 `docs/memory/rl-verify-worklog.md`（验证事实源）并登记到 MEMORY.md 索引。

已删过程性叙述（阻塞编号、run 编号、评价性文字、报告自我说明），保留可复现的命令、参数、版本与处置。

This PR was written in part with the assistance of generative AI.