### PR TITLE
docs(vllm): mthreads MUSA 4.3.6 rebuilt-image re-verify — F path ✅ (flagtree 0.6.1) + torchvision guard (0.24.0 OOT gap)

### DIFF
--- a/packaging/vllm/docs/report-vllm-0.24.0.md
+++ b/packaging/vllm/docs/report-vllm-0.24.0.md
@@ -452,11 +452,18 @@ MUSA 平台走插件路径（`PlatformFL` → device_type `musa`、dist_backend 
 - **`kernel_warmup` 无条件 import `minimax_m3_msa_warmup`**：
   import 链到达 `torchvision.transforms`（`transformers_utils/processors/
   minimax_m3.py`），而 OOT Runtime 不装 torchvision（装它必然覆盖厂商匹配的
-  torch 矩阵）。该 warmup 对非 MiniMaxM3 模型是 no-op，try/except 门控 +
-  调用处判空即可。
-- **这是换到 v0.3.0-dev 后仍需要的唯一补丁** —— 它属于 vLLM 0.24.0 wheel
-  本身（site-packages），不属插件，不能进 vllm-plugin-FL PR。
-  归属待定：进 repack 步骤（wheel 里直接打）还是 runtime 层（镜像装 torchvision）。
+  torch 矩阵）。该 warmup 对非 MiniMaxM3 模型是 no-op。
+- **归属已定：进插件调用侧（PR #386）** —— `kernel_warmup` 调用点在插件
+  `vllm_fl/worker/worker.py`，在调用处 `try/except ImportError` 门控即可，
+  不改 vllm wheel（wheel 保持与上游逐字节一致），也不在镜像里装 torchvision。
+  这是 **0.24.0 全部无 torchvision OOT 后端（cambricon×2、hygon、ascend×2、
+  mthreads×2）的通用前置修复**，见 §9.4。
+- **早期 serve "零补丁" 的诚实注记**：5.2.0（§8.2）与 4.3.6 首轮（§9.2）
+  的 serve 成功，实际依赖节点侧就地改写 site-packages 的
+  `kernel_warmup.py`（`/tmp/patch_minimax_warmup.py`，不可复现），不是 wheel
+  内建能力；重建镜像的新容器不补丁必崩（torchvision ImportError）。
+  §8.2/§9.2 的"零补丁"仅指**插件**零补丁，vllm 在树补丁一直存在。
+  可复现路径 = 插件 guard（PR #386），重建镜像后已按此路径重验（§9.4）。
 
 ### 8.4 验证过程要点
 
@@ -467,11 +474,11 @@ MUSA 平台走插件路径（`PlatformFL` → device_type `musa`、dist_backend 
   先清 `__pycache__` 再 `pip install -e . --no-build-isolation`
   （head 构建依赖 `torch>=2.7.1`、`scikit-build-core==0.11`、`cmake`，
   必须 `--no-build-isolation`，否则 pip 隔离环境会从公共源拉 torch 覆盖矩阵）。
-- **serve 启动逐级打通**（v0.3.0-dev）：EngineCore 初始化（`device_config=musa`、
-  `backend=mccl`，DP/PP/PCP/TP rank 分配）→ 插件 OpManager
-  （10 ops / 14 implementations，attention_backend `default.flagos` →
-  `vendor.musa`）→ 权重加载（safetensors 2/2，约 5 秒）→ KV cache 初始化
-  → kernel_warmup（在树门控仍生效）→ `Application startup complete`。
+- **serve 启动逐级打通**（v0.3.0-dev + torchvision guard）：EngineCore 初始化
+  （`device_config=musa`、`backend=mccl`，DP/PP/PCP/TP rank 分配）→ 插件
+  OpManager（10 ops / 14 implementations，attention_backend `default.flagos`
+  → `vendor.musa`）→ 权重加载（safetensors 2/2，约 5 秒）→ KV cache 初始化
+  → kernel_warmup（插件 guard 门控，见 §9.4）→ `Application startup complete`。
   插件换装是 editable install（`.pth` + finder），`vllm-plugin-fl==0.0.0`；
   插件无 `.so`（csrc 仅 ascend/cuda，`vllm_fl._C` import 为 try/except 门控）。
 - **推理**：8031 端口两次请求均输出连贯 chain-of-thought（DeepSeek-R1
