### PR TITLE
feat(megatron): deps_app — per-app vendor-conditional packages in configs.yaml

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -57,6 +57,15 @@
 #                        base/runtime/app must mirror EXACTLY what the image sets —
 #                        the source of truth for per-image env documentation.
 #   "deps:"            — Python dependencies (torch stack, etc.).
+#   "deps_app:"        — per-app vendor-conditional Python packages, keyed by
+#                        app name (vllm / megatron-training / megatron-rl).
+#                        Every backend lists every app; [] means "app exists
+#                        here, needs verification, but has no vendor package" —
+#                        NOT "don't build". Public packages never appear here
+#                        (they ride the wheel's extras, see packaging/megatron).
+#                        The app's own wheel is NOT a deps_app entry — it is
+#                        the app's identity and is carried by the Containerfile
+#                        (e.g. MEGATRON_VERSION), not per-backend conditionality.
 #   "hardware:"        — chip models the image targets (rendered as a prerequisite).
 #   "driver:"          — host driver version installed on the node — a prerequisite,
 #                        distinct from the in-container SDK. Probed from the vendor's
@@ -124,6 +133,10 @@ vendors:
         - torchaudio==2.10.0+cu128
         - torchvision==0.25.0+cu128
         - numpy==2.3.5
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - CUDA 12.8 (x86_64)
 
@@ -150,6 +163,10 @@ vendors:
         - torchaudio==2.11.0+cu130
         - torchvision==0.26.0+cu130
         - numpy==2.3.5
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - CUDA 13.3 (x86_64)
 
@@ -166,6 +183,10 @@ vendors:
         - torch==2.9.0+cpu
         - torch-npu==2.9.0
         - numpy==2.3.5
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - CANN Toolkit 8.5.0 (aarch64)     # Ascend-cann-toolkit_8.5.0_linux-aarch64.run
         - CANN 910B Ops 8.5.0 (aarch64)    # Ascend-cann-910b-ops_8.5.0_linux-aarch64.run
@@ -185,6 +206,10 @@ vendors:
         - torch==2.10.0+cpu
         - torch-npu==2.10.0
         - numpy==2.3.5
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - CANN Toolkit 9.0.0 (aarch64)  # Ascend-cann_9.0.0_linux-aarch64.run
         - CANN 910B Ops 9.0.0 (aarch64) # Ascend-cann-910b-ops_9.0.0_linux-aarch64.run
@@ -208,6 +233,10 @@ vendors:
         - torch-mlu==1.29.2+torch2.7.1
         - torch-mlu-ops==1.8.0+torch2.7.1
         - numpy==2.2.6
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - cnmon 6.2.15         # cnmon-6.2.15-x86_64.zip
         - cntoolkit 4.4.3      # cntoolkit_4.4.3-1.ubuntu22.04_amd64.deb
@@ -234,6 +263,10 @@ vendors:
         - torch-mlu-ops==1.12.1+torch2.11.0
         - numpy==2.2.6
         - pandas==3.0.5
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - cnmon 6.5.48           # cnmon-6.5.48-x86_64.zip
         - cntoolkit 4.7.2        # cntoolkit_4.7.2-1.ubuntu24.04_amd64.deb
@@ -266,6 +299,10 @@ vendors:
         - torchvision==0.25.0+cpu
         - torch-gcu==2.10.0+3.7.20260408
         - flash-attn==2.7.2+torch.2.10.0.gcu.3.4.20260506
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - Enflame driver 1.9.10   # enflame-x86_64-gcc-1.9.10-20260520104313.run
         - TOPS Runtime 1.9.10     # topsruntime_1.9.10-1_amd64.deb
@@ -306,6 +343,10 @@ vendors:
         - topstx==1.10.6
         - enflame-modelopt==3.6.20260615+torch.2.11.0
         - numpy==2.3.5
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - Enflame driver 1.10.6   # enflame-x86_64-gcc-1.10.6-20260720190108.run
         - TOPS Runtime 1.10.6     # topsruntime_1.10.6-1_amd64.deb
@@ -339,6 +380,12 @@ vendors:
         # opencv-python-headless declares numpy>=2, but that is a pkg declaration only.
         # Its wheel is runtime backward-compatible with numpy>=1.19
         - numpy==1.26.4
+      deps_app:
+        vllm: []
+        megatron-training: []
+        # RL 训练 forward 强制 TE（hygon25 E2E §5.4）；vendor 条件包。
+        megatron-rl:
+          - transformer_engine==2.10.0+das.opt1.dtk2604.torch290
       sdk:
         - Hygon DTK 26.04      # DTK-26.04-Ubuntu22.04-x86_64.tar.gz
         - Hygon DTK LLVM       # dtk_llvm.run (2026-05-15 version)
