### PR TITLE
feat(megatron): parameterize app name in megatron-app-image workflow

### DIFF
--- a/.github/workflows/megatron-app-image.yml
+++ b/.github/workflows/megatron-app-image.yml
@@ -114,8 +114,6 @@ jobs:
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     name: app-${{ matrix.name }}
     runs-on: ${{ fromJSON(matrix.runson) }}
-    env:
-      IMAGE: ${{ inputs.app }}-app-${{ matrix.name }}:${{ github.run_id }}
     steps:
       - name: Checkout build-infra
         uses: actions/checkout@v7

--- a/.github/workflows/megatron-app-image.yml
+++ b/.github/workflows/megatron-app-image.yml
@@ -14,22 +14,24 @@
 
 name: Megatron app image
 
-# Builds flagos-app/megatron-{vendor}-{backend}:{version} from the runtime
-# image by installing the megatron-core wheel single-step (no --no-deps), then
+# Builds flagos-app/{app}-{vendor}-{backend}:{version} ({app} = megatron-training
+# | megatron-rl) from the runtime image by installing the megatron-core wheel
+# single-step (no --no-deps), then
 # verifies the built image on the node: the torch/triton/flag_gems/numpy
 # matrix must be identical to the runtime's, and megatron.core must import
 # with helpers_cpp bound (see packaging/megatron/verify/verify-megatron-backend.sh).
 #
 # Facility 2 (app-image automation): installs the megatron-core wheel into a
 # flagos-runtime-{vendor}-{backend} image and produces the app image
-# flagos-app/megatron-{vendor}-{backend}:{version}. The Containerfile installs
+# flagos-app/{app}-{vendor}-{backend}:{version}. The Containerfile installs
 # with a single-step `pip install` (no --no-deps) — the wheel keeps its
 # torch>=2.6.0 Requires-Dist and the runtime's vendor torch satisfies it, so the
 # runtime's torch/triton/flag_gems matrix cannot be disturbed (the repack
 # facility was removed 2026-08-14).
 #
-# Backend matrix comes from scripts/generate_matrix.py --app megatron (same
-# runtime fields as runtime-image.yaml plus the per-backend app env vars).
+# Backend matrix comes from scripts/generate_matrix.py --app {app} (same
+# runtime fields as runtime-image.yaml plus the per-backend app env vars and
+# vendor-conditional deps from configs.yaml deps_app.{app}).
 # Per-vendor PyPI (flagos_pypi) is searched first; aliyun is the fallback.
 
 on:
@@ -39,6 +41,13 @@ on:
         description: 'Backend to build (e.g. hygon-dtk26.04), or "all"'
         type: string
         default: all
+      app:
+        description: 'App to build: megatron-training (training + post_training) or megatron-rl (RL loop)'
+        type: choice
+        options:
+          - megatron-training
+          - megatron-rl
+        default: megatron-training
       megatron_version:
         description: 'megatron-core version to install (e.g. 0.17.1)'
         type: string
@@ -84,9 +93,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.backend }}" == "all" ]]; then
-            python3 scripts/generate_matrix.py --app megatron > matrix.json
+            python3 scripts/generate_matrix.py --app "${{ inputs.app }}" > matrix.json
           else
-            python3 scripts/generate_matrix.py --app megatron ${{ inputs.backend }} > matrix.json
+            python3 scripts/generate_matrix.py --app "${{ inputs.app }}" ${{ inputs.backend }} > matrix.json
           fi
           cat matrix.json
           echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
@@ -106,7 +115,7 @@ jobs:
     name: app-${{ matrix.name }}
     runs-on: ${{ fromJSON(matrix.runson) }}
     env:
-      IMAGE: megatron-app-${{ matrix.name }}:${{ github.run_id }}
+      IMAGE: ${{ inputs.app }}-app-${{ matrix.name }}:${{ github.run_id }}
     steps:
       - name: Checkout build-infra
         uses: actions/checkout@v7
@@ -140,13 +149,14 @@ jobs:
           set -euo pipefail
           host="${{ needs.set-matrix.outputs.harbor_host }}"
           app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
-          app_tag="${host}/${app_prefix}/megatron-${{ matrix.name }}:${{ matrix.version }}"
+          app_tag="${host}/${app_prefix}/${{ inputs.app }}-${{ matrix.name }}:${{ matrix.version }}"
           docker build \
             --build-arg "RUNTIME_IMAGE=${{ matrix.image_tag }}" \
             --build-arg "MEGATRON_VERSION=${{ inputs.megatron_version }}" \
             --build-arg "FLAGOS_PYPI=${{ matrix.flagos_pypi }}" \
             --build-arg "EXTRA_PYPI=${{ matrix.extra_pypi }}" \
             --build-arg "APP_ENV=${{ matrix.app_env }}" \
+            --build-arg "APP_DEPS=${{ matrix.app_deps }}" \
             -t "${app_tag}" \
             -f app/megatron/Containerfile .
           echo "Built: ${app_tag}"