@@ -484,7 +491,7 @@ MUSA 平台走插件路径（`PlatformFL` → device_type `musa`、dist_backend 
 - 节点：`mthreads`（JumpServer → 10.121.38.24），用户 `secure`
 - 容器：`vllm-verify-mthreads-musa4.3.6`，MUSA SDK 4.3.6（torch 2.9.0+musa.4.3.6）
 - venv：`/flagos`（cpython-3.10 —— 与 5.2.0 同为 cp310 wheel）
-- 插件：v0.3.0-dev head（零补丁），editable install 于 `/opt/vllm-plugin-FL`
+- 插件：v0.3.0-dev head + torchvision guard（PR #386），editable install 于 `/opt/vllm-plugin-FL`
 - 模型：`/data/DeepSeek-R1-0528-Qwen3-8B-FlagOS`
 - 端口：8031
 
@@ -493,13 +500,20 @@ MUSA 平台走插件路径（`PlatformFL` → device_type `musa`、dist_backend 
 同 §8.1 —— 单步安装 `vllm==0.24.0+flagos`（cp310 wheel，命中 `+flagos`
 wheel，无 torch 侧漏）；`pin_indirect: {xgrammar: "0.2.3"}` 同。
 
-### 9.2 插件基线：v0.3.0-dev 零补丁
+### 9.2 插件基线：v0.3.0-dev + torchvision guard
 
-同 §8.2 —— v0.3.0-dev head（fbc115d），零补丁。serve 启动链与 5.2.0 一致：
+插件 v0.3.0-dev head（fbc115d），除 **torchvision guard**（§8.3/§9.4，插件
+PR #386 的调用侧补丁）外零补丁。serve 启动链与 5.2.0 一致：
 OpManager **10 ops / 14 implementations** → attention_backend fallback
 `default.flagos` → `vendor.musa` → 权重加载 → `Application startup complete`。
 非致命遥测 fork 报错（`Cannot re-initialize MUSA in forked subprocess`）与
 §8.2 相同，不影响服务。
+
+**重建镜像复验（2026-08-17）**：configs bump（PR #414）后重建的镜像
+（flagtree 0.6.1 烘焙于 `/opt/flagtree`），新容器首次 serve 因 torchvision
+ImportError 崩溃（§9.4 首段）；应用插件 guard 后 F/T 双路径均重验 ✅
+（F 见 §9.3，T 见 §9.4 末段）。早期首轮 serve 记录在 §9.3 的 0.6.0/0.6.1
+实验中，仅作根因证据。
 
 ### 9.3 编译器路径判定
 
@@ -510,14 +524,14 @@ OpManager **10 ops / 14 implementations** → attention_backend fallback
   flag_gems `pow_scalar` → `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`。
   该内核在 **vendor triton 下编译通过**（op 级 repro 输出
   `OK [1.0, 1.01358..., 1.02735...]`）。
-- serve E2E ✅：`Application startup complete`；completions greedy 与
-  chat CoT 均连贯；指纹 `vllm-0.24.0-5936039f`（5.2.0 为
-  `vllm-0.24.0-423da8ca`）。
+- serve E2E ✅（重建镜像复验 2026-08-17）：`Application startup complete`；
+  completions greedy 与 chat CoT 均连贯；指纹 `vllm-0.24.0-5936039f`
+  （5.2.0 为 `vllm-0.24.0-423da8ca`）。
 - 验证模型为 DeepSeek-R1-0528-Qwen3-8B-FlagOS（mthreads 节点无 Qwen3-4B），
   矩阵"Qwen3-4B"约定在此单元格不适用；原始 completions 直给 R1 模型 +
   temperature 0.6 的整段重复回声是模型行为伪影（同 §8.2）。
 
