### PR TITLE
docs(megatron): flagtree 3.6.0 four-scenario re-verification on hygon

### DIFF
--- a/packaging/megatron/docs/megatron-hygon25-e2e.md
+++ b/packaging/megatron/docs/megatron-hygon25-e2e.md
@@ -32,6 +32,14 @@ wheel 单步安装直跑，均 exit 0，并已在 vendor triton 3.5.1（PR #404 
 | post_training | ✅ 通过 | driver 全 import + `simple_generate`，exit 0；前提 = ad-hoc 装 modelopt（§1.3.3） |
 | inference | ✅ 通过 | `StaticInferenceEngine(legacy=True)`，3 请求 × 8 tokens，exit 0 |
 
+**flagtree 线（2026-08-17 复验）：** 四场景在 `compiler flagtree`
+（3.6.0）下全验通过（F 列全 ✅，矩阵见
+[[megatron-verification-matrix.md]]）。跨场景前置 = jit_fuser noop
+（§1.4：`--disable-jit-fuser` 不足——import 期已绑定 torch.compile，
+warmup 触发 inductor→flagtree `cluster_dims` 崩溃；复验用容器侧
+jit.py 补丁绕过，上游修复方向 = 惰性装饰）。post_training/inference
+本身编译器无关路径。
+
 **教训清单**：
 
 1. **打包范围必须覆盖 entry point 与顶层脚本**——否则完整服务无法单步安装即用。已由全范围打包关闭（§1.1，PR #107）。
@@ -170,12 +178,17 @@ vendor 包（`flagos-pypi-{vendor}` 上我们掌控、可 repack）的问题分�
 - **jit_fuser 在模块 import 期绑定 `torch.compile`:** `enable_jit_fuser()`
   在**模块 import 时即执行**（`megatron/core/jit.py:16-33`），把全局
   `jit_fuser` 绑定为 `torch.compile`；`--disable-jit-fuser` 在 args 解析之后才翻转全局，**晚于装饰器生效点**，无法阻止训练 warmup 期的
-  `torch.compile`。旧镜像（无 DTK LLVM 包，§1.5）warmup 期 flagtree 编译失败
-  → HSACOError；DTK LLVM 包后两编译器皆可编译，flagtree 下是否仍需
-  `--disable-jit-fuser` 待复测（RL 复测被 tensorboard 阻塞，未到达 warmup，
-  §5.1）。修复方向：`jit_fuser` 改为惰性装饰（或
-  `enable_jit_fuser` 默认 no-op，由训练入口显式开启）。
-- **现在状态:** 待反馈本 fork。
+  `torch.compile`。**flagtree 复验实证（2026-08-17）：** `--disable-jit-fuser`
+  **不足**——args 里已为 True，warmup 仍触发 torch.compile →
+  torchinductor → flagtree 3.6.0 内核缺 `cluster_dims` 元数据
+  （`KernelMetadata` AttributeError，torch 2.9.0
+  `triton_heuristics.py:1757 make_launcher`）→ 四场景若不经处理均在此崩。
+  复验用**容器侧 jit.py 补丁**（`enable_jit_fuser()` → `disable_jit_fuser()`，
+  仅测试用途，非仓库改动）绕过。修复方向不变：`jit_fuser` 改为惰性装饰
+  （或 `enable_jit_fuser` 默认 no-op，由训练入口显式开启）——落地后
+  `--disable-jit-fuser` 才真正生效，flagtree/triton 两线均不需要补丁。
+- **现在状态:** 待反馈本 fork（§1.4 jit_fuser 惰性装饰修复方向，现已有
+  flagtree 四场景实证支撑）。
 
 ### 1.5 工具链：编译器可用性与 DTK LLVM 前置（flagtree"屏蔽"已修正）
 
@@ -230,7 +243,7 @@ checkout；`megatron.training` 已在 wheel 中，§1.1）。**3.5.1 复验通�
 | 参数 / 配置 | 原因 |
 |---|---|
 | `--no-masked-softmax-fusion` | §1.4：fused 路径 import CUDA-only 扩展 |
