### PR TITLE
docs(megatron): record hygon non-RL scenarios re-verified on triton 3.5.1

### DIFF
--- a/packaging/megatron/docs/megatron-hygon25-e2e.md
+++ b/packaging/megatron/docs/megatron-hygon25-e2e.md
@@ -22,7 +22,8 @@ attention。
 ## 0. Summary
 
 **结论：** 四个场景全部打通。training / post_training / inference 由全范围
-wheel 单步安装直跑，均 exit 0；rl 场景耗时最长——未声明依赖与厂商包问题逐一解决后，全链路首次跑通 exit 0。
+wheel 单步安装直跑，均 exit 0，并已在 vendor triton 3.5.1（PR #404 升级后）
+下全部复验通过（2026-08-17）；rl 场景耗时最长——未声明依赖与厂商包问题逐一解决后，全链路首次跑通 exit 0。
 
 | 场景 | 状态 | 一句话事实 |
 |---|---|---|
@@ -137,7 +138,10 @@ vendor 包（`flagos-pypi-{vendor}` 上我们掌控、可 repack）的问题分�
 - **现象:** post_training 场景依赖 modelopt（HARD 依赖）。
 - **原因:** 仅 enflame 有 vendor 变体（`enflame-modelopt`）；NVIDIA 用
   NVIDIA modelopt 可用，其余后端成功率不确定。
-- **处置:** `--no-deps` ad-hoc 装入 runtime venv，**未入镜像**——与其余场景的"单步安装 wheel 即可用"不同，违反交付目标。
+- **处置:** 带依赖解析 ad-hoc 装入 runtime venv（aliyun 镜像；PuLP/
+  antlr4-python3-runtime-4.9.3/nvidia-ml-py/omegaconf/scipy 随装，torch
+  2.9.0 落位未动），**未入镜像**——与其余场景的"单步安装 wheel 即可用"
+  不同，违反交付目标。
 - **现在状态:** 纳入镜像与否待镜像层决策。
 
 #### 1.3.4 triton 3.5.1+das.opt1.dtk2604.torch290（torch 依赖剥除）
@@ -212,7 +216,14 @@ vendor 包（`flagos-pypi-{vendor}` 上我们掌控、可 repack）的问题分�
 ## 2. training
 
 **结论:** 全范围 wheel 单步安装直跑 `pretrain_gpt.py`，exit 0（无需 repo
-checkout；`megatron.training` 已在 wheel 中，§1.1）。
+checkout；`megatron.training` 已在 wheel 中，§1.1）。**3.5.1 复验通过
+（2026-08-17）**：`compiler triton` 下 mock data 5 iter 全跑完 exit 0
+（loss 1.084036E+01 → 1.083188E+01，lr 1e-6 constant 下降极小符合预期；
+3.3.0 时代 loss 9.1295→8.8622 因当时参数/初始化不同不直接可比），参数 =
+本节省 DCU 基线（--no-masked-softmax-fusion --disable-jit-fuser
+--no-persist-layer-norm --no-gradient-accumulation-fusion
+--attention-backend unfused --transformer-impl local --bf16）+
+--untie-embeddings-and-output-weights + seed 42。
 
 **可复现运行参数基线**（DCU 上完整跑通 megatron 训练的最小 flags / 容器配置；rl 场景引用，并在 §5 中给出 RL 特有参数）：
 
@@ -250,16 +261,25 @@ checkout；`megatron.training` 已在 wheel 中，§1.1）。
 ## 3. post_training
 
 **结论:** driver 跑通（post_training surface 全 import + `simple_generate`，
-输出 shape=(1, 8)，exit 0）。
+输出 shape=(1, 8)，exit 0）。**3.5.1 复验通过（2026-08-17）**：`compiler
+triton` 下同一 driver exit 0，输出 shape=(1, 8)，与 3.3.0 时代事实一致；
+checkpointing.py:7 模块级 `import modelopt.torch` 由 ad-hoc 装入的
+nvidia-modelopt 0.45.0 满足。
 
-- **前提:** nvidia-modelopt 以 `--no-deps` ad-hoc 装入 runtime venv，**未入镜像**——与其余场景的"单步安装 wheel 即可用"不同，违反交付目标（§1.3.3）。
+- **前提:** nvidia-modelopt 0.45.0 带依赖解析 ad-hoc 装入 runtime venv
+  （aliyun 镜像：PuLP/antlr4-python3-runtime-4.9.3/nvidia-ml-py/omegaconf/
+  scipy 随装，torch 2.9.0 落位未动），**未入镜像**——与其余场景的"单步安装
+  wheel 即可用"不同，违反交付目标（§1.3.3）。
 - **注意:** modelopt 是唯一有 vendor 变体的 HARD 依赖；其余后端成功率不确定（§1.3.3）。
 
 ## 4. inference
 
 **结论:** `StaticInferenceEngine(controller, legacy=True)`，3 请求 × 8 tokens
 （`prompt_tokens` 直接注入 `InferenceRequest`，绕过 NullTokenizer 无