@@ -164,7 +174,7 @@ jobs:
           set -euo pipefail
           host="${{ needs.set-matrix.outputs.harbor_host }}"
           app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
-          app_tag="${host}/${app_prefix}/megatron-${{ matrix.name }}:${{ matrix.version }}"
+          app_tag="${host}/${app_prefix}/${{ inputs.app }}-${{ matrix.name }}:${{ matrix.version }}"
           bash packaging/megatron/verify/verify-megatron-backend.sh \
             "${{ matrix.name }}" \
             --megatron-version "${{ inputs.megatron_version }}" \
@@ -175,5 +185,5 @@ jobs:
         run: |
           host="${{ needs.set-matrix.outputs.harbor_host }}"
           app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
-          app_tag="${host}/${app_prefix}/megatron-${{ matrix.name }}:${{ matrix.version }}"
+          app_tag="${host}/${app_prefix}/${{ inputs.app }}-${{ matrix.name }}:${{ matrix.version }}"
           docker push "${app_tag}"

--- a/app/megatron/Containerfile
+++ b/app/megatron/Containerfile
@@ -28,6 +28,12 @@
 #                path — the wheel keeps torch>=2.6.0 and the runtime's
 #                vendor torch satisfies it). Plain wheel from the
 #                vendor PyPI, still single-step no--no-deps.
+#   2026-08-17   APP_DEPS build arg: vendor-conditional packages from
+#                configs.yaml deps_app.{app} (e.g. hygon's TE for the
+#                rl app), installed before the wheel from the vendor
+#                PyPI — index isolation so a vendor package can't be
+#                re-resolved from the mirror. Workflow now parameterizes
+#                the app name (megatron-training | megatron-rl).
 # TODO
 #   - Publish-time verification (torch version, megatron.core import).
 # ============================================================
@@ -44,6 +50,22 @@ ARG FLAGOS_PYPI=""
 
 # Fallback for all other dependencies.
 ARG EXTRA_PYPI="https://mirrors.aliyun.com/pypi/simple"
+
+# Vendor-conditional packages for this app (configs.yaml deps_app.{app}),
+# space-separated. Installed before the wheel from the vendor PyPI — index
+# isolation so a vendor package (e.g. hygon's transformer_engine for the rl
+# app) can't be re-resolved from the mirror. Empty for apps with no vendor
+# packages on this backend.
+ARG APP_DEPS=""
+
+# --- Install vendor-conditional deps ---------------------------
+
+RUN if [ -n "${APP_DEPS}" ]; then \
+      pip install \
+        --index-url "${FLAGOS_PYPI}" \
+        --extra-index-url "${EXTRA_PYPI}" \
+        ${APP_DEPS}; \
+    fi
 
 # --- Install megatron-core ------------------------------------
 


### PR DESCRIPTION
## Summary

The `megatron-app-image.yml` workflow hardcoded the app name `megatron` in the image tag and the matrix generation. This PR parameterizes the app so the same workflow builds either app image, per the D4 naming (`flagos-app/megatron-{training|rl}-{vendor}-{backend}`):

- **new `app` input** (choice: `megatron-training` / `megatron-rl`, default `megatron-training`) — matches the `deps_app` keys in `configs.yaml`, so the matrix lookup works unchanged.
- **matrix generation** now passes `--app {app}` (previously hardcoded `--app megatron`).
- **image tag** becomes `flagos-app/{app}-{vendor}-{backend}:{version}` in build / verify / push steps.
- **new `APP_DEPS` build arg** — passes `matrix.app_deps` (vendor-conditional packages from `configs.yaml deps_app.{app}`, emitted by `generate_matrix.py --app`) to the Containerfile.
- **Containerfile** gains an `ARG APP_DEPS` install RUN that installs the vendor-conditional packages from the vendor PyPI **before** the wheel install (index isolation — a vendor package like hygon's `transformer_engine` can't be re-resolved from the aliyun mirror). Empty on backends/apps with no vendor packages.

This is the workflow half of the app split. The Containerfile itself is still the unsplit `app/megatron/Containerfile` — the `Containerfile.megatron-training` / `Containerfile.rl` split (with the `[training]` / `[rl]` extra installs) lands separately once the MLF extras PR (#114) merges.

## Validation

- `python3 scripts/generate_matrix.py --app megatron-training hygon-dtk26.04` → `app_deps: ""` (training has no vendor package on hygon)
- `python3 scripts/generate_matrix.py --app megatron-rl hygon-dtk26.04` → `app_deps: "transformer_engine==2.10.0+das.opt1.dtk2604.torch290"` (RL forces TE, §5.4)
- Workflow YAML parses cleanly.

## Merge order

Depends on #424 (deps_app mechanism in `generate_matrix.py`) — without it `matrix.app_deps` is absent and the arg passes an empty string (harmless no-op). Merge #424 first.

This PR was written in part with the assistance of generative AI.