-| `--disable-jit-fuser` | vendor triton 下不需要；flagtree 下旧结论（无法编译 HCU）已证伪，是否仍需待复测（§1.4 + §1.5） |
+| `--disable-jit-fuser` | **flagtree 下不足（2026-08-17 实证，§1.4）**：args 翻转晚于 import 期绑定，warmup 仍 torch.compile→inductor→flagtree `cluster_dims` 崩；flagtree 线需 jit_fuser noop（容器侧补丁 / 上游惰性装饰修复）；vendor triton 下不需要 |
 | `--no-persist-layer-norm` / `--no-gradient-accumulation-fusion` | 相应 fused kernel 在 DCU 上不可用的显式关闭 |
 | `--attention-backend unfused` | 仅 local 训练线需要；RL（TE）线不传（§5.4） |
 | `--transformer-impl` | 训练用 `local`；RL 必须 `transformer_engine`（§5.4） |
@@ -271,6 +284,9 @@ nvidia-modelopt 0.45.0 满足。
   scipy 随装，torch 2.9.0 落位未动），**未入镜像**——与其余场景的"单步安装
   wheel 即可用"不同，违反交付目标（§1.3.3）。
 - **注意:** modelopt 是唯一有 vendor 变体的 HARD 依赖；其余后端成功率不确定（§1.3.3）。
+- **flagtree 复验（2026-08-17）：** 同 driver 在 `compiler flagtree` 下直跑
+  exit 0（DummyModel + `simple_generate`，不编译 triton kernel
+  ——编译器无关路径）；F 列 ✅。
 
 ## 4. inference
 
@@ -287,6 +303,9 @@ NullTokenizer 无 detokenize，复验 driver 补最小实现（controller.detoke
   flash-attn、不编译 triton kernel**，对 hygon 属编译器无关路径。
 - **注意:** 非 legacy 路径内部构造 DynamicInferenceContext +
   DynamicInferenceEngine → 回到 §5.5 的 flash-attn 依赖。
+- **flagtree 复验（2026-08-17）：** 同 driver（3 请求 × 8 tokens，legacy
+  static）在 `compiler flagtree` 下直跑 exit 0——静态路径不编译 triton kernel，
+  编译器无关；F 列 ✅。
 
 ## 5. rl
 
@@ -297,6 +316,9 @@ Iteration 0..." → PAD/EOD 日志 → `compute_logprobs_batch` TE forward → 2
 Coordinator: shut down successfully"。rl 四步（rollout → logprob → 训练 →
 退出）首次在 hygon25 全通。
 **前提:** 补装 §5.1 未声明依赖（测试用途，aliyun）+ §5.4 vendor TE。
+**flagtree 复验（2026-08-17）：** `compiler flagtree` 下同参数全链直跑
+exit 0（rollout → logprob → 2 训练迭代 → 干净关闭；前提 jit_fuser noop，
+§1.4）。TE triton kernel 在 flagtree 3.6.0 下编译正常；F 列 ✅。
 **配方相应改动:** `--transformer-impl local → transformer_engine`、删
 `--attention-backend unfused`（local 时代 DCU 基线）。
 
@@ -430,7 +452,8 @@ tensorboard 一个，而是一组，偏离方式分三种：
   python3-config → sysconfig
 
 **待反馈至本 fork:**
-- §1.4 jit_fuser import 期绑定时序、fused kernel 默认开启的平台假设
+- §1.4 jit_fuser import 期绑定时序、fused kernel 默认开启的平台假设——
+  **jit_fuser 项已有 flagtree 四场景实证支撑（2026-08-17，§1.4）**
 - §5.1 RL 依赖 extra 声明偏差（tensorboard/wandb/httpx/tqdm/openai/uvicorn/
   fastapi/datasets/transformers/pyzmq/msgpack/quart/hypercorn 实际使用与
   `rl` extra 不符）
@@ -440,8 +463,9 @@ tensorboard 一个，而是一组，偏离方式分三种：
 **待决策:**
 - §1.3.3 modelopt 纳入镜像与否
 - §5.2 (datasets, pyarrow) 实测版本对固化到 CI
