### PR TITLE
fix(runtime): unzip triton_post_install overlay instead of pip --target

### DIFF
--- a/runtime/Containerfile
+++ b/runtime/Containerfile
@@ -149,6 +149,14 @@ RUN if [ -n "${FLAGTREE_PKG}" ]; then \
 # The compiler() shell function toggles by prepending /opt/triton to
 # PYTHONPATH. Always create /opt/triton so the runtime COPY doesn't fail
 # on missing source.
+#
+# TRITON_EXTRA_PKGS (configs.yaml triton_post_install:) are overlay packages
+# that ship a full triton tree — they replace triton/__init__.py, compiler/
+# and _C/*.so, and add their backend subtree (triton/backends/ascend/ for
+# triton_ascend). `pip install --target` cannot extend the existing
+# top-level triton/ dir, so the overlay is lost and the backend is missing
+# at runtime. Download the wheel and unzip -o over /opt/triton instead
+# (unzip keeps the wheel's executable bits; python -m zipfile does not).
 RUN mkdir -p /opt/triton
 RUN if [ -n "${TRITON_PKG}" ]; then \
       _installed=1; \
@@ -165,13 +173,17 @@ RUN if [ -n "${TRITON_PKG}" ]; then \
       if [ -n "${TRITON_EXTRA_PKGS}" ]; then \
         _installed=1; \
         for i in 1 2 3; do \
-          if PIP_INDEX_URL="${FLAGOS_PYPI}" \
-             PIP_EXTRA_INDEX_URL="${EXTRA_PYPI}" \
-             pip install --no-cache-dir --target /opt/triton \
-            ${TRITON_EXTRA_PKGS}; then \
+          if mkdir -p /tmp/triton-overlay \
+             && PIP_INDEX_URL="${FLAGOS_PYPI}" \
+                PIP_EXTRA_INDEX_URL="${EXTRA_PYPI}" \
+                pip download --no-deps --no-cache-dir \
+                -d /tmp/triton-overlay ${TRITON_EXTRA_PKGS} \
+             && (cd /opt/triton && unzip -qo /tmp/triton-overlay/*.whl) \
+             && rm -rf /tmp/triton-overlay; then \
             _installed=0; break; \
           fi; \
           echo "Triton extra install attempt $i failed, retrying..."; \
+          rm -rf /tmp/triton-overlay; \
         done; \
         [ "$_installed" -eq 0 ] || { echo "ERROR: Triton extra install failed after 3 attempts"; exit 1; }; \
       fi; \


### PR DESCRIPTION
## Problem

`runtime/Containerfile` installs `triton_post_install:` overlay wheels
(`triton_ascend`, `triton-gcu`) with `pip install --target /opt/triton`.

pip's `--target` mode **silently skips files that already exist** in the
target dir. An overlay wheel ships a full `triton/` override tree plus a
vendor backend subtree (`triton/backends/ascend/`); under `--target` the
existing files win, so the override is lost and only the `.dist-info`
lands. The image then has **no** `triton.backends.<vendor>`.

Verified broken on the shipped `flagos-runtime-ascend-cann9.0.0:2.1.2`
image: `/opt/triton/triton/backends/` contains only `amd` + `nvidia`,
`triton/__init__.py` is still upstream `3.5.0`, and the
`triton_ascend-3.2.1.dist-info/RECORD` lists 36 `triton/backends/ascend/*`
files that never landed. `compiler triton` on that image cannot load the
ascend backend.

## Fix

Download the overlay wheel and `unzip -o` over `/opt/triton` so the
override tree is actually laid down (`unzip` also preserves the wheel's
executable bits, which `python -m zipfile` does not).

Affected backends using `triton_post_install`:
- `ascend-cann9.0.0` (`triton_ascend==3.2.1`)
- `enflame tops1.9.10` / `tops1.10.6` (`triton-gcu`)

Images for these backends must be rebuilt after this lands.

## Verification

- Structural check on the broken image (`/opt/triton` layout, RECORD vs
  filesystem) confirms the failure mode; the fix's `unzip -o` path is the
  same mechanism already used by the runtime COPY layer and is covered by
  the existing retry loop in the same RUN block.
- Rebuild + E2E verification of `ascend-cann9.0.0` triton path is pending
  (separate verification ticket, needs a node).

This PR was written in part with the assistance of generative AI.