@@ -362,6 +409,10 @@ vendors:
         - torchaudio==2.7.1+corex.4.4.0
         - torchvision==0.22.1+corex.4.4.0
         - numpy==1.26.4
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - Corex Runtime 4.4.0      # corex-installer-linux64-4.4.0_x86_64_10.2.run
         - CUDA Header files 260604 # cuda-header-260604.zip
@@ -396,6 +447,10 @@ vendors:
         - xformers==0.0.29+1e7a8ec.d20260114
         - xmlir==1.0.0.1
         - numpy==2.2.6
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - CUDA 12.9.0_575.51.03     # cuda_12.9.0_575.51.03_linux.run
         - XRE-CUDA12 5.37.1.0       # xre-Linux-x86_64-cuda12-5.37.1.0.run
@@ -420,6 +475,10 @@ vendors:
         - torchvision==0.15.1+metax3.7.2.0
         - flash_attn==2.6.3+metax3.7.2.0torch2.8
         - numpy==2.3.5
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - MetaX Driver 3.7.2.30   # metax-driver-3.7.2.30-deb-x86_64.run
         - MACA SDK 3.7.2.0        # maca-sdk-3.7.2.0-deb-x86_64.tar.xz
@@ -447,6 +506,10 @@ vendors:
         - flash_linear_attention==0.5.0+metax3.8.1.0torch2.10
         - flash_mla==1.0.1+metax3.8.1.0torch2.10
         - numpy==2.3.5  # TODO: Confirm this
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - MetaX Driver 3.8.1.6   # metax-driver-3.8.1.6-deb-x86_64.run
         - MACA SDK 3.8.1.3       # maca-sdk-3.8.1.3-deb-x86_64.tar.xz
@@ -474,6 +537,10 @@ vendors:
         - torch_musa==2.9.0
         - mkl==2024.0.0
         - numpy==1.26.4
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - MUSA Toolkits RC4.3.6     # musa_toolkits_rc4.3.6.tar.gz
         - MCCL RC2.1.6              # mccl_rc2.1.6.PH1.tar.gz
@@ -500,6 +567,10 @@ vendors:
         - mkl==2024.0.0
         - numpy==1.26.4
 
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - MUSA Toolkits 5.2.0     # musa_toolkits_5.2.0.tar.gz
         - MCCL 2.4.0              # mccl.2.4.0.PH1.tar.gz
@@ -515,6 +586,10 @@ vendors:
         - torch==2.8.0+spacemit.0
         - numpy==2.3.5
 
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
   sunrise:
     tangrt1.2.0:
       extras: sunrise
@@ -534,6 +609,10 @@ vendors:
         - torchvision==0.26.0+cpu
         - torch-ptpu==0.2.3+torch2.11
         - numpy==2.2.6
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - Tang Toolkit 1.2.0   # tangtk-v1.2.0-linux-x86_64.run
         - PCCL 1.2.0           # pccl-v1.2.0-linux_x86_64.run
@@ -551,6 +630,10 @@ vendors:
         - torch==2.9.0+ppu2.0.0.oe
         - numpy==2.3.5
 
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
   tsingmicro:
     tsm260610:
       extras: tsingmicro
@@ -585,6 +668,10 @@ vendors:
         - torch_txda==0.1.0+20260728.f6fbdb71
         - txops==0.1.0+20260716.e94d9509
         - numpy==2.2.6
+      deps_app:
+        vllm: []
+        megatron-training: []
+        megatron-rl: []
       sdk:
         - TSM Runtime 260610164501           # Tsm_runtime_260610164501_x86_64_installer.run
         - TSM Validation Suite 260610164501  # Tsm_validation_suite_260610164501_x86_64_installer.run

--- a/packaging/megatron/docs/megatron-hygon25-e2e.md
+++ b/packaging/megatron/docs/megatron-hygon25-e2e.md
@@ -454,18 +454,25 @@ tensorboard 一个，而是一组，偏离方式分三种：
 **待反馈至本 fork:**
 - §1.4 jit_fuser import 期绑定时序、fused kernel 默认开启的平台假设——
   **jit_fuser 项已有 flagtree 四场景实证支撑（2026-08-17，§1.4）**
-- §5.1 RL 依赖 extra 声明偏差（tensorboard/wandb/httpx/tqdm/openai/uvicorn/
-  fastapi/datasets/transformers/pyzmq/msgpack/quart/hypercorn 实际使用与
-  `rl` extra 不符）
+- §5.1 RL 依赖 extra 声明偏差——**已升格为阶段二 C 前置阻塞项**（2026-08-17
+  定）：MLF pyproject 修 `[training]`+`[rl]` extras 一条 PR 一起提，公共包
+  全回 extras 带版本 pin，pyarrow 版本对进 datasets 声明；build-infra
+  `deps_app` 只背 vendor 条件包
 - §5.4 local impl 不支持 THD 打包序列训练 forward（RL 训练 forward 被迫依赖
   TE）；无 vendor TE 平台的适配路径