-- §1.4 flagtree 下是否仍需 `--disable-jit-fuser`（RL E2E 复测确认；复测被
-  §5.1 tensorboard 阻塞，未到达 warmup）
+- ~~§1.4 flagtree 下是否仍需 `--disable-jit-fuser`~~ **已实证关闭
+  （2026-08-17）**：flagtree 四场景复验完成（F 列全 ✅），`--disable-jit-fuser`
+  不足、需 jit_fuser noop 的结论与修复方向见 §1.4。
 
 **相关文档:** `packaging/megatron/builder/report-megatron-0.17.1.md`（构建与依赖面；
 依赖处理并入其 §1/§3）。

--- a/packaging/megatron/docs/megatron-verification-matrix.md
+++ b/packaging/megatron/docs/megatron-verification-matrix.md
@@ -16,14 +16,16 @@
 
 列名后缀：T = Triton 编译器，F = FlagTree 编译器。
 
-> 注：hygon 的 F 列为 ⬜ 而非 ❌——flagtree 编译级可用（DTK LLVM 包后，
-> 与 triton 3.5.1 同源 dtk 特判），但 megatron 场景级 E2E 均未在 flagtree 下
-> 验证，可能有问题，待按场景复测（§1.4 `--disable-jit-fuser` 是否仍需同测）。
->
 > 注：hygon 的 T 列均按当前 triton **3.5.1** 计——四场景（training/RL/
 > post_training/inference）已全部在 3.5.1 下 E2E 复验通过（2026-08-17）。
 > 编译器机制跨版本不移植（3.3.0 直出码无 clang 子进程 → 3.5.1 调外部
 > clang），3.3.0 时代结论仅作参考。
+>
+> 注：hygon 的 F 列（2026-08-17 复验后）——flagtree 3.6.0 四场景级 E2E
+> 已全验（✅），但 **每场景均需 jit_fuser noop**（§1.4：`--disable-jit-fuser`
+> 不足，import 期已绑定 torch.compile，warmup 触发 torch.compile→inductor→
+> flagtree `KernelMetadata.cluster_dims` 崩溃；复验用容器侧 jit.py 补丁绕过，
+> 上游修复 = 惰性装饰，见 §1.4）。post_training/inference 本身编译器无关。
 
 ## 矩阵
 
@@ -37,7 +39,7 @@
 | 寒武纪   | NEUWARE 4.7.2 | ⬜      | —       | ⬜          | —           | ？        | —         | ⛔      | —       |
 | 燧原     | TOPS 1.9.10   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 燧原     | TOPS 1.10.6   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
-| 海光     | DTK 26.04     | ✅      | ⬜      | ✅          | ⬜          | ✅        | ⬜        | ✅      | ⬜      |
+| 海光     | DTK 26.04     | ✅      | ✅      | ✅          | ✅          | ✅        | ✅        | ✅      | ✅      |
 | 天数智芯 | COREX 4.4.0   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 昆仑芯   | XRE 5.37.1    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 沐曦     | MACA 3.7.2.1  | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
@@ -58,39 +60,40 @@
 
 - **hygon training**：vendor triton **3.5.1** ✅（2026-08-17 复验：mock data
   5 iter E2E exit 0，loss 1.084036E+01 → 1.083188E+01；3.3.0 时代已验证，但
-  编译器机制跨版本不移植，仅作参考）。flagtree 3.6.0 **编译级可用**（DTK
-  LLVM 包 PR #403 后，与 triton 3.5.1 同源 dtk 特判 aillvm/clang-18；
-  flag_gems mm/addmm/mm-bf16 全过 diff 0.0）但 **场景级 E2E 未在 flagtree
-  下验证**——训练(F)=⬜。详见 [[megatron-hygon25-e2e.md]] 与
-  [[memory/hygon-compiler-mask]]。
+  编译器机制跨版本不移植，仅作参考）。flagtree 3.6.0 **场景级 E2E 已复验 ✅**
+  （2026-08-17，5 iters exit 0，前提 jit_fuser noop，§1.4）。详见
+  [[megatron-hygon25-e2e.md]] 与 [[memory/hygon-compiler-mask]]。
 - **hygon 编译器版本 × 场景 映射（2026-08-17）**：四场景 E2E 全部在 triton
   **3.5.1** 复验通过（RL：run 13；training/post_training/inference：
   2026-08-17 复验，exit 0）——**编译器机制跨版本不移植**（3.3.0 直出码无
   clang 子进程 → 3.5.1 调外部 clang），3.3.0 时代结论仅作参考。inference
   走 legacy 静态路径，编译器无关（§4）；T 列已逐格回填 ✅。