-**F 路径 ✅（flagtree 0.6.1；configs 现 pin 0.6.0 需 bump）**：
+**F 路径 ✅（flagtree 0.6.1 烘焙镜像，重建后复验）**：
 
 1. **0.6.0 的失败（双层根因，镜像原状）**：
    a. **flag_gems 拦截 pow → flagtree codegen 失败**：`base ** pos_freqs` →
@@ -535,7 +549,7 @@ OpManager **10 ops / 14 implementations** → attention_backend fallback
       `RuntimeError: tensor.device().is_cpu() INTERNAL ASSERT FAILED at
       pybind_utils.cpp:590` —— torch 2.9.0+musa.4.3.6 无法处理 Python float
       底数 ** MUSA 张量指数。
-2. **0.6.0→0.6.1 实验（2026-08-17）确认修复**：同一容器手动替换 flagtree
+2. **0.6.0→0.6.1 实验（2026-08-17）确认根因**：同一容器手动替换 flagtree
    为 **0.6.1+mthreads3.6**（whl `flagtree-0.6.1+mthreads3.6-cp310-cp310-...`，
    安装到 `/opt/flagtree061` 后整体替换 `/opt/flagtree`，原 0.6.0 保留在
    `/opt/flagtree060`）后：
@@ -544,24 +558,47 @@ OpManager **10 ops / 14 implementations** → attention_backend fallback
    - serve E2E ✅：`Application startup complete`（OpManager 10 ops / 14
      impls，rms_norm / silu_and_mul 走 `default.flagos`），completions greedy
      + chat CoT 均连贯；指纹 `vllm-0.24.0-5936039f`（同 T 路径，同容器同插件）。
+3. **烘焙镜像复验（2026-08-17，configs bump #414 已合并）**：configs.yaml
+   bump 后重建的镜像把 **0.6.1+mthreads3.6 烘焙于 `/opt/flagtree`**（不再
+   手动替换）。F 路径（`compiler flagtree`）+ 插件 torchvision guard 下
+   serve 到 `Application startup complete`、completions greedy + chat CoT
+   均连贯、指纹 `vllm-0.24.0-5936039f`，与 T 路径完全一致。✅
 
 结论：`self.base ** pos_freqs` 在 flagtree **0.6.1** 下可用 —— 0.6.0→0.6.1
 即修复（不再对 `tl.exp2` 发出 vendor llc 不可选择的 `v2f32 = fexp2`）。
-**configs.yaml 4.3.6 现 pin flagtree==0.6.0（F 路径坏），需 bump 到 0.6.1
-并重建镜像后，单元格才对应交付物。** 5.2.0 自始即 0.6.1（§8，F 路径 ✅），
-两者对齐后 mthreads 平台 F 路径全线一致。
+configs bump（PR #414）已合并、镜像已重建，4.3.6 F 路径对应交付物验证完成；
+5.2.0 自始即 0.6.1（§8，F 路径 ✅），mthreads 平台 F 路径全线一致。
+
+### 9.4 torchvision guard：0.24.0 通用 OOT 前置（插件 PR #386）
+
+- **现象**：重建镜像的新容器（flagtree 0.6.1 烘焙）首次 serve 在 EngineCore
+  init 崩溃 —— vllm 0.24.0 `kernel_warmup()` 无条件 import
+  `minimax_m3_msa_warmup`，import 链到达 `torchvision.transforms`
+  （§8.3），OOT runtime 不装 torchvision → `ImportError: No module named
+  'torchvision'`。
+- **为什么 5.2.0 / 4.3.6 早期 serve 没崩**：那些容器在节点侧就地改写
+  site-packages 的 `kernel_warmup.py`（`/tmp/patch_minimax_warmup.py`）——
+  不可复现，不属于任何 wheel。**重建镜像的新容器即复现**，排除了
+  "wheel 自带补丁" 的误判。
+- **修复（插件调用侧，PR #386）**：`kernel_warmup(self)` 调用处
+  `try/except ImportError` 门控 + warning（warmup 对非 MiniMaxM3 是 no-op）。
+  不改 vllm wheel（与上游逐字节一致），不装 torchvision（不污染厂商 torch
+  矩阵）。**影响全部无 torchvision OOT 后端**：cambricon×2、hygon、
+  ascend×2、mthreads×2。
+- **复验**：同一新容器应用 guard 后（`/opt/vllm-plugin-FL/vllm_fl/worker/
+  worker.py`，与 PR #386 逐字相同，compile OK）→ F/T 双路径 serve 均到
+  `Application startup complete`、推理连贯、指纹 `vllm-0.24.0-5936039f`。
 
 ---
 
 ## 10. 遗留事项
 
 - [ ] `setuptools 84.0.0` 不满足 pyproject 中 `<81` 要求 —— 非致命问题，先不动，留意。