+- §5.5 flash_attn dynamic 引擎硬依赖 ≥2.7.3——建议软化（megatron.py:87 可配置
+  fallback）；workaround 栈已定：vendor 包 → MLF 内置 → 复用 flag_gems
+  varlen paged（fork vllm-plugin-FL `AttentionFLBackend` 生产模板）
 
-**待决策:**
-- §1.3.3 modelopt 纳入镜像与否
-- §5.2 (datasets, pyarrow) 实测版本对固化到 CI
-- ~~§1.4 flagtree 下是否仍需 `--disable-jit-fuser`~~ **已实证关闭
-  （2026-08-17）**：flagtree 四场景复验完成（F 列全 ✅），`--disable-jit-fuser`
-  不足、需 jit_fuser noop 的结论与修复方向见 §1.4。
+**已决策（2026-08-17，阶段二）：**
+- §1.3.3 modelopt 纳入镜像——**进 `[training]` extra**（公共 PyPI 包）；
+  enflame vendor 变体"见到了就装，可要可不要，不担心"
+- §5.2 (datasets, pyarrow) 实测版本对——**固化进 MLF pyproject datasets
+  声明**（C 前置 PR 内），不进 configs.yaml
+- 交付形态——两应用镜像 `megatron-training-{vendor}-{backend}` /
+  `megatron-rl-{vendor}-{backend}`（详见阶段二状态记录）
+- apex 纳入 hygon runtime——**已落地**（build-infra PR #422 merged，wheel
+  已传 flagos-pypi-hygon）
 
 **相关文档:** `packaging/megatron/builder/report-megatron-0.17.1.md`（构建与依赖面；
 依赖处理并入其 §1/§3）。

--- a/packaging/megatron/docs/memory/megatron-verification-state.md
+++ b/packaging/megatron/docs/memory/megatron-verification-state.md
@@ -5,7 +5,7 @@ metadata:
   node_type: memory
   type: project
   originSessionId: d7f830af-2108-4f39-aba9-825e3ddd911e
-  modified: 2026-08-14T09:00:00.000Z
+  modified: 2026-08-17T09:00:00.000Z
 ---
 
 # Megatron 应用镜像验证阶段 — 状态快照（2026-08-17 结构决策收口）
@@ -37,17 +37,17 @@ runtime
 
 ## 阶段二固化待办（2026-08-17 结构决策后刷新）
 