-`tokenize()` 的限制），generate 4.2s，exit 0。
+`tokenize()` 的限制），generate 4.2s，exit 0。**3.5.1 复验通过（2026-08-17）**：
+同构 driver 生成 4s（tqdm 3/3 [00:04, 1.49s/it]），与 3.3.0 时代 4.2s 吻合；
+NullTokenizer 无 detokenize，复验 driver 补最小实现（controller.detokenize
+无条件 `inspect.signature`，text_generation_controller.py:209）。
 
 - **正面经验:** legacy 静态引擎路径保留 `StaticInferenceContext` →
   `is_static_batching()=True` → attention.py static 分支

--- a/packaging/megatron/docs/megatron-verification-matrix.md
+++ b/packaging/megatron/docs/megatron-verification-matrix.md
@@ -19,6 +19,11 @@
 > 注：hygon 的 F 列为 ⬜ 而非 ❌——flagtree 编译级可用（DTK LLVM 包后，
 > 与 triton 3.5.1 同源 dtk 特判），但 megatron 场景级 E2E 均未在 flagtree 下
 > 验证，可能有问题，待按场景复测（§1.4 `--disable-jit-fuser` 是否仍需同测）。
+>
+> 注：hygon 的 T 列均按当前 triton **3.5.1** 计——四场景（training/RL/
+> post_training/inference）已全部在 3.5.1 下 E2E 复验通过（2026-08-17）。
+> 编译器机制跨版本不移植（3.3.0 直出码无 clang 子进程 → 3.5.1 调外部
+> clang），3.3.0 时代结论仅作参考。
 
 ## 矩阵
 
@@ -51,11 +56,18 @@
 
 ## 已验证/已知事实
 
-- **hygon training**：vendor triton 3.3.0 ✅（E2E exit 0，loss 9.1295→8.8622）。
-  flagtree 3.6.0 **编译级可用**（DTK LLVM 包 PR #403 后，与 triton 3.5.1 同源
-  dtk 特判 aillvm/clang-18；flag_gems mm/addmm/mm-bf16 全过 diff 0.0）但
-  **场景级 E2E 未在 flagtree 下验证**——训练(F)=⬜。详见
-  [[megatron-hygon25-e2e.md]] 与 [[memory/hygon-compiler-mask]]。
+- **hygon training**：vendor triton **3.5.1** ✅（2026-08-17 复验：mock data
+  5 iter E2E exit 0，loss 1.084036E+01 → 1.083188E+01；3.3.0 时代已验证，但
+  编译器机制跨版本不移植，仅作参考）。flagtree 3.6.0 **编译级可用**（DTK
+  LLVM 包 PR #403 后，与 triton 3.5.1 同源 dtk 特判 aillvm/clang-18；
+  flag_gems mm/addmm/mm-bf16 全过 diff 0.0）但 **场景级 E2E 未在 flagtree
+  下验证**——训练(F)=⬜。详见 [[megatron-hygon25-e2e.md]] 与
+  [[memory/hygon-compiler-mask]]。
+- **hygon 编译器版本 × 场景 映射（2026-08-17）**：四场景 E2E 全部在 triton
+  **3.5.1** 复验通过（RL：run 13；training/post_training/inference：
+  2026-08-17 复验，exit 0）——**编译器机制跨版本不移植**（3.3.0 直出码无
+  clang 子进程 → 3.5.1 调外部 clang），3.3.0 时代结论仅作参考。inference
+  走 legacy 静态路径，编译器无关（§4）；T 列已逐格回填 ✅。
 - **hygon flagtree 场景级状态（2026-08-17 更正）**：曾判"屏蔽"系旧容器缺
   DTK LLVM 包所致，已证伪；现四场景 F 列一律 ⬜——编译级可用，场景级未验证，
   "可能有问题，不确定"，待按场景复测（含 §1.4 `--disable-jit-fuser`）。
@@ -63,16 +75,22 @@
   - **归属**：上游 **core_v0.17.0** 自己的代码（fork #34 忠实同步），非 fork 偏离。上游修复时点：0.17.0/0.17.1 = 3 处裸 import；0.18.0/0.18.2 = 2 处；main = 0（全部收敛进 `megatron/training/models/`）。
   - **状态**：全范围 wheel 从打包侧关闭阻塞，其余后端推理列仍 ⛔ —— 需 PR #107 合入后按序验证。结构性问题（决策4 关联："顶层文件作入口"模式不支持 wheel 包发布）仍然成立，但不阻塞交付。
 - **hygon inference**：`StaticInferenceEngine(legacy=True)` 路径 E2E 跑通
