### PR TITLE
feat(vllm): consolidate vllm wheel/plugin/app-image pipeline in CI

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -32,8 +32,10 @@ registry:
     builder: flagos-dev
     # App images live under flagos-app (e.g. flagos-app/megatron-nvidia-cuda12.8,
     # flagos-app/vllm-nvidia-cuda12.8). Consumed by the app-image workflows
-    # (megatron-app-image.yml) to compose the image tag.
-    app: flagos-app
+    # (megatron-app-image.yml, vllm-app-image.yml) to compose the image tag.
+    # TEMPORARY: the flagos-app Harbor project does not exist yet — images land
+    # in flagos-dev until it is created (flip back to flagos-app then).
+    app: flagos-dev
 
 # Which runner builds each image (base containerfile name -> runs-on).
 # Backends not listed under `overrides` use `default`.

--- a/.github/workflows/vllm-app-image.yml
+++ b/.github/workflows/vllm-app-image.yml
@@ -1,0 +1,185 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: vllm app image
+
+# Builds flagos-app/vllm-{vendor}-{backend}:{version} from the runtime image
+# by installing the repacked vllm wheel (+flagos) and the vllm-plugin-FL wheel
+# single-step — two clean pip installs, no source builds (the plugin wheel is
+# built and audited by the vllm-plugin-wheel workflow; the vllm wheel by the
+# vllm-wheel workflow). The +flagos pin and the plugin's audited-empty
+# Requires-Dist mean neither install can touch the runtime's baked
+# torch/torch_npu/triton/flag_gems/numpy matrix.
+#
+# Then verifies the built image on the node: the critical-package matrix must
+# be identical to the runtime's (BEFORE snapshot from the runtime image, AFTER
+# from the app image), and vllm + vllm_fl must import (see
+# packaging/vllm/verify-vllm-backend.sh --app-image). Verify gates push.
+#
+# Backend matrix comes from scripts/generate_matrix.py --app vllm (same
+# runtime fields as runtime-image.yml plus the per-backend app env vars and
+# vendor-conditional deps from configs.yaml deps_app.vllm).
+# Per-vendor PyPI (flagos_pypi) is searched first; aliyun is the fallback.
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: 'Backend to build (e.g. ascend-cann9.0.0), or "all"'
+        type: string
+        default: all
+      vllm_version:
+        description: 'vllm version to install (repacked +flagos wheel, e.g. 0.24.0)'
+        type: string
+        default: 0.24.0
+      plugin_fl_version:
+        description: >-
+          vllm-plugin-fl wheel version to install (commit-precise pin, e.g.
+          0.2.0+gcf8998c.d20260815). Empty = skip the plugin install.
+        type: string
+        default: ''
+      push:
+        description: 'Push image(s) to the registry'
+        type: boolean
+        default: false
+      verify:
+        description: 'Run the on-node verification step (matrix + import check)'
+        type: boolean
+        default: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/check-trigger-author
+
+  set-matrix:
+    needs: authorize
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      harbor_host: ${{ steps.harbor-host.outputs.host }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+
+      - id: set-matrix
+        shell: bash
+        run: |
+          if [[ "${{ inputs.backend }}" == "all" ]]; then
+            python3 scripts/generate_matrix.py --app vllm > matrix.json
+          else
+            python3 scripts/generate_matrix.py --app vllm ${{ inputs.backend }} > matrix.json
+          fi
+          cat matrix.json
+          echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+      - id: harbor-host
+        shell: bash
+        run: |
+          host=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['host'])")
+          echo "host=$host" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: set-matrix
+    if: ${{ fromJSON(needs.set-matrix.outputs.matrix).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    name: app-${{ matrix.name }}
+    runs-on: ${{ fromJSON(matrix.runson) }}
+    steps:
+      - name: Checkout build-infra
+        uses: actions/checkout@v7
+
+      - name: Harbor login (push only)
+        if: ${{ inputs.push }}
+        env:
+          HARBOR_USER: ${{ secrets.HARBOR_USER }}
+          HARBOR_PW: ${{ secrets.HARBOR_PASSWORD }}
+        run: |
+          host="${{ needs.set-matrix.outputs.harbor_host }}"
+          for i in 1 2 3; do
+            if printf '%s' "$HARBOR_PW" | docker login "$host" -u "$HARBOR_USER" --password-stdin; then
+              exit 0
+            fi
+            echo "Harbor login attempt $i failed, retrying..."
+            sleep 30
+          done
+          echo "::error::Harbor login failed after 3 attempts"
+          exit 1
+
+      - name: Pull runtime image
+        run: |
+          docker pull "${{ matrix.image_tag }}" || {
+            echo "::error::Failed to pull runtime image ${{ matrix.image_tag }}"
+            exit 1
+          }
+
+      - name: Build vllm app image
+        run: |
+          set -euo pipefail
+          host="${{ needs.set-matrix.outputs.harbor_host }}"
+          app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
+          app_tag="${host}/${app_prefix}/vllm-${{ matrix.name }}:${{ matrix.version }}"
+          docker build \
+            --build-arg "RUNTIME_IMAGE=${{ matrix.image_tag }}" \
+            --build-arg "VLLM_VERSION=${{ inputs.vllm_version }}" \
+            --build-arg "PLUGIN_FL_VERSION=${{ inputs.plugin_fl_version }}" \
+            --build-arg "FLAGOS_PYPI=${{ matrix.flagos_pypi }}" \
+            --build-arg "EXTRA_PYPI=${{ matrix.extra_pypi }}" \
+            --build-arg "APP_ENV=${{ matrix.app_env }}" \
+            --build-arg "APP_DEPS=${{ matrix.app_deps }}" \
+            -t "${app_tag}" \
+            -f app/vllm/Containerfile .
+          echo "Built: ${app_tag}"
+
+      # On-node verify of the built artifact. Reuses verify-vllm-backend.sh in
+      # --app-image mode: BEFORE snapshot from the runtime image, AFTER from
+      # the app image — the torch/torch_npu/triton/flag_gems/numpy matrix must
+      # match item by item (proves the single-step install baked into the image
+      # was inert), then import vllm + vllm_fl on the app container. Runs
+      # before push so a failed verify gates the push. Needs hardware access
+      # (the script reads run flags from .github/build-config.yml).
+      - name: Verify vllm app image
+        if: ${{ inputs.verify }}
+        run: |
+          set -euo pipefail
+          host="${{ needs.set-matrix.outputs.harbor_host }}"
+          app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
+          app_tag="${host}/${app_prefix}/vllm-${{ matrix.name }}:${{ matrix.version }}"
+          bash packaging/vllm/verify-vllm-backend.sh \
+            "${{ matrix.name }}" \
+            --vllm-version "${{ inputs.vllm_version }}" \
+            --app-image "${app_tag}"
+
+      - name: Push vllm app image
+        if: ${{ inputs.push }}
+        run: |
+          host="${{ needs.set-matrix.outputs.harbor_host }}"
+          app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
+          app_tag="${host}/${app_prefix}/vllm-${{ matrix.name }}:${{ matrix.version }}"
+          docker push "${app_tag}"

--- a/.github/workflows/vllm-plugin-wheel.yml
+++ b/.github/workflows/vllm-plugin-wheel.yml
@@ -1,0 +1,217 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: vllm-plugin wheel
+
+# Build vllm-plugin-FL wheels in the backend's runtime image, and
+# (optionally) upload them to the per-vendor PyPI.
+#
+# THE BUILD ENVIRONMENT IS THE BACKEND'S RUNTIME IMAGE: BASE_IMAGE =
+# flagos-runtime-{vendor}-{backend}:{version} (from generate_matrix --runtime),
+# exactly the megatron-wheel.yml model. Build env == delivery env: the wheel
+# is built against the same python/torch/triton/flag_gems the app image will
+# run, so it can be installed single-step without pulling in (or upgrading)
+# any runtime package.
+#
+# Dependency audit gate: after the wheel is built, packaging/vllm/audit-deps.py
+# reads the wheel's METADATA Requires-Dist and fails the build if it declares
+# any critical package (torch / torch_npu / torchvision / torchaudio / triton /
+# flag_gems / numpy / vllm). The plugin must not ship dependencies that could
+# overwrite the runtime matrix — the image provides them.
+#
+# Wheel flavor per backend: vllm_vendor comes from the build matrix
+# (generate_matrix.py, derived from cmake_backend). cuda-ABI backends compile
+# vllm_fl._C with VLLM_VENDOR=cuda; PrivateUse1 backends (ascend, gcu) build
+# the pure-python wheel with VLLM_VENDOR unset. The version (setuptools-scm
+# 0.2.0+g<sha>.d<date>, or the explicit plugin_version input) encodes the
+# exact plugin commit, so the app Containerfile's
+# `pip install vllm-plugin-fl==<version>` is a commit-precise pin.
+#
+# Upload target defaults to flagos-pypi-<vendor> so the wheel lands next to
+# that backend's vllm+flagos / torch / flag_gems. There is no schedule:
+# uploads are manual.
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: 'Backend whose runtime image builds the wheel (e.g. ascend-cann9.0.0, or "all")'
+        type: string
+        default: ascend-cann9.0.0
+      plugin_ref:
+        description: 'vllm-plugin-FL git ref to build (SHA pinning preferred; a branch name works but moves)'
+        type: string
+        default: main
+      plugin_version:
+        description: 'Wheel version override (e.g. 0.2.0+gcf8998c.d20260815); blank = setuptools-scm derivation'
+        type: string
+        default: ''
+      upload:
+        description: 'upload the wheel to the vendor PyPI'
+        type: boolean
+        default: false
+      pypi_repo:
+        description: 'Nexus PyPI repo (default flagos-pypi-<vendor>)'
+        type: string
+        default: ''
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/check-trigger-author
+
+  set-matrix:
+    needs: authorize
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install PyYAML
+        run: |
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages pyyaml
+      - id: set-matrix
+        run: |
+          if [[ "${{ inputs.backend }}" == "all" ]]; then
+            python3 scripts/generate_matrix.py --runtime > matrix.json
+          else
+            python3 scripts/generate_matrix.py --runtime ${{ inputs.backend }} > matrix.json
+          fi
+          cat matrix.json
+          echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: set-matrix
+    if: ${{ fromJSON(needs.set-matrix.outputs.matrix).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    runs-on: ${{ fromJSON(matrix.runson) }}
+    env:
+      WORK: /tmp/vllm-plugin-${{ matrix.name }}-${{ github.run_id }}
+      BASE_IMAGE: ${{ matrix.image_tag }}
+      PLUGIN_REF: ${{ inputs.plugin_ref }}
+      PLUGIN_VERSION: ${{ inputs.plugin_version }}
+      VLLM_VENDOR: ${{ matrix.vllm_vendor }}
+      EXTRA_PYPI: ${{ matrix.extra_pypi }}
+    steps:
+      - name: Checkout build-infra
+        uses: actions/checkout@v7
+
+      # Build the wheel inside the runtime image: same python/ABI as delivery.
+      # The git clone goes through HTTPS_PROXY (the secret) — github.com is
+      # not on the runtime image's baked NO_PROXY.
+      - name: Build the wheel in the runtime image
+        run: |
+          set -euo pipefail
+          docker pull "${BASE_IMAGE}"
+          mkdir -p "${WORK}/src" "${WORK}/out"
+          docker run --rm \
+            -e VLLM_VENDOR \
+            -e PLUGIN_VERSION \
+            -e HTTPS_PROXY="${{ secrets.HTTP_PROXY }}" \
+            -e HTTP_PROXY="${{ secrets.HTTP_PROXY }}" \
+            -v "${WORK}/src:/work/src" \
+            -v "${WORK}/out:/work/out" \
+            "${BASE_IMAGE}" \
+            bash -euo pipefail -c '
+              git clone --depth 1 \
+                https://github.com/flagos-ai/vllm-plugin-FL.git /work/src
+              cd /work/src
+              git fetch --depth 1 origin "${PLUGIN_REF}"
+              git checkout FETCH_HEAD
+              git rev-parse HEAD > /work/out/commit.txt
+              # --no-build-isolation: build against the runtime venv (same
+              # python/ABI as delivery). An explicit PLUGIN_VERSION forces the
+              # setuptools-scm version deterministically.
+              if [ -n "${PLUGIN_VERSION}" ]; then
+                export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VLLM_PLUGIN_FL="${PLUGIN_VERSION}"
+              fi
+              /flagos/bin/pip install --quiet --index-url "${EXTRA_PYPI}" \
+                "setuptools>=77,<81" "setuptools-scm>=8" "wheel"
+              /flagos/bin/pip wheel --no-build-isolation --no-deps \
+                -w /work/out .
+              ls -la /work/out/
+            '
+          echo ">>> plugin commit: $(cat "${WORK}/out/commit.txt")"
+          wheel=$(ls "${WORK}"/out/*.whl | head -n1)
+          if [ -z "${PLUGIN_VERSION}" ] && \
+             [[ "$(basename "${wheel}")" == vllm_plugin_fl-0.0.0* ]]; then
+            echo "ERROR: derived version is 0.0.0 — the plugin repo tag is " \
+                 "unreachable on this runner (cached mirror). Pass " \
+                 "plugin_version to pin the version explicitly." >&2
+            exit 1
+          fi
+          echo ">>> built: $(basename "${wheel}")"
+
+      # Host-side audit (stdlib only): fail the build if the wheel declares a
+      # critical package — it would drift the runtime matrix on a single-step
+      # app-image install.
+      - name: Audit the wheel dependencies
+        run: |
+          set -euo pipefail
+          python3 packaging/vllm/audit-deps.py "${WORK}"/out/*.whl
+
+      # Upload only when explicitly requested (default false so a manual build
+      # from a branch is safe). Upload runs from inside the runtime image —
+      # no host python needed (the node runner's /usr/bin/python3 may lack
+      # pip). The secret travels via `-e NEXUS_TOKEN` so it never appears in
+      # a process list or image layer.
+      - name: Upload to vendor PyPI
+        if: ${{ inputs.upload }}
+        env:
+          NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEXUS_TOKEN:-}" ]; then
+            echo "ERROR: NEXUS_TOKEN secret is empty or unset" >&2
+            exit 1
+          fi
+          vendor="${matrix.name%%-*}"
+          pypi_repo="${{ inputs.pypi_repo }}"
+          pypi_repo="${pypi_repo:-flagos-pypi-${vendor}}"
+          echo ">>> uploading $(ls "${WORK}"/out/*.whl | xargs -n1 basename) to ${pypi_repo}"
+          docker run --rm \
+            -e NEXUS_TOKEN \
+            -e pypi_repo="${pypi_repo}" \
+            -e EXTRA_PYPI="${EXTRA_PYPI}" \
+            -v "${WORK}/out:/wheels" \
+            "${BASE_IMAGE}" \
+            bash -euo pipefail -c '
+              # Upgrade pkginfo too: setuptools >=77 (PEP 639) stamps
+              # Metadata-Version 2.4 into the wheel, which older pkginfo cannot
+              # parse -> twine aborts before upload. pkginfo >=1.11 reads 2.4.
+              /flagos/bin/pip install --quiet --index-url "${EXTRA_PYPI}" --upgrade twine pkginfo
+              export TWINE_USERNAME="${NEXUS_TOKEN%%:*}"
+              export TWINE_PASSWORD="${NEXUS_TOKEN#*:}"
+              /flagos/bin/twine upload \
+                --repository-url "https://resource.flagos.net/repository/${pypi_repo}/" \
+                --non-interactive \
+                /wheels/*.whl
+            '
+
+      - name: Clean up the work dir
+        if: ${{ always() }}
+        run: rm -rf "${WORK}"

--- a/.github/workflows/vllm-wheel.yml
+++ b/.github/workflows/vllm-wheel.yml
@@ -1,0 +1,172 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: vllm wheel
+
+# Build + repack vllm wheels for one (or all) backend(s), and optionally
+# upload them to the per-vendor PyPI. This is the CI consolidation of the
+# manual packaging/vllm/build-and-repack.sh — same build (runtime
+# flagos-runtime-{vendor}-{backend}:{version}-build image, nvidia = standard
+# pip download mode, other backends = VLLM_TARGET_DEVICE=empty source build),
+# same repack (packaging/vllm/repack.py + config.yaml), same per-vendor
+# upload target.
+#
+# Why the wheel at all: vllm >= 0.24.0 ships rust frontend components, so the
+# wheel is ABI-bound to the vendor image's (python, arch) — there is no
+# py3-none-any wheel (user correction, 2026-08-18). Repacking strips the
+# torch chain and pins the binary deps (opencv, xgrammar) to the vendor
+# matrix; keeping the matched set on one index is what makes a vllm version
+# bump safe. The app image installs this wheel single-step
+# (vllm==<version>+flagos), never touching the runtime matrix.
+#
+# Note: per-vendor vllm_version defaults are not yet in configs.yaml — pass
+# --vllm-version / the vllm_version input explicitly.
+#
+# Upload target defaults to flagos-pypi-<vendor>. There is no schedule:
+# uploads are manual.
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: 'Backend whose -build image repacks the wheel (e.g. ascend-cann9.0.0, or "all")'
+        type: string
+        default: ascend-cann9.0.0
+      vllm_version:
+        description: 'vLLM version to build (e.g. 0.24.0)'
+        type: string
+        default: 0.24.0
+      upload:
+        description: 'upload the repacked +flagos wheel(s) to the vendor PyPI'
+        type: boolean
+        default: false
+      pypi_repo:
+        description: 'Nexus PyPI repo (default flagos-pypi-<vendor>)'
+        type: string
+        default: ''
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/check-trigger-author
+
+  set-matrix:
+    needs: authorize
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install PyYAML
+        run: |
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --break-system-packages pyyaml
+      - id: set-matrix
+        run: |
+          if [[ "${{ inputs.backend }}" == "all" ]]; then
+            python3 scripts/generate_matrix.py --runtime > matrix.json
+          else
+            python3 scripts/generate_matrix.py --runtime ${{ inputs.backend }} > matrix.json
+          fi
+          cat matrix.json
+          echo "matrix=$(jq -c . matrix.json)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: set-matrix
+    if: ${{ fromJSON(needs.set-matrix.outputs.matrix).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    runs-on: ${{ fromJSON(matrix.runson) }}
+    env:
+      STACK_VERSION: ${{ matrix.version }}
+      VLLM_VERSION: ${{ inputs.vllm_version }}
+    steps:
+      - name: Checkout build-infra
+        uses: actions/checkout@v7
+
+      # Wraps build-and-repack.sh; the -build image must already exist on the
+      # runner (pulled by the script, `|| true`). Wheels land in
+      # /tmp/vllm-repack-<vendor>-<backend>/output on the runner host.
+      # HTTPS_PROXY is not needed: the build pulls vllm source from the
+      # internal filestore / aliyun, never github.com.
+      - name: Build + repack the vllm wheel
+        run: |
+          set -euo pipefail
+          # STACK_VERSION comes from the matrix; the script also needs pyyaml
+          # on the runner, which set-matrix already installed.
+          bash packaging/vllm/build-and-repack.sh \
+            "${{ matrix.name }}" \
+            --vllm-version "${VLLM_VERSION}"
+
+      - name: Audit the wheel dependencies
+        run: |
+          set -euo pipefail
+          python3 packaging/vllm/audit-deps.py \
+            /tmp/vllm-repack-${{ matrix.name%%-* }}-${{ matrix.name#*- }}/output/*.whl
+
+      # Upload only when explicitly requested. Runs from inside the -build
+      # image (no host python needed); the secret travels via `-e
+      # NEXUS_TOKEN` so it never appears in a process list or image layer.
+      - name: Upload to vendor PyPI
+        if: ${{ inputs.upload }}
+        env:
+          NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
+          EXTRA_PYPI: ${{ matrix.extra_pypi }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEXUS_TOKEN:-}" ]; then
+            echo "ERROR: NEXUS_TOKEN secret is empty or unset" >&2
+            exit 1
+          fi
+          vendor="${{ matrix.name%%-* }}"
+          backend="${{ matrix.name#*- }}"
+          pypi_repo="${{ inputs.pypi_repo }}"
+          pypi_repo="${pypi_repo:-flagos-pypi-${vendor}}"
+          img="harbor.baai.ac.cn/flagos-runtime/flagos-runtime-${{ matrix.name }}:${STACK_VERSION}-build"
+          echo ">>> uploading $(ls /tmp/vllm-repack-${vendor}-${backend}/output/*.whl | xargs -n1 basename) to ${pypi_repo}"
+          docker run --rm \
+            -e NEXUS_TOKEN \
+            -e pypi_repo="${pypi_repo}" \
+            -e EXTRA_PYPI="${EXTRA_PYPI}" \
+            -v "/tmp/vllm-repack-${vendor}-${backend}:/work" \
+            "${img}" \
+            bash -euo pipefail -c '
+              # Upgrade pkginfo too: setuptools >=77 (PEP 639) stamps
+              # Metadata-Version 2.4 into the wheel, which older pkginfo cannot
+              # parse -> twine aborts before upload. pkginfo >=1.11 reads 2.4.
+              /flagos/bin/pip install --quiet --index-url "${EXTRA_PYPI}" --upgrade twine pkginfo
+              export TWINE_USERNAME="${NEXUS_TOKEN%%:*}"
+              export TWINE_PASSWORD="${NEXUS_TOKEN#*:}"
+              /flagos/bin/twine upload \
+                --repository-url "https://resource.flagos.net/repository/${pypi_repo}/" \
+                --non-interactive \
+                /work/output/*.whl
+            '
+
+      - name: Clean up the build container and work dir
+        if: ${{ always() }}
+        run: |
+          docker rm -f vllm-build-${{ matrix.name%%-* }}-${{ matrix.name#*- }} 2>/dev/null || true
+          rm -rf /tmp/vllm-repack-${{ matrix.name%%-* }}-${{ matrix.name#*- }}

--- a/app/vllm/Containerfile
+++ b/app/vllm/Containerfile
@@ -21,9 +21,11 @@
 # Revision history:
 #   2026-07-28   Initial version. vllm from repacked wheel (vendor
 #                PyPI), vllm-plugin-FL from source.
+#   2026-08-18   vllm-plugin-FL installed from the vendor PyPI as a prebuilt
+#                wheel (vllm-plugin-fl==<version>) built + dependency-audited
+#                by the vllm-plugin-wheel workflow — no git clone, no source
+#                build inside the app image.
 # TODO
-#   - vllm-plugin-FL: build+release as wheel, then `pip install`
-#     instead of source-building.
 #   - Publish-time verification (torch version, vllm import).
 # ============================================================
 
@@ -40,13 +42,16 @@ ARG FLAGOS_PYPI=""
 # Fallback for all other dependencies.
 ARG EXTRA_PYPI="https://mirrors.aliyun.com/pypi/simple"
 
-# vllm-plugin-FL git ref.
-ARG PLUGIN_FL_REF=""
+# vllm-plugin-FL wheel version (e.g. "0.2.0+gcf8998c.d20260815") — the
+# setuptools-scm tag+commit encoding, so wheel == exact plugin commit. Built
+# by the vllm-plugin-wheel workflow in the same runtime image and published
+# to the vendor PyPI; nothing is built from source here.
+ARG PLUGIN_FL_VERSION=""
 
-# "cuda" for CUDA-ABI backends (nvidia, metax, hygon, iluvatar,
-#   mthreads, kunlunxin, cambricon).
-# "ascend" / "gcu" for PrivateUse1.
-ARG VLLM_VENDOR=cuda
+# Vendor-conditional app-level deps (configs.yaml deps_app.vllm), installed
+# after the plugin. Some backends need a package in the app layer that is not
+# in the runtime matrix.
+ARG APP_DEPS=""
 
 # --- Install vllm (repacked wheel) ----------------------------
 
@@ -61,18 +66,17 @@ RUN pip install \
   --extra-index-url "${EXTRA_PYPI}" \
   "vllm==${VLLM_VERSION}+flagos"
 
-# --- Install vllm-plugin-FL (source) --------------------------
+# --- Install vllm-plugin-FL (wheel) --------------------------
 
-ARG PLUGIN_FL_REF
-RUN if [ -n "${PLUGIN_FL_REF}" ]; then \
-    git clone \
-      --branch "${PLUGIN_FL_REF}" \
-      --depth 1 \
-      https://github.com/flagos-ai/vllm-plugin-FL.git \
-      /workspace/vllm-plugin-FL \
-    && cd /workspace/vllm-plugin-FL \
-    && VLLM_VENDOR=${VLLM_VENDOR} pip install --no-build-isolation . \
-    && rm -rf /workspace/vllm-plugin-FL ; \
+# Clean single-step install of the audited plugin wheel — same index pair as
+# vllm. The wheel's Requires-Dist is audited to be empty of the runtime's
+# critical packages (audit-deps.py), so pip has no reason to touch the baked
+# matrix.
+RUN if [ -n "${PLUGIN_FL_VERSION}" ]; then \
+    pip install \
+      --index-url "${FLAGOS_PYPI}" \
+      --extra-index-url "${EXTRA_PYPI}" \
+      "vllm-plugin-fl==${PLUGIN_FL_VERSION}" ; \
   fi
 
 # --- App env ---------------------------------------------------
@@ -84,6 +88,15 @@ ARG APP_ENV=""
 RUN if [ -n "${APP_ENV}" ]; then \
       printf '%s\n' "${APP_ENV}" > /etc/profile.d/app_env.sh; \
     fi
+
+# --- Vendor-conditional app deps -----------------------------
+
+RUN if [ -n "${APP_DEPS}" ]; then \
+    pip install \
+      --index-url "${FLAGOS_PYPI}" \
+      --extra-index-url "${EXTRA_PYPI}" \
+      ${APP_DEPS} ; \
+  fi
 
 # --- Runtime --------------------------------------------------
 

--- a/packaging/vllm/audit-deps.py
+++ b/packaging/vllm/audit-deps.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit a built wheel's declared dependencies against the critical set.
+
+The runtime image bakes a pinned matrix (torch / torch_npu / torchvision /
+torchaudio / triton / flag_gems / numpy, plus vllm itself for the app layer).
+App images install wheels single-step, so a wheel that *declares* one of
+these packages would give pip a reason to resolve/upgrade it and silently
+drift the matrix. This gate reads each wheel's METADATA ``Requires-Dist`` and
+fails the build when a watched package is declared.
+
+The vllm-plugin-FL wheel is the motivating case: it must ship with an empty
+(or pyyaml-only) requirement set even though its runtime needs torch — the
+torch comes from the image, never from the wheel.
+
+Usage:
+    python3 audit-deps.py [--watch pkg ...] wheel.whl [wheel.whl ...]
+
+Exit status: 0 = clean, 1 = a watched package is declared.
+"""
+
+import argparse
+import sys
+import zipfile
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--watch",
+        action="append",
+        default=["torch", "torch_npu", "torchvision", "torchaudio", "triton",
+                 "flag_gems", "numpy", "vllm"],
+        metavar="PKG",
+        help="package names to fail on if declared (repeatable)",
+    )
+    parser.add_argument("wheels", nargs="+", metavar="wheel.whl")
+    args = parser.parse_args()
+
+    watch = {w.lower().replace("_", "-") for w in args.watch}
+    failed = False
+
+    for wheel in args.wheels:
+        requires: list[str] = []
+        with zipfile.ZipFile(wheel) as zf:
+            for name in zf.namelist():
+                if name.endswith(".dist-info/METADATA"):
+                    requires = [
+                        ln.split(";", 1)[0].split("[", 1)[0].strip()
+                        for ln in zf.read(name).decode().splitlines()
+                        if ln.startswith("Requires-Dist:")
+                    ]
+                    break
+
+        declared = {r.lower().replace("_", "-") for r in requires}
+        hits = sorted(declared & watch)
+        print(f"{wheel}: requires {len(requires)} packages "
+              f"(watchlist hits: {', '.join(hits) if hits else 'none'})")
+        if hits:
+            failed = True
+            for pkg in hits:
+                print(f"  FAIL: declares critical package {pkg} — "
+                      f"an app-image single-step install would drift the "
+                      f"runtime matrix. Drop it from the wheel's "
+                      f"dependencies; the image provides it.",
+                      file=sys.stderr)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/vllm/verify-vllm-backend.sh
+++ b/packaging/vllm/verify-vllm-backend.sh
@@ -36,6 +36,12 @@
 #   4. Verify torch version not overwritten
 #   5. Install vllm-plugin-FL
 #   6. Test vllm serve and inference
+#
+# --app-image <image>: instead of steps 3-6, verify a prebuilt
+#   flagos-dev/vllm-{vendor}-{backend}:{version} image (built by the
+#   vllm-app-image workflow): the critical-package matrix
+#   (torch/torch_npu/triton/flag_gems/numpy) must be identical to the runtime
+#   image's, and vllm + vllm_fl must import. No installs run; serve is skipped.
 
 set -euo pipefail
 
@@ -44,16 +50,20 @@ set -euo pipefail
 VENDOR_BACKEND="${1:-}"
 MODEL_PATH="${MODEL_PATH:-/data/models/Qwen/Qwen3-4B}"
 VLLM_VERSION="${VLLM_VERSION:-0.20.2}"
+PLUGIN_FL_VERSION="${PLUGIN_FL_VERSION:-}"
 SKIP_SERVE=false
 VLLM_VENDOR="cuda"
+APP_IMAGE=""
 
 shift || true
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --model) MODEL_PATH="$2"; shift 2 ;;
         --vllm-version) VLLM_VERSION="$2"; shift 2 ;;
+        --plugin-fl-version) PLUGIN_FL_VERSION="$2"; shift 2 ;;
         --skip-serve) SKIP_SERVE=true; shift ;;
         --vllm-vendor) VLLM_VENDOR="$2"; shift 2 ;;
+        --app-image) APP_IMAGE="$2"; shift 2 ;;
         --help)
             echo "Usage: $0 <vendor-backend> [options]"
             echo ""
@@ -63,8 +73,10 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --model <path>       Path to model for serve test"
             echo "  --vllm-version <ver> vLLM version to install (default: 0.20.2)"
+            echo "  --plugin-fl-version <ver> vllm-plugin-FL wheel version (default: skip plugin)"
             echo "  --vllm-vendor <vendor> VLLM_VENDOR for plugin build (default: cuda)"
             echo "  --skip-serve          Skip serve test, only install and verify imports"
+            echo "  --app-image <image>   Verify a prebuilt vllm app image (matrix + import)"
             exit 0
             ;;
         *) echo "Unknown option: $1"; exit 1 ;;
@@ -167,15 +179,83 @@ raw = vendor_config.get('raw', '')
 print(toolkit if toolkit else raw)
 ")
 
+# The model mount is only needed for the serve test — skip it in --app-image
+# mode (no installs, no serve; the path may not even exist on the node).
+MODEL_MOUNT=""
+[[ -z "${APP_IMAGE}" ]] && MODEL_MOUNT="-v ${MODEL_PATH}:${MODEL_PATH}:ro"
+
 docker run -d --name "${CONTAINER}" \
     ${RUN_FLAGS} \
     -v "${WORK_DIR}:${WORK_DIR}" \
-    -v "${MODEL_PATH}:${MODEL_PATH}:ro" \
+    ${MODEL_MOUNT} \
     --network host \
     "${RUNTIME_IMAGE}" \
     sleep infinity
 
 log_info "Container started: ${CONTAINER}"
+
+# ── App-image mode: verify a prebuilt vllm app image ─────────────────────
+#
+# Facility 2 (vllm-app-image.yml) verifies the built
+# flagos-dev/vllm-{vendor}-{backend}:{version} image instead of installing
+# from scratch: BEFORE snapshot from the runtime image, AFTER from the app
+# image — the critical-package matrix (torch / torch_npu / triton /
+# flag_gems / numpy) must match item by item, proving the single-step wheel
+# installs baked into the image were inert. Then import vllm + vllm_fl on
+# the app container. No install steps run; the serve test is skipped.
+if [[ -n "${APP_IMAGE}" ]]; then
+    log_step "App-image mode: verifying ${APP_IMAGE}"
+
+    APP_CONTAINER="vllm-app-verify-${VENDOR}-${BACKEND}"
+    docker rm -f "${APP_CONTAINER}" 2>/dev/null || true
+
+    WATCH_PKGS="torch torch_npu triton flag_gems numpy"
+    snapshot() {
+        local cid="$1" pkg ver
+        for pkg in ${WATCH_PKGS}; do
+            ver=$(docker exec "${cid}" python3 -c \
+                "import importlib.metadata as m; print(m.version('${pkg}'))" \
+                2>/dev/null || echo "NOT_INSTALLED")
+            echo "${pkg}=${ver}"
+        done
+    }
+
+    log_step "BEFORE snapshot (runtime image)"
+    snapshot "${CONTAINER}" | tee "${WORK_DIR}/before.txt"
+
+    docker run -d --name "${APP_CONTAINER}" \
+        ${RUN_FLAGS} \
+        --network host \
+        "${APP_IMAGE}" \
+        sleep infinity
+    log_info "App container started: ${APP_CONTAINER}"
+
+    log_step "AFTER snapshot (app image)"
+    snapshot "${APP_CONTAINER}" | tee "${WORK_DIR}/after.txt"
+
+    log_step "Comparing critical-package matrix"
+    if diff -u "${WORK_DIR}/before.txt" "${WORK_DIR}/after.txt"; then
+        log_info "✅ Matrix unchanged: the app image did not overwrite runtime packages"
+    else
+        log_error "❌ Matrix changed: the app image overwrote a runtime package"
+        docker rm -f "${APP_CONTAINER}" 2>/dev/null || true
+        exit 1
+    fi
+
+    log_step "Import check (vllm + vllm_fl)"
+    if docker exec "${APP_CONTAINER}" bash -c \
+        'python3 -c "import vllm, vllm_fl; print(\"vllm\", vllm.__version__, \"| plugin ok\")"'; then
+        log_info "✅ vllm + vllm_fl import OK"
+    else
+        log_error "❌ import failed"
+        docker rm -f "${APP_CONTAINER}" 2>/dev/null || true
+        exit 1
+    fi
+
+    docker rm -f "${APP_CONTAINER}" 2>/dev/null || true
+    log_info "App-image verification PASSED"
+    exit 0
+fi
 
 # ── Step 2: Verify runtime environment ──────────────────────────────────
 
@@ -282,23 +362,29 @@ docker exec "${CONTAINER}" bash -c "
     esac
 "
 
-# ── Step 5: Install vllm-plugin-FL ──────────────────────────────────────
+# ── Step 5: Install vllm-plugin-FL (wheel) ──────────────────────────────
 
 log_step "Step 5: Installing vllm-plugin-FL"
 
-docker exec "${CONTAINER}" bash -c "
-    cd /workspace
-    if [ ! -d vllm-plugin-FL ]; then
-        git clone --depth 1 https://github.com/flagos-ai/vllm-plugin-FL.git
-    fi
-    cd vllm-plugin-FL
+if [[ -z "${PLUGIN_FL_VERSION}" ]]; then
+    log_warn "No --plugin-fl-version given; skipping plugin install"
+    log_warn "Pass --plugin-fl-version <version> to install the audited plugin wheel"
+else
+    # Clean single-step install from the vendor PyPI, same index pair as
+    # vllm. The wheel's Requires-Dist is audited to be empty of the runtime's
+    # critical packages (packaging/vllm/audit-deps.py), so pip has no reason
+    # to touch the baked torch/triton/flag_gems matrix.
+    docker exec "${CONTAINER}" bash -c "
+        pip install \
+            --index-url '${VENDOR_PYPI}' \
+            --extra-index-url '${ALIYUN_PYPI}' \
+            'vllm-plugin-fl==${PLUGIN_FL_VERSION}'
 
-    VLLM_VENDOR=${VLLM_VENDOR} pip install --no-build-isolation -e .
-
-    echo ''
-    echo 'Plugin installed:'
-    pip list | grep -i vllm
-"
+        echo ''
+        echo 'Plugin installed:'
+        pip show vllm-plugin-fl | grep -E '^(Name|Version|Location)'
+    "
+fi
 
 # ── Step 6: Test vllm serve ─────────────────────────────────────────────
 

--- a/scripts/generate_matrix.py
+++ b/scripts/generate_matrix.py
@@ -129,6 +129,12 @@ def _runtime_matrix(
         cpp_backend = str(backend_info.get("cmake_backend", "")).lower()
         cpp_extra = f"cpp-{cpp_backend}" if cpp_backend else ""
 
+        # vllm-plugin-FL build vendor: cuda-ABI backends (cmake_backend cuda)
+        # compile the vllm_fl._C extension (VLLM_VENDOR=cuda); PrivateUse1
+        # backends (NPU, no cuda in cmake_backend) build the pure-python
+        # package with VLLM_VENDOR unset.
+        vllm_vendor = "cuda" if "cuda" in cpp_backend else ""
+
         # Per-backend runtime env vars — serialized as "KEY=value\nKEY2=value2"
         runtime_env = (backend_info.get("env") or {}).get("runtime", {})
         runtime_env_lines = "\n".join(
@@ -168,6 +174,7 @@ def _runtime_matrix(
                 backend_info.get("triton_post_install", [])
             ) if isinstance(backend_info.get("triton_post_install"), list) else "",
             "runtime_env": runtime_env_lines,
+            "vllm_vendor": vllm_vendor,
         }
         # App build matrix = runtime fields + app env + app deps; --runtime
         # keeps no app_env/app_deps keys so runtime-image.yml output is unchanged.


### PR DESCRIPTION
## Summary

Replaces the dirty git-clone vllm-plugin-FL install with a three-workflow, wheel-based pipeline. build-infra owns packaging **and** the dependency audit, so a single-step app-image install can never overwrite the runtime's baked torch / torch_npu / triton / flag_gems / numpy matrix.

## The three workflows

1. **`vllm-plugin-wheel.yml`** — builds the vllm-plugin-FL wheel **inside the backend's runtime image** (`BASE_IMAGE = flagos-runtime-{vendor}-{backend}:{version}`, same model as megatron-wheel.yml): build env == delivery env, so the wheel installs single-step without pulling in or upgrading any runtime package. `VLLM_VENDOR` comes from the matrix (`generate_matrix.py`: `cuda` if `"cuda" in cpp_backend`, else empty) — cuda-ABI backends compile `vllm_fl._C`, PrivateUse1 backends (ascend, gcu) get a pure-python wheel. The setuptools-scm version (`0.2.0+g<sha>.d<date>`, or the `plugin_version` input) encodes the exact plugin commit. **audit-deps.py gates the build.**

2. **`vllm-wheel.yml`** — wraps `packaging/vllm/build-and-repack.sh` (empty build mode for non-nvidia backends, standard pip download for nvidia), audits the repacked `vllm==<version>+flagos` wheel, optionally uploads to the per-vendor PyPI. vllm >= 0.24.0 ships rust frontend components, so the wheel is ABI-bound to the vendor image's (python, arch) — the `+flagos` pin on the vendor index is what makes a version bump safe.

3. **`vllm-app-image.yml`** — builds `flagos-app/vllm-{vendor}-{backend}:{version}` from the runtime image with **two clean pip installs** (`vllm==<ver>+flagos` then `vllm-plugin-fl==<ver>`, both vendor-PyPI-first / aliyun-fallback), then verifies the built image on-node before push: `verify-vllm-backend.sh --app-image` snapshots the critical-package matrix from the runtime image (BEFORE) and the app image (AFTER) — they must match item by item, proving the baked installs were inert — plus a `vllm + vllm_fl` import check.

## Supporting pieces

- **`packaging/vllm/audit-deps.py`** — stdlib-only METADATA Requires-Dist scanner; fails the build if the wheel declares any critical runtime package (torch / torch_npu / torchvision / torchaudio / triton / flag_gems / numpy / vllm). The plugin must not ship dependencies that could overwrite the runtime matrix.
- **`app/vllm/Containerfile`** — plugin installed as a prebuilt wheel (`ARG PLUGIN_FL_VERSION`, git-clone block removed); new `ARG APP_DEPS` for vendor-conditional app-level deps (`configs.yaml deps_app.vllm`).
- **`packaging/vllm/verify-vllm-backend.sh`** — Step 5 now installs the audited plugin wheel (`--plugin-fl-version`, no git clone); new `--app-image` mode (matrix BEFORE/AFTER diff + import check, no installs, serve skipped, no model mount).
- **`scripts/generate_matrix.py`** — `vllm_vendor` derived from `cmake_backend` for `--app vllm` matrices.

## Not included

- `packaging/megatron/docs/memory/megatron-verification-state.md` (megatron track) — left out of this PR.

This PR was written in part with the assistance of generative AI.