-**B 已定稿（2026-08-17）：两镜像依赖定案。** `megatron-training` = wheel + modelopt + tqdm + datasets(+pyarrow)（post_training 双引用，扫描实证）+ apex(hygon, runtime 继承)；不含 wandb/web 栈/TE（post_training 零引用）。`megatron-rl` = wheel + TE(vendor 条件) + 13 公共包全组 + flash_attn(runtime 继承) + apex(runtime 继承)。**安装两条 RUN**（vendor 装 TE → aliyun 装公共组，index 隔离便于检测）。**flash_attn 结论（2026-08-17 定）**：有则最好、无则有 workaround（MLF 内置一份 / 复用 flag_gems varlen paged——fork vllm-plugin-FL `AttentionFLBackend` 生产模板，vllm_fl/dispatch/backends/flaggems/impl/attention.py:589）。**TE 定性修正**：障碍是代码强制 thd（rl_utils.py:666-682 无条件构造 packed，含 sequence_packing=False 单序列）非 vendor 门；local-THD 修掉后 TE 降为可选加速包。**MLF 两缺口修掉后 RL = 纯公共依赖场景**（假设，待第二后端实证）。**enflame modelopt 例外不担心**（用户：见到了就装，可要可不要）。**verify 定性（用户 2026-08-17）**：断言是测试阶段手段（pip check / torch 落位 / §3 driver / TE+FA 版本断言 / run 13 同款 RL driver），**最终镜像锁定版本后行为即确定**——断言不进最终镜像，锁版才是交付契约。**待办剩：点 2 lock 版本清单**（13+2 包从验证环境取回，含 pyarrow 版本对，§5.2）。
+**B 已定稿（2026-08-17）：两镜像依赖定案。** `megatron-training` = wheel + modelopt + tqdm + datasets(+pyarrow)（post_training 双引用，扫描实证）+ apex(hygon, runtime 继承)；不含 wandb/web 栈/TE（post_training 零引用）。`megatron-rl` = wheel + TE(vendor 条件) + 13 公共包全组 + flash_attn(runtime 继承) + apex(runtime 继承)。**安装两条 RUN**（vendor 装 TE → aliyun 装公共组，index 隔离便于检测）。**flash_attn 结论（2026-08-17 定）**：有则最好、无则有 workaround（MLF 内置一份 / 复用 flag_gems varlen paged——fork vllm-plugin-FL `AttentionFLBackend` 生产模板，vllm_fl/dispatch/backends/flaggems/impl/attention.py:589）。**TE 定性修正**：障碍是代码强制 thd（rl_utils.py:666-682 无条件构造 packed，含 sequence_packing=False 单序列）非 vendor 门；local-THD 修掉后 TE 降为可选加速包。**MLF 两缺口修掉后 RL = 纯公共依赖场景**（假设，待第二后端实证）。**enflame modelopt 例外不担心**（用户：见到了就装，可要可不要）。**verify 定性（用户 2026-08-17）**：断言是测试阶段手段（pip check / torch 落位 / §3 driver / TE+FA 版本断言 / run 13 同款 RL driver），**最终镜像锁定版本后行为即确定**——断言不进最终镜像，锁版才是交付契约。**待办剩：Containerfile 拆分（#4，阻塞 = MLF PR #114）**；点 2 lock 版本清单已随 #114 落地（`[rl]` extra 15 包全 pin，含 pyarrow 版本对，§5.2）。
 
 **C 定稿（2026-08-17）："让 wheel 自己说话"。** 公共包依赖真相全部回 MLF extras（`[training]` + `[rl]` 一起提，各带版本 pin，pyarrow 版本对进 datasets 声明）；build-infra 只握顶层 wheel 名 + extra 选择器；configs.yaml `deps_app` 只背 vendor 条件包（TE），**不重复 13 包清单**；两条 RUN（vendor / mirror）保留。**边界规则**：extra 只许公共包；vendor 条件包（TE）不许进 extra，留 deps_app；flash_attn 是 runtime 层继承、不属 app 声明。**MLF pyproject 修 extra 的 PR 升格为 C 前置阻塞项**。C 机制"结构定了、等 MLF PR + hygon RL 验证后落地"。**#1 已提（2026-08-17）：PR #114**（feat/declare-runtime-extras，`[training]` +4 包 pin、新 `[rl]` extra 15 包全 pin）——待合并；C 机制落地解锁条件 = #114 合并。
 
 **C/D 形状（2026-08-17 定稿）：deps_app 每后端显式列全 app（vllm/megatron-training/megatron-rl 一键），vendor 包按需填——`[]` 表示"该 app 在此后端存在、需验证、但无 vendor 包"，不是不建。两职责解耦：app 存在性 = 键本身（验证矩阵全展开依据，期望状态）；vendor 包 = 列表内容（构建时实际装什么）。hygon megatron-rl 有 TE，其余后端全空。交付矩阵（现实状态）是验证结论的产物，不在 configs 硬编码。app 级平级（vllm/training/rl），"rl 是否可建"是每后端待验证项（默认可建）——未来纯公共 RL 后所有后端 rl 皆 `[]` 而恒建。**
 
 1. **`app/megatron/Containerfile` 拆分**：`Containerfile.megatron-training`（wheel + modelopt + tqdm + datasets）/ `Containerfile.rl`（wheel + TE 条件 + 13 包全组）；原 `Containerfile` 改名并留注释说明目录名≠镜像名的对应