-  （3 请求 × 8 tokens，exit 0）。legacy 静态批处理走 `apply_module(core_attention)`
-  （DotProductAttention/sdpa），**不依赖 flash-attn、不编译 triton kernel**——
-  对 hygon 属编译器无关路径；推理(F)=⬜ 仅因未在 flagtree 下实测
-  （编译器无关，预期可跑）。
+  （3 请求 × 8 tokens，exit 0）——**3.5.1 复验通过（2026-08-17，生成 4s，
+  与 3.3.0 时代 4.2s 吻合）**。legacy 静态批处理走
+  `apply_module(core_attention)`（DotProductAttention/sdpa），**不依赖
+  flash-attn、不编译 triton kernel**——对 hygon 属编译器无关路径；推理(F)=⬜
+  仅因未在 flagtree 下实测（编译器无关，预期可跑）。
 - **hygon RL**：全链路 exit 0（vendor triton 3.5.1 + TE 2.10.0 vendor 变体）——
   tokenizer → NCCL 初始化 → TE 模型构建 → dynamic 引擎（cuda graph）→
   text-gen server → 2 训练迭代 → 退出。此前阻塞项已全部关闭：flash_attn
   断言（repack 三处版本串一致 → 2.8.3 满足 ≥2.7.3）、torch 落位 bug
   （repack 剥 torch 依赖）。RL(F)=⬜ 待在 flagtree 下复测。
-- **hygon post_training**：driver 跑通（post_training surface 全 import + `simple_generate`，exit 0）。前提是 nvidia-modelopt 已 ad-hoc 装入 runtime venv（`--no-deps`，**未入镜像**——违反"单步安装即可用"目标，modelopt 纳入与否待镜像层决策）。
+- **hygon post_training**：driver 跑通（post_training surface 全 import +
+  `simple_generate`，输出 shape=(1, 8)，exit 0）——**3.5.1 复验通过
+  （2026-08-17）**。前提是 nvidia-modelopt 0.45.0 已 ad-hoc 装入 runtime
+  venv（aliyun 带依赖解析：PuLP/antlr4-python3-runtime-4.9.3/nvidia-ml-py/
+  omegaconf/scipy；torch 2.9.0 落位未动；**未入镜像**——违反"单步安装即可用"
+  目标，modelopt 纳入与否待镜像层决策）。
 - **post_training 依赖**：modelopt 是唯一有 vendor 变体的 HARD 依赖（configs.yaml 仅 enflame 有 `enflame-modelopt`）；tqdm 纯 PyPI。NVIDIA 用 NVIDIA modelopt 可用；其余后端成功率不确定。
 - **rl 依赖**：模块级仅 pydantic + typing_extensions（纯 PyPI）；全树 0 处 triton/torch.compile，复用 training/core 的编译器链。**注意**：rl 场景阻塞不在依赖面而在推理引擎——dynamic 引擎硬依赖 flash-attn（§5.5；hygon 已由 vendor flash_attn 2.8.3 满足），属场景级缺口，非依赖面缺口。
 

--- a/packaging/megatron/docs/memory/rl-verify-worklog.md
+++ b/packaging/megatron/docs/memory/rl-verify-worklog.md
@@ -175,6 +175,41 @@ metadata:
 
 **补充复核（flash-attn 断言实证通过）：** run 13 过后对 §5.1 的动态引擎 flash-attn 断言做容器内实测——`flash_attn.__version__` = `"2.8.3"`（`__init__.py` 首行），`get_fa_version()` = 2.8.3 ≥ 2.7.3 → `is_fa_min_version("2.7.3")` = True，`HAVE_FA3` = False（无 flash_attn_3/flashattn_hopper）但 or 分支满足。**§5.1 上文记的"__version__ 硬编码 2.6.1"来自更早容器/轮子状态，在当前已验证容器不成立（已实证 2.8.3）**。报告 §5.1/§5.6 已按此修正：动态引擎 flash-attn 断言不再是 RL 阻塞，阻塞链止于 TE 要求。
 