-- **hygon flagtree 场景级状态（2026-08-17 更正）**：曾判"屏蔽"系旧容器缺
-  DTK LLVM 包所致，已证伪；现四场景 F 列一律 ⬜——编译级可用，场景级未验证，
-  "可能有问题，不确定"，待按场景复测（含 §1.4 `--disable-jit-fuser`）。
+- **hygon flagtree 场景级状态（2026-08-17 复验完成）**：曾判"屏蔽"系旧容器缺
+  DTK LLVM 包所致，已证伪；**四场景 F 列全 ✅**（训练/RL/post_training/inference
+  均 exit 0）。跨场景前置：每场景需 jit_fuser noop（§1.4，`--disable-jit-fuser`
+  不足——import 期已绑定 torch.compile，warmup 触发 inductor→flagtree
+  `cluster_dims` 崩溃；复验用容器侧 jit.py 补丁，上游修复方向 = 惰性装饰）。
+  post_training/inference 本身编译器无关（DummyModel / legacy static 路径）。
 - **inference 裸 import 阻塞（已由全范围 wheel 关闭）**：`megatron/inference/utils.py` 依赖的 `gpt_builders`/`mamba_builders`/`model_provider` 是 **repo 根顶层入口文件**（不在 `megatron/` 包内）——core-only wheel（0.17.1+flagos）打包时被忽略，安装后 `import megatron.inference.utils` 即 ImportError。MLF PR #107（feat/wheel-full-scope）把顶层入口文件一并打包，hygon 已用该 wheel 验证推理场景跑通（见下）。
   - **归属**：上游 **core_v0.17.0** 自己的代码（fork #34 忠实同步），非 fork 偏离。上游修复时点：0.17.0/0.17.1 = 3 处裸 import；0.18.0/0.18.2 = 2 处；main = 0（全部收敛进 `megatron/training/models/`）。
   - **状态**：全范围 wheel 从打包侧关闭阻塞，其余后端推理列仍 ⛔ —— 需 PR #107 合入后按序验证。结构性问题（决策4 关联："顶层文件作入口"模式不支持 wheel 包发布）仍然成立，但不阻塞交付。
 - **hygon inference**：`StaticInferenceEngine(legacy=True)` 路径 E2E 跑通
-  （3 请求 × 8 tokens，exit 0）——**3.5.1 复验通过（2026-08-17，生成 4s，
-  与 3.3.0 时代 4.2s 吻合）**。legacy 静态批处理走
-  `apply_module(core_attention)`（DotProductAttention/sdpa），**不依赖
-  flash-attn、不编译 triton kernel**——对 hygon 属编译器无关路径；推理(F)=⬜
-  仅因未在 flagtree 下实测（编译器无关，预期可跑）。
+  （3 请求 × 8 tokens，exit 0）。legacy 静态批处理走 `apply_module(core_attention)`
+  （DotProductAttention/sdpa），**不依赖 flash-attn、不编译 triton kernel**——
+  对 hygon 属编译器无关路径；**3.5.1 复验通过（2026-08-17，生成 4s，与 3.3.0
+  时代 4.2s 吻合）**；flagtree 下复验 ✅（2026-08-17，同 driver，exit 0）。
 - **hygon RL**：全链路 exit 0（vendor triton 3.5.1 + TE 2.10.0 vendor 变体）——
   tokenizer → NCCL 初始化 → TE 模型构建 → dynamic 引擎（cuda graph）→
   text-gen server → 2 训练迭代 → 退出。此前阻塞项已全部关闭：flash_attn
   断言（repack 三处版本串一致 → 2.8.3 满足 ≥2.7.3）、torch 落位 bug
-  （repack 剥 torch 依赖）。RL(F)=⬜ 待在 flagtree 下复测。
+  （repack 剥 torch 依赖）。**flagtree 下复验 ✅（2026-08-17，同参数全链
+  exit 0，前提 jit_fuser noop，§1.4）**。
 - **hygon post_training**：driver 跑通（post_training surface 全 import +
   `simple_generate`，输出 shape=(1, 8)，exit 0）——**3.5.1 复验通过