-2. **configs.yaml `deps.app` 机制**（新建，对称 `env.app`）：`megatron-training` 背 modelopt/tqdm/datasets；`megatron-rl` 背 TE(vendor) + 13 包组(公共)。**机制先不建**——等结构定稿 + 第一客户（hygon RL）验证后再落地（用户"不要急于落地"）
-3. **CI 支撑**：megatron-app-image.yml stub 参数化 app 名；generate_matrix 支持 app 级 deps
+2. **configs.yaml `deps_app` 机制**（新建，对称 `env.app`，**已落地：PR #424 OPEN**）：19 后端全展开 `deps_app: {vllm, megatron-training, megatron-rl}`，`[]` = app 存在待验证无 vendor 包（非"不建"）；仅 hygon `megatron-rl` 有 `transformer_engine==2.10.0+das.opt1.dtk2604.torch290`。**wheel 边界（用户 2026-08-17 定案）：wheel 不是 deps_app 条目——是 app 身份，走 Containerfile `MEGATRON_VERSION` arg，判定准则 = 每后端条件性而非装自哪个 index**，已写进 configs.yaml header 注释。公共包（modelopt/tqdm/datasets/13 组）**不在此处**——走 wheel extras（C 定稿，等 #114）
+3. **CI 支撑（已落地，两 PR）**：generate_matrix 支持 app 级 deps + `--app {app}` 输出 `app_env`/`app_deps` 随 **PR #424 OPEN**；megatron-app-image.yml 参数化 app 名（`megatron-training`|`megatron-rl` input → 镜像 tag / matrix / APP_DEPS build-arg，Containerfile 前置 vendor RUN）随 **PR #425 OPEN**
 4. **apex 纳入 hygon runtime**（A1，2026-08-17 确认，**已落地：PR #422 merged + wheel 已传 flagos-pypi-hygon**）：上传 `apex==1.7.0+das.opt1.dtk2604.torch290` + configs.yaml hygon deps 加 `apex==1.7.0+das.opt1.dtk2604.torch290`。**定性：apex 是 vendor 可选加速包（熔断可选，MLF 里 4 处使用全 try/except fallback——multi_tensor_applier / FusedLayerNorm / FusedAdam），非 RL 硬依赖**；kunlunxin/metax 已有先例（apex==0.1 / apex==0.1+metax3.8.1.0）
-5. **TE 每后端条件性登记**：hygon 建 RL 镜像（有 vendor TE repack 2.10.0+das.opt1.dtk2604.torch290）；其他后端 RL 镜像取决于 vendor TE 是否到位
+5. **TE 每后端条件性登记（已落地，随 #424）**：hygon `megatron-rl` deps_app 登记 `transformer_engine==2.10.0+das.opt1.dtk2604.torch290`；其余后端 `[]`（无 vendor TE，构建时无 vendor 包，RL 纯公共场景假设待第二后端实证）
 
 **待 MLF 反馈项**（建议权，不阻塞 build-infra）：jit_fuser 惰性装饰、RL extra 声明偏差（**已提 PR #114，见 C 定稿**）、local-THD（rl_utils.py:666 无条件 thd → 条件构造）、eos_id None 兜底、dynamic 引擎 flash_attn 依赖软化（megatron.py:87 可配置 fallback）。
 

--- a/packaging/megatron/docs/memory/megatron-verification-state.md
+++ b/packaging/megatron/docs/memory/megatron-verification-state.md
@@ -8,21 +8,57 @@ metadata:
   modified: 2026-08-14T09:00:00.000Z
 ---
 
-# Megatron 应用镜像验证阶段 — 状态快照（2026-08-13 收工点）
+# Megatron 应用镜像验证阶段 — 状态快照（2026-08-17 结构决策收口）
 
 **阶段:** hygon25 验证期（build-infra 的 megatron 打包 + 应用镜像工作）。
 