+## 2026-08-17 3.5.1 复验（用户批准计划：Triton 升级后 RL 之外场景全测）
+
+**training(T) 复验 ✅（run: pretrain35，vendor triton 3.5.1）：** `compiler triton` 下
+`python -m pretrain_gpt`（wheel 内 py-module，full-scope wheel 0.17.1+fl.20260814）mock
+data 5 iter 全跑完 exit 0。loss 1.084036E+01 → 1.083188E+01（5 iter，lr 1e-6 constant
+下降极小符合预期；3.3.0 时代 loss 9.1295→8.8622 因当时参数/初始化不同，不直接可比）。
+参数 = §2 DCU 基线（--no-masked-softmax-fusion --disable-jit-fuser
+--no-persist-layer-norm --no-gradient-accumulation-fusion --attention-backend unfused
+--transformer-impl local --bf16）+ --untie-embeddings-and-output-weights + seed 42。
+NCCL 正常拆解退出，0 Traceback。**3.5.1 下 training E2E 跑通。**
+
+**post_training(T) 复验 ✅（run: posttrain35，vendor triton 3.5.1）：** `compiler triton`
+下 `/tmp/posttrain35.py` driver（post_training surface 全 import + `simple_generate`）
+exit 0，输出 shape=(1, 8)——与 3.3.0 时代事实逐字一致。modelopt 依赖链走通：
+checkpointing.py:7 模块级 import modelopt.torch 由 ad-hoc 装入的 nvidia-modelopt
+0.45.0（aliyun，带依赖解析：PuLP/antlr4-python3-runtime-4.9.3/nvidia-ml-py/
+omegaconf/scipy；torch 2.9.0 落位未动）满足——**测试用途，未入镜像**（§1.3.3
+决策未变）。simple_generate 走 forward_backward_no_pipelining，DummyModel 需满足
+MegatronModule 最小接口（config/set_input_tensor/model_type）。MASTER_PORT=29502。
+
+**inference(T) 复验 ✅（run: infer35，vendor triton 3.5.1）：** `compiler triton` 下
+`/tmp/infer35.py` driver（legacy static 引擎）exit 0，3 请求 × 8 tokens，生成耗时
+4s（tqdm 3/3 [00:04, 1.49s/it]）——与 3.3.0 时代"generate 4.2s"吻合。**编译器无关
+路径成立**：StaticInferenceContext → is_static_batching() → attention.py static 分支
+apply_module(core_attention)（DotProductAttention/sdpa），不依赖 flash-attn、不编译
+triton kernel。两处 driver 内 bypass（测试用途）：prompt_tokens 直接注入
+InferenceRequest 绕过 NullTokenizer 无 tokenize()；NullTokenizer 补最小 detokenize
+（controller.detokenize 无条件 inspect.signature，text_generation_controller.py:209）。
+模型 = 与 training 同构 gpt_builder 随机初始化（无 ckpt），3 个 InferenceRequest
+request_id=0/1/2 + sampling_params(num_tokens_to_generate=8)。MASTER_PORT=29503。
+
+**3.5.1 复验总结：** 三场景（training/post_training/inference）在 vendor triton
+3.5.1 下全部 exit 0——升级后仅 RL 复验（run 13）的缺口已补全。T 列逐格回填 ✅
+（矩阵 2026-08-17）。
+
 ## 待办/开放问题
 
 - [ ] **阻塞 M 已解（2026-08-17，run 11 确认）**：数据层修复（tokenizer_config.json 声明 eos/bos/unk）+ 包装类拷贝回环（huggingface_tokenizer.py:208-209）→ eod=50256 正常。gpt2 系 tokenizer 配方要求写进报告；`eos_id` 无 None 兜底是 MLF minor 发现。**已关闭**


### PR DESCRIPTION
## Summary

After the Triton upgrade (3.3.0 → 3.5.1, PR #404), only the RL scenario had been re-verified under vendor triton 3.5.1 (run 13). This PR records the 2026-08-17 re-verification of the remaining three hygon scenarios, all exit 0 under vendor triton 3.5.1:

- **training**: `pretrain_gpt.py` mock data 5 iter E2E exit 0 (loss 1.084036E+01 → 1.083188E+01)
- **post_training**: post_training surface imports + `simple_generate`, output shape (1, 8); modelopt premise corrected from `--no-deps` to with-dependency-resolution (aliyun mirror)
- **inference**: `StaticInferenceEngine(legacy=True)`, 3 requests × 8 tokens, generate 4s (vs 4.2s under 3.3.0)

## Changes

- `docs/megatron-verification-matrix.md` — T-column note: all four scenarios now verified under triton 3.5.1; training/inference/post_training bullets updated to 3.5.1-reverified facts; 3.3.0-era facts marked reference-only (compiler mechanism does not port across versions)
- `docs/megatron-hygon25-e2e.md` — §0/§2/§3/§4 conclusions + §1.3.3 disposition updated with 3.5.1 re-verify (2026-08-17) and modelopt install correction
- `docs/memory/rl-verify-worklog.md` — 2026-08-17 section recording the three re-verification runs (pretrain35 / posttrain35 / infer35)

This PR was written in part with the assistance of generative AI.