+- [ ] **插件 PR #386（torchvision guard）合入 v0.3.0-dev** —— 0.24.0 其余
+      OOT 后端（cambricon、hygon、ascend）验证前必须先合（§9.4）。
 - [ ] 0.24.0 其余后端（hygon、iluvatar、enflame、sunrise、cambricon、
       ascend、kunlunxin 等）的验证 —— mthreads（§8 5.2.0 全通；§9 4.3.6
-      T ✅ / F ✅*，`*` = flagtree 0.6.1 验证、configs 待 bump）；nvidia ✅（§6）
-- [ ] mthreads-musa4.3.6 **configs.yaml flagtree 0.6.0→0.6.1 bump** + 镜像
-      重建 —— 0.6.1 已验证修复 F 路径（§9.3），0.6.0 构建的镜像 F 路径
-      仍不可用，重建后矩阵 `✅*` 才对应交付物
+      T ✅ / F ✅，烘焙镜像双路径复验 2026-08-17）；nvidia ✅（§6）
 
 ---
 

--- a/packaging/vllm/docs/vllm-verification-matrix.md
+++ b/packaging/vllm/docs/vllm-verification-matrix.md
@@ -17,7 +17,6 @@
 | — | 该后端无此编译器 |
 
 列名后缀：T = Triton 编译器，F = FlagTree 编译器。
-`*` = 单元格存在前置条件（flagtree 版本），见事实 bullet 与报告 §9。
 
 ## 矩阵
 
@@ -36,7 +35,7 @@
 | 昆仑芯 | XRE 5.37.1 | ⛔ | ⛔ | ⬜ | ⬜ |
 | 沐曦 | MACA 3.7.2.1 | ⬜ | ✅ | ✅ | ✅ |
 | 沐曦 | MACA 3.8.1.3 | ⬜ | ⬜ | ✅ | ✅ |
-| 摩尔线程 | MUSA 4.3.6 | ⬜ | ⬜ | ✅ | ✅* |
+| 摩尔线程 | MUSA 4.3.6 | ⬜ | ⬜ | ✅ | ✅ |
 | 摩尔线程 | MUSA 5.2.0 | — | ✅ | ✅ | ✅ |
 | 进迭时空 | SPACEMIT | ⬜ | — | ⬜ | — |
 | 曦望 | TANGRT 1.2.0 | ✅ | ❌ | ⬜ | ⬜ |
@@ -108,7 +107,7 @@
   `get_top_k_top_p` 与 `pool` 的 UVA CPU 索引 + 移回设备；新 SDK（triton 3.6.0）无需。
 - **0.24.0 其余后端待验证**：hygon, iluvatar, enflame, sunrise,
   cambricon, ascend, kunlunxin 等。
-- **mthreads-musa5.2.0** ✅✅（2026-08-16~17，v0.3.0-dev 零补丁）：
+- **mthreads-musa5.2.0** ✅✅（2026-08-16~17，v0.3.0-dev 零插件补丁）：
   F 路径 ✅（2026-08-16，默认 flagtree 3.6.0）+ T 路径 ✅（2026-08-17，
   `compiler triton` → vendor triton 3.6.0，musa backend）。两条路径均
   OpManager 10 ops/14 impls、attention fallback `vendor.musa`、serve 到
@@ -116,27 +115,31 @@
   **注意：验证模型为 DeepSeek-R1-0528-Qwen3-8B-FlagOS**（mthreads 节点无
   Qwen3-4B），矩阵"Qwen3-4B"约定在此单元格不适用，详见
   `report-vllm-0.24.0.md` §8。