-## 已定案（今天确认的决策）
+## 制品结构决策（2026-08-17 全定案，本轮核心产出）
+
+| # | 决策 | 结论 |
+|---|---|---|
+| D1 | RL 独立 app | **概念属训练**（参数更新主循环），**工程为复合体**（训练+推理引擎+env 服务）→ 不塞进 training 镜像 |
+| D2 | training + post_training 一类 | **生产模型用户画像**；post_training 是 modelopt 增量、可后拆 |
+| D3 | inference 不独立交付 | **唯一客户是 RL**（`megatron/rl/inference/` text-gen replicas）；独立市场与 vllm 冲突 → 不建 inference 独立 app；inference 是 RL 能力子集 |
+| D4 | 命名 | `flagos-app/megatron-training-{vendor}-{backend}` / `flagos-app/megatron-rl-{vendor}-{backend}`，统一 `megatron-` 前缀、对称自明 |
+| D5 | 目录组织 | `app/megatron/` 按**上游项目**（Megatron-LM-FL）组织，不拆目录；内含两个 Containerfile（`Containerfile.megatron-training` / `Containerfile.rl`）。切后端=参数化 `-f`，不用分 app 找目录 |
+| D6 | TE 归属 | **TE 是 RL app 的 per-application 依赖，不进 runtime**（"太重"）；runtime 定义保持 torch/triton/flag_gems；TE 每后端条件性（hygon 有 vendor TE，其他后端没有）落在 app 层：有 TE 的后端建 RL 镜像，没有的不建——与交付面归并规则咬合 |
+| D7 | 镜像拓扑 | **RL 直接 FROM runtime**，不叠加 megatron-training；两 app 并列、互不依赖、层缓存独立，wheel 装两遍无害 |
+
+**镜像形态（最终）:**
+```
+runtime
+├──→ flagos-app/megatron-training-*    = runtime + wheel + modelopt(公共包)
+└──→ flagos-app/megatron-rl-*          = runtime + wheel + TE(每后端条件) + RL 13 包组
+```
+
+**modelopt 定性：** 公共 PyPI 包（aliyun 装，nvidia-modelopt 0.45.0），非 vendor 包，无每后端条件性 → 声明进 `megatron-training` 的 deps.app 组即可（与 TE 不同，TE 才有条件性）。**安装须测试（2026-08-17 用户定）**：ad-hoc 验证（§1.3.3/§3，torch 2.9.0 落位未动 + import/simple_generate 双编译器过）已证明公共路径可解析；**缺口 = 入镜像单步安装**（megatron-core + modelopt 同一条 pip install，vendor index + aliyun 并列）——测试随 B 走：`pip check` 干净 + torch 落位断言 + §3 driver 复测。
+
+**inference 模块定位：** 不独立交付；活在 RL 镜像（内部引擎）与 wheel 内。megatron app 不含推理服务承诺。
+
+## 阶段二固化待办（2026-08-17 结构决策后刷新）
+
+**B 已定稿（2026-08-17）：两镜像依赖定案。** `megatron-training` = wheel + modelopt + tqdm + datasets(+pyarrow)（post_training 双引用，扫描实证）+ apex(hygon, runtime 继承)；不含 wandb/web 栈/TE（post_training 零引用）。`megatron-rl` = wheel + TE(vendor 条件) + 13 公共包全组 + flash_attn(runtime 继承) + apex(runtime 继承)。**安装两条 RUN**（vendor 装 TE → aliyun 装公共组，index 隔离便于检测）。**flash_attn 结论（2026-08-17 定）**：有则最好、无则有 workaround（MLF 内置一份 / 复用 flag_gems varlen paged——fork vllm-plugin-FL `AttentionFLBackend` 生产模板，vllm_fl/dispatch/backends/flaggems/impl/attention.py:589）。**TE 定性修正**：障碍是代码强制 thd（rl_utils.py:666-682 无条件构造 packed，含 sequence_packing=False 单序列）非 vendor 门；local-THD 修掉后 TE 降为可选加速包。**MLF 两缺口修掉后 RL = 纯公共依赖场景**（假设，待第二后端实证）。**enflame modelopt 例外不担心**（用户：见到了就装，可要可不要）。**verify 定性（用户 2026-08-17）**：断言是测试阶段手段（pip check / torch 落位 / §3 driver / TE+FA 版本断言 / run 13 同款 RL driver），**最终镜像锁定版本后行为即确定**——断言不进最终镜像，锁版才是交付契约。**待办剩：点 2 lock 版本清单**（13+2 包从验证环境取回，含 pyarrow 版本对，§5.2）。
+
+**C 定稿（2026-08-17）："让 wheel 自己说话"。** 公共包依赖真相全部回 MLF extras（`[training]` + `[rl]` 一起提，各带版本 pin，pyarrow 版本对进 datasets 声明）；build-infra 只握顶层 wheel 名 + extra 选择器；configs.yaml `deps_app` 只背 vendor 条件包（TE），**不重复 13 包清单**；两条 RUN（vendor / mirror）保留。**边界规则**：extra 只许公共包；vendor 条件包（TE）不许进 extra，留 deps_app；flash_attn 是 runtime 层继承、不属 app 声明。**MLF pyproject 修 extra 的 PR 升格为 C 前置阻塞项**。C 机制"结构定了、等 MLF PR + hygon RL 验证后落地"。**#1 已提（2026-08-17）：PR #114**（feat/declare-runtime-extras，`[training]` +4 包 pin、新 `[rl]` extra 15 包全 pin）——待合并；C 机制落地解锁条件 = #114 合并。
+
+**C/D 形状（2026-08-17 定稿）：deps_app 每后端显式列全 app（vllm/megatron-training/megatron-rl 一键），vendor 包按需填——`[]` 表示"该 app 在此后端存在、需验证、但无 vendor 包"，不是不建。两职责解耦：app 存在性 = 键本身（验证矩阵全展开依据，期望状态）；vendor 包 = 列表内容（构建时实际装什么）。hygon megatron-rl 有 TE，其余后端全空。交付矩阵（现实状态）是验证结论的产物，不在 configs 硬编码。app 级平级（vllm/training/rl），"rl 是否可建"是每后端待验证项（默认可建）——未来纯公共 RL 后所有后端 rl 皆 `[]` 而恒建。**
+
+1. **`app/megatron/Containerfile` 拆分**：`Containerfile.megatron-training`（wheel + modelopt + tqdm + datasets）/ `Containerfile.rl`（wheel + TE 条件 + 13 包全组）；原 `Containerfile` 改名并留注释说明目录名≠镜像名的对应
+2. **configs.yaml `deps.app` 机制**（新建，对称 `env.app`）：`megatron-training` 背 modelopt/tqdm/datasets；`megatron-rl` 背 TE(vendor) + 13 包组(公共)。**机制先不建**——等结构定稿 + 第一客户（hygon RL）验证后再落地（用户"不要急于落地"）
+3. **CI 支撑**：megatron-app-image.yml stub 参数化 app 名；generate_matrix 支持 app 级 deps
+4. **apex 纳入 hygon runtime**（A1，2026-08-17 确认，**已落地：PR #422 merged + wheel 已传 flagos-pypi-hygon**）：上传 `apex==1.7.0+das.opt1.dtk2604.torch290` + configs.yaml hygon deps 加 `apex==1.7.0+das.opt1.dtk2604.torch290`。**定性：apex 是 vendor 可选加速包（熔断可选，MLF 里 4 处使用全 try/except fallback——multi_tensor_applier / FusedLayerNorm / FusedAdam），非 RL 硬依赖**；kunlunxin/metax 已有先例（apex==0.1 / apex==0.1+metax3.8.1.0）
+5. **TE 每后端条件性登记**：hygon 建 RL 镜像（有 vendor TE repack 2.10.0+das.opt1.dtk2604.torch290）；其他后端 RL 镜像取决于 vendor TE 是否到位
+
+**待 MLF 反馈项**（建议权，不阻塞 build-infra）：jit_fuser 惰性装饰、RL extra 声明偏差（**已提 PR #114，见 C 定稿**）、local-THD（rl_utils.py:666 无条件 thd → 条件构造）、eos_id None 兜底、dynamic 引擎 flash_attn 依赖软化（megatron.py:87 可配置 fallback）。
+
+## 既有定案（早前，仍有效）
 
 1. **交付形态 = 应用镜像**：wheel 单步安装进 `flagos-runtime-{vendor}-{backend}` 镜像，用户直接跑训练服务。**repo checkout 交付 = 王八蛋方式，不可接受。**