-  （2026-08-17）**。前提是 nvidia-modelopt 0.45.0 已 ad-hoc 装入 runtime
-  venv（aliyun 带依赖解析：PuLP/antlr4-python3-runtime-4.9.3/nvidia-ml-py/
-  omegaconf/scipy；torch 2.9.0 落位未动；**未入镜像**——违反"单步安装即可用"
-  目标，modelopt 纳入与否待镜像层决策）。
+  （2026-08-17）**；**flagtree 下复验 ✅（2026-08-17，同 driver，exit 0）**。
+  前提是 nvidia-modelopt 0.45.0 已 ad-hoc 装入 runtime venv（aliyun 带依赖解析：
+  PuLP/antlr4-python3-runtime-4.9.3/nvidia-ml-py/omegaconf/scipy；torch 2.9.0
+  落位未动；**未入镜像**——违反"单步安装即可用"目标，modelopt 纳入与否待镜像层决策）。
 - **post_training 依赖**：modelopt 是唯一有 vendor 变体的 HARD 依赖（configs.yaml 仅 enflame 有 `enflame-modelopt`）；tqdm 纯 PyPI。NVIDIA 用 NVIDIA modelopt 可用；其余后端成功率不确定。
 - **rl 依赖**：模块级仅 pydantic + typing_extensions（纯 PyPI）；全树 0 处 triton/torch.compile，复用 training/core 的编译器链。**注意**：rl 场景阻塞不在依赖面而在推理引擎——dynamic 引擎硬依赖 flash-attn（§5.5；hygon 已由 vendor flash_attn 2.8.3 满足），属场景级缺口，非依赖面缺口。
 

--- a/packaging/megatron/docs/memory/rl-verify-worklog.md
+++ b/packaging/megatron/docs/memory/rl-verify-worklog.md
@@ -210,6 +210,23 @@ request_id=0/1/2 + sampling_params(num_tokens_to_generate=8)。MASTER_PORT=29503
 3.5.1 下全部 exit 0——升级后仅 RL 复验（run 13）的缺口已补全。T 列逐格回填 ✅
 （矩阵 2026-08-17）。
 
+## 2026-08-17 第九轮：FlagTree 四场景复验（用户指令"hygon 上的 FlagTree 从头验一遍"）
+
+**范围：** `compiler flagtree`（3.6.0）下四场景全验——training / RL / post_training / inference（矩阵 F 列原为 ⬜）。
+
+**核心发现（§1.4 实证）：`--disable-jit-fuser` 不足。**
+- `enable_jit_fuser()` 在模块 import 期把 `jit_fuser` 绑定为 `torch.compile`（megatron/core/jit.py:16-33）；`--disable-jit-fuser` 在 args 解析后才翻转，**晚于装饰器生效点**。args dump 里 `--disable-jit-fuser` 已是 True，warmup（initialize.py:495 `_warmup_jit_function`）**仍执行 torch.compile** → torchinductor → flagtree 3.6.0 内核缺 `cluster_dims` 元数据 → `AttributeError: 'KernelMetadata' object has no attribute 'cluster_dims'`（torch 2.9.0 `triton_heuristics.py:1757 make_launcher`）。
+- **测试绕过（容器内，非仓库改动）：** site-packages `megatron/core/jit.py` 末行 `enable_jit_fuser()` → `disable_jit_fuser()`（备份 /tmp/jit.py.bak）。上游修复方向 = 惰性装饰（§1.4 已建议，待反馈本 fork，现有实证支撑）。
+- **影响面：** training 与 RL 均触发 warmup torch.compile；post_training/inference 的 driver 不走 warmup（编译器无关路径）——但 RL 场景若不用补丁，与 training 同样在 warmup 崩。
+
+**四场景结果（均 `compiler flagtree`，日志 /tmp/flagtree-*.log）：**
+- **training ✅**（flagtree-training2.log）：`pretrain_gpt.py` 5 iters，loss 1.0838E+01 → 1.0835E+01，EXIT=0。首次失败（training1）即 `cluster_dims` 崩溃，补丁后通过。
+- **RL ✅**（flagtree-rl.log）：同 run 13 参数（TE 线），全链 exit 0——rollout → logprob → 2 训练迭代 → "Inference Coordinator: shut down successfully"。TE triton kernel 在 flagtree 3.6.0 下编译正常。
+- **post_training ✅**（flagtree-posttrain3.log）：DummyModel + `simple_generate`（1,8），EXIT=0。编译器无关路径。前两次失败为 wrapper 缺 args（assert micro_batch_size）与 MASTER_ADDR——脚本问题，非场景问题。
+- **inference ✅**（flagtree-infer2.log）：`StaticInferenceEngine(legacy=True)` 3 请求 × 8 tokens，EXIT=0。编译器无关路径（不编译 triton kernel）。
+
+**文档产物：** 矩阵 hygon 行 F 列全 ✅ + 顶部注更新；报告 §0（flagtree 线小节）、§1.4（实证结论）、§2 基线表、§3/§4/§5（各场景 flagtree 复验注）、§6（待决策项关闭）。
+
 ## 待办/开放问题
 
 - [ ] **阻塞 M 已解（2026-08-17，run 11 确认）**：数据层修复（tokenizer_config.json 声明 eos/bos/unk）+ 包装类拷贝回环（huggingface_tokenizer.py:208-209）→ eod=50256 正常。gpt2 系 tokenizer 配方要求写进报告；`eos_id` 无 None 兜底是 MLF minor 发现。**已关闭**