+  **serve 期的 torchvision 依赖经节点侧就地 patch 绕过（不可复现）**：
+  该次 `kernel_warmup` 崩溃被就地改写 `kernel_warmup.py` 绕过，非 wheel
+  内建能力；可复现修复 = 插件 guard（PR #386），见跨版本事实。
   **早期 "T 路径不可用" 注记作废**：`No module named 'triton.backends.mthreads'`
   是裸 `compiler`（status）探测的 bug —— `_compiler_import_triton` prepend
   不清除已在 PYTHONPATH 的另一个 side dir，导致 entry-point 混叠
   （flagtree 声明 `mthreads` backend、/opt/triton 声明 `musa`），
   切换路径本身干净。已修 `runtime/zz-compiler.sh`（PR #411）。
-- **mthreads-musa4.3.6**（2026-08-17，v0.3.0-dev 零补丁，python 3.10）：
+- **mthreads-musa4.3.6**（2026-08-17，v0.3.0-dev + 插件 torchvision guard，python 3.10）：
   **T 路径 ✅** —— `compiler triton` → vendor triton 3.6.0+git89458660，
   同一 pow 内核编译通过，serve 到 `Application startup complete`、推理连贯，
   指纹 `vllm-0.24.0-5936039f`（5.2.0 为 `vllm-0.24.0-423da8ca`）。
   验证模型同为 DeepSeek-R1-0528-Qwen3-8B-FlagOS（矩阵"Qwen3-4B"约定
   在此单元格不适用，同 §8）。
-  **F 路径 ✅*（flagtree 0.6.1，2026-08-17 实验确认）**：同一容器手动替换
-  flagtree 0.6.0 → **0.6.1+mthreads3.6** 后，同一 pow 内核（flag_gems
-  `pow_scalar` → `pow_func_scalar_tensor_kernel_rank_1_bptr_t1024`，`tl.exp2`）
-  编译通过 —— 0.6.0 下报 `LLVM ERROR: Cannot select: v2f32 = fexp2`
-  （vendor llc `-march=mtgpu -mcpu=mp_31`）SIGABRT，0.6.1 下无此问题；
-  serve 到 `Application startup complete`、completions greedy + chat CoT 均
-  连贯（op 级 repro `OK [1.0, 1.01358..., 1.02735...]`）。
-  **`*` 前提：configs.yaml 4.3.6 现 pin flagtree==0.6.0**（F 路径坏），
-  需 bump 到 0.6.1 后重建镜像，单元格才对应交付物；0.6.0→0.6.1 差异即
-  根因（见 `report-vllm-0.24.0.md` §9）。
+  **F 路径 ✅（flagtree 0.6.1 烘焙镜像，重建后复验）**：configs bump
+  （PR #414）已合并、镜像已重建（0.6.1+mthreads3.6 烘焙于
+  `/opt/flagtree`）。重建镜像 F 路径（`compiler flagtree`）serve 到
+  `Application startup complete`、completions greedy + chat CoT 均连贯、
+  指纹 `vllm-0.24.0-5936039f`，同 T 路径。0.6.0→0.6.1 即 pow 内核修复
+  （`v2f32 = fexp2`，见 `report-vllm-0.24.0.md` §9.3）。
+  **torchvision guard（插件 PR #386）为本次 F 路径 serve 的前置**：重建镜像
+  新容器首次 serve 因 vllm 0.24.0 `kernel_warmup` 无条件 import
+  minimax_m3_msa_warmup → torchvision（OOT runtime 不装）而崩；
+  早期 4.3.6/5.2.0 serve 成功依赖节点侧就地 patch（不可复现）。修复落在
+  插件调用侧，详见 §9.4 与跨版本事实。
 
 **跨版本事实**
 
@@ -146,6 +149,12 @@
   wheel 在 cuda13.3（torch 2.11.0+cu130）上单步安装运行 ✅。
   是否可跨 OS/架构（如 aarch64）仍待验证。
 - 所有适配补丁收敛在 vllm-plugin-FL 插件侧，不修改官方 vLLM。