-2. **单 wheel，不做多组件**。应用场景（训练/后训练/RL/推理）归并进一个 wheel，场景是镜像内能力、不是镜像种类。
+2. **单 wheel，不做多组件**：应用场景归并进一个 wheel（场景是镜像内能力）；镜像种类按本快照 D1-D7 拆分。
 3. **编译器归并规则**（用户原话定性）：**验证面不归并**——每个后端 × 两个编译器（flagtree/triton）都要验证；**交付面归并**——每后端只交付能用的编译器，不能用的屏蔽（不设默认/不装）。
-4. **hygon 编译器 mask**：flagtree 3.6.0 ✗（屏蔽，clang-17 拒 5 个 `-mllvm` flags → HSACOError），vendor triton 3.3.0 ✓（交付，`llvm.translate_to_asm()` 直接出码）。详见 [[hygon-compiler-mask]]。
-5. **vendor triton 复跑成功**：两种验证形态均 exit 0，**不再需要 jit.py 补丁和 `--disable-jit-fuser`**（这两者是 flagtree 缺陷的规避，不是平台必需的）。loss 9.1295→8.8622（完整训练服务）。
-6. **打包范围扩大方向**：pyproject include 已改（core+plugin+training+legacy），**未提交、未构建、未验证**。决策 3 未定案（见下）。
-7. **psutil 缺口定性**：代码是 NVIDIA 上游（ADLR/Megatron-LM）写的，本 fork（megatron-lm-fl）**继承**该缺口，PR #106 修复（声明进 pyproject）。
-8. **打包环境 = runtime 镜像**（2026-08-14 用户定）：不再依赖设想中的 megatron-builder-py* 镜像（从未构建过——#368 时设想，CI 因此失败 `base name should not be blank`）。runtime 镜像自带正确 python 版本 + 关键运行时包，打包过程不变（clone → patch → stamp → pip wheel → gate），且打包环境 = 交付环境 → 装完 wheel 即可做依赖面安全验证。
-9. **repack facility 已删**（2026-08-14 用户同意后 git rm）：`packaging/megatron/repack/` 唯一正事是剥 torch（vllm sdist 模式才需要）；megatron 是 fork 源码模式，**torch>=2.6.0 声明保留不动**（全后端 vendor torch ≥2.7.1，pip 解析天然满足），repack 无活可干。verify 脚本移至 `packaging/megatron/verify/verify-megatron-backend.sh`。
+4. **hygon 编译器 mask（2026-08-17 修正）**：flagtree 3.6.0 ✅ 可用（四场景复验全过，2026-08-17）——DTK LLVM 前置 + 需 jit.py noop 补丁（§1.4，上游修复未合并）；vendor triton 3.5.1 ✅（repack 后）。详见 [[hygon-compiler-mask]] 与 [[rl-verify-worklog]]。
+5. **打包环境 = runtime 镜像**（2026-08-14 用户定）：打包环境 = 交付环境 → 装完 wheel 即可做依赖面安全验证。
+6. **repack facility 已删**（2026-08-14）：megatron 是 fork 源码模式，`torch>=2.6.0` 声明保留，repack 无活可干。verify 脚本移至 `packaging/megatron/verify/verify-megatron-backend.sh`。
 
 ## 待决事项（用户需权衡）
 