@@ -224,3 +241,7 @@ request_id=0/1/2 + sampling_params(num_tokens_to_generate=8)。MASTER_PORT=29503
 - [ ] tensorboard 缺口固化到可重复流程（build-infra 侧声明，版本对齐 MLF pin 2.19.0？）
 - [ ] RL 完整接入 TE 实测（rl-v4 继续），逐段暴露并固化依赖缺口
 - [ ] MLF 侧 PR（feat/rl-optdeps-verify）保持开放，供 MLF 采纳
+- [ ] **jit_fuser 惰性装饰修复反馈 MLF（2026-08-17 flagtree 复验实证，§1.4）**：
+  `--disable-jit-fuser` 不足（import 期绑定早于 flag 翻转），flagtree 线 warmup
+  必崩 `cluster_dims`；容器 rl-v4 有测试用 jit.py 补丁（enable→disable），
+  上游惰性装饰修复合并后移除


### PR DESCRIPTION
## Summary

FlagTree 3.6.0 four-scenario re-verification on hygon (2026-08-17), per the
directive to re-verify FlagTree on hygon from scratch rather than moving to
other platforms first. All four scenarios now pass under `compiler flagtree`:
training, RL, post_training, inference — matrix F columns backfilled from ⬜
to ✅.

## Key finding (§1.4, now empirically confirmed)

`--disable-jit-fuser` is **insufficient** under flagtree:

- `enable_jit_fuser()` binds `jit_fuser` to `torch.compile` at module import
  (megatron/core/jit.py), before `--disable-jit-fuser` flips at args-parse time.
- warmup (`_warmup_jit_function`) still runs torch.compile → torchinductor →
  flagtree 3.6.0 kernels lack the `cluster_dims` metadata →
  `AttributeError: 'KernelMetadata' object has no attribute 'cluster_dims'`
  (torch 2.9.0 `triton_heuristics.py:1757 make_launcher`).
- Re-verification bypassed it with a container-side jit.py patch
  (enable → disable; test-only, not a repo change).
- Upstream fix direction stays **lazy decoration** — now with four-scenario
  empirical support; flagged for the Megatron-LM-FL fork.

Scope of the finding: training and RL hit warmup (need jit_fuser noop under
flagtree); post_training/inference are compiler-independent paths (DummyModel /
legacy static, no triton kernels).

## Changes

- `megatron-verification-matrix.md` — hygon F columns → ✅; top note + verified-facts
  bullets updated.
- `megatron-hygon25-e2e.md` — §0 flagtree line, §1.4 empirical conclusion,
  §2 baseline table, §3/§4/§5 per-scenario flagtree notes, §6 待决策 item closed.
- `docs/memory/rl-verify-worklog.md` — 第九轮 (2026-08-17) FlagTree four-scenario
  re-verify section + jit_fuser follow-up item.

This PR was written in part with the assistance of generative AI.