+- **torchvision 依赖（0.24.0 通用 OOT 缺口）**：`kernel_warmup()` 无条件
+  import minimax_m3_msa_warmup → torchvision。OOT runtime（cambricon×2、
+  hygon、ascend×2、mthreads×2）不装 torchvision（会覆盖厂商 torch 矩阵），
+  因此 vllm 0.24.0 在全部无 torchvision 后端首次 serve 都会在 EngineCore
+  init 崩溃。修复在插件调用侧（PR #386，`try/except ImportError` skip，
+  warmup 对 MiniMaxM3 以外的模型是 no-op）。详见 `report-vllm-0.24.0.md` §9.4。
 
 ## 已知问题 / 阻塞
 
@@ -153,10 +162,6 @@
   （TritonSDNN pass 链 / XTDK 后端断言），应用层无法绕过。
 - **sunrise**：flagtree flash-attn decode 挂死，已交 FlagTree 团队；
   交付固定走官方 Triton。
-- **mthreads-musa4.3.6**：flagtree **0.6.0** 对 pow 内核发出 vendor llc
-  不可选择的 `v2f32 = fexp2`；黑名单排除后原生 torch pow
-  （torch 2.9.0+musa.4.3.6）亦损坏。**0.6.1 已验证修复**（F 路径 ✅*）；
-  阻塞项转为 configs.yaml 4.3.6 flagtree 0.6.0→0.6.1 bump + 镜像重建。
 - **iluvatar**：推理乱码根因在厂商工具链过旧（torch 2.7.1），非编译器层问题。
 - **enflame**：策略性不用 flagtree（不信任），走 vendor triton + native FLASH_ATTN。
 


### PR DESCRIPTION
## Summary

Follow-up to #413 after the configs bump (#414) merged and the mthreads-musa4.3.6
runtime image was rebuilt with flagtree 0.6.1 baked in at `/opt/flagtree`.

Re-verified **both compiler paths on the rebuilt image** (2026-08-17, vLLM 0.24.0
empty-mode wheel + vllm-plugin-FL v0.3.0-dev, python 3.10, MTT S5000,
DeepSeek-R1-0528-Qwen3-8B-FlagOS):

- **F path (flagtree 0.6.1)** — `compiler flagtree` serves to `Application
  startup complete`, greedy + chat CoT coherent, fingerprint
  `vllm-0.24.0-5936039f`.
- **T path (vendor triton 3.6.0)** — same pow kernel compiles, startup complete,
  fingerprint `vllm-0.24.0-5936039f`.

Both paths now verified against the actual deliverable (rebuilt image), so the
matrix 4.3.6 F column moves `✅*` → `✅` and the `*` legend (flagtree-version
precondition) is dropped. The fexp2 blocker bullet is removed as resolved.

## torchvision guard — 0.24.0 general OOT gap

A fresh rebuilt-image container exposed that vLLM 0.24.0's `kernel_warmup()`
unconditionally imports `minimax_m3_msa_warmup` → `torchvision`, which no OOT
runtime ships (installing it would overwrite the vendor-matched torch matrix),
so first serve crashes at EngineCore init on every no-torchvision backend
(cambricon×2, hygon, ascend×2, mthreads×2). This is now documented as a
cross-version fact and in report §9.4. The reproducible fix lives in the plugin
call site (vllm-plugin-FL #386, `try/except ImportError` skip — the warmup is a
no-op for any model other than MiniMaxM3). The report also carries an honest
note that the earlier 5.2.0/4.3.6 "zero-patch" serves relied on node-side
in-place patching of `kernel_warmup.py` (not reproducible, not in any wheel).

## Files

- `packaging/vllm/docs/vllm-verification-matrix.md` — legend, 4.3.6 row,
  5.2.0/4.3.6 facts bullets, blocked section, cross-version fact.
- `packaging/vllm/docs/report-vllm-0.24.0.md` — §8.3, §9.2, §9.3 (new rebuilt-image
  re-verify item), new §9.4, §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