--- a/scripts/generate_matrix.py
+++ b/scripts/generate_matrix.py
@@ -92,7 +92,9 @@ def _runtime_matrix(
 
     When ``app`` is given, the matrix is the same superset plus the
     per-backend app env vars from configs.yaml env.app.{app}, serialized
-    as "KEY=value\\n..." (same format as runtime_env) under ``app_env``.
+    as "KEY=value\\n..." (same format as runtime_env) under ``app_env``,
+    and the per-backend app deps from configs.yaml deps_app.{app}
+    (space-separated) under ``app_deps``.
     """
     build_config = load_yaml(repo_root / ".github" / "build-config.yml")
     registry = build_config.get("registry") or {}
@@ -135,10 +137,16 @@ def _runtime_matrix(
 
         # Per-backend app env vars for one app — same serialization as runtime_env
         app_env_lines = ""
+        # Per-backend app deps for one app — vendor-conditional packages only
+        # (configs.yaml deps_app.{app}). Space-separated, same format as deps.
+        app_deps = ""
         if app is not None:
             app_env = ((backend_info.get("env") or {}).get("app") or {}).get(app, {})
             app_env_lines = "\n".join(
                 f"{k}={v}" for k, v in (app_env or {}).items()
+            )
+            app_deps = " ".join(
+                (backend_info.get("deps_app") or {}).get(app, [])
             )
 
         entry = {
@@ -161,10 +169,11 @@ def _runtime_matrix(
             ) if isinstance(backend_info.get("triton_post_install"), list) else "",
             "runtime_env": runtime_env_lines,
         }
-        # App build matrix = runtime fields + app env; --runtime keeps no
-        # app_env key so runtime-image.yml output is unchanged.
+        # App build matrix = runtime fields + app env + app deps; --runtime
+        # keeps no app_env/app_deps keys so runtime-image.yml output is unchanged.
         if app is not None:
             entry["app_env"] = app_env_lines
+            entry["app_deps"] = app_deps
         include.append(entry)
 
     return {"include": include}


### PR DESCRIPTION
## Summary

`deps_app` is the app-level twin of `deps:`. The megatron app-image work needs a place to declare **per-backend vendor-conditional** packages for each app (vllm / megatron-training / megatron-rl), because the dependency truth now lives in the wheel's extras and build-infra only holds what differs per backend.

```yaml
vendors:
  hygon:
    dtk26.04:
      deps_app:
        vllm: []
        megatron-training: []
        megatron-rl:                 # RL training forward forces TE (hygon25 E2E §5.4)
          - transformer_engine==2.10.0+das.opt1.dtk2604.torch290
```

- **configs.yaml** — `deps_app:` blocks on all 19 backends, documented in the backend-spec header comment. Every backend lists every app; `[]` means "app exists here, needs verification, but has no vendor package" — **NOT** "don't build". Public packages never appear here (they ride the wheel's extras). The app's own wheel is explicitly out of scope: it is the app's identity, carried by the Containerfile (MEGATRON_VERSION), not per-backend conditionality.
- **hygon-dtk26.04** — `megatron-rl` carries vendor TE 2.10.0+das.opt1.dtk2604.torch290, the first and currently only deps_app entry.
- **scripts/generate_matrix.py** — `--app` mode reads `deps_app.{app}` into `app_deps` (space-separated, same format as `deps`); the runtime matrix output is byte-identical (no app keys leak).
- **docs** — the e2e report §6 and verification-state snapshot are updated to reflect the C decision ("let the wheel speak") and the deps_app scope.

## Validation

```
$ python3 scripts/generate_matrix.py --app megatron-rl | jq -r '.include[] | [.name, .app_deps] | @tsv'
hygon-dtk26.04   transformer_engine==2.10.0+das.opt1.dtk2604.torch290
(17 other backends)   (empty)
```

`--runtime` output unchanged; `--app megatron` (legacy stub name) yields empty `app_deps`, so the existing workflow is unaffected.

This PR was written in part with the assistance of generative AI.
