### PR TITLE
fix(vllm-plugin-wheel): move NO_PROXY comment off continuation lines

### DIFF
--- a/.github/workflows/vllm-plugin-wheel.yml
+++ b/.github/workflows/vllm-plugin-wheel.yml
@@ -232,6 +232,11 @@ jobs:
             -e NEXUS_TOKEN \
             -e pypi_repo="${pypi_repo}" \
             -e EXTRA_PYPI="${EXTRA_PYPI}" \
+            # Same proxy bypass as the build step: no baked NO_PROXY in the
+            # runtime image, so aliyun (twine/pkginfo install) and
+            # resource.flagos.net (upload) must bypass the tunnel.
+            -e NO_PROXY=".aliyun.com,.flagos.net,.baai.ac.cn" \
+            -e no_proxy=".aliyun.com,.flagos.net,.baai.ac.cn" \
             -v "${WORK}/out:/wheels" \
             "${BASE_IMAGE}" \
             bash -euo pipefail -c '

--- a/.github/workflows/vllm-plugin-wheel.yml
+++ b/.github/workflows/vllm-plugin-wheel.yml
@@ -149,6 +149,12 @@ jobs:
           fi
           docker pull "${BASE_IMAGE}"
           mkdir -p "${WORK}/src" "${WORK}/out"
+          # The runtime image bakes no NO_PROXY, so without it every pip
+          # request (aliyun/flagos) tunnels through the proxy and dies with
+          # "Tunnel connection failed: 500". Mirror the megatron builder's
+          # baked NO_PROXY (packaging/megatron/builder/Containerfile):
+          # vendor-adjacent traffic bypasses the tunnel, github.com (not on
+          # the list) keeps using the proxy for the clone.
           docker run --rm \
             -e VLLM_VENDOR \
             -e PLUGIN_VERSION \
@@ -157,12 +163,6 @@ jobs:
             -e EXTRA_PYPI \
             -e HTTPS_PROXY="${{ secrets.HTTP_PROXY }}" \
             -e HTTP_PROXY="${{ secrets.HTTP_PROXY }}" \
-            # The runtime image bakes no NO_PROXY, so without it every pip
-            # request (aliyun/flagos) tunnels through the proxy and dies with
-            # "Tunnel connection failed: 500". Mirror the megatron builder's
-            # baked NO_PROXY (packaging/megatron/builder/Containerfile):
-            # vendor-adjacent traffic bypasses the tunnel, github.com (not on
-            # the list) keeps using the proxy for the clone.
             -e NO_PROXY=".aliyun.com,.flagos.net,.baai.ac.cn" \
             -e no_proxy=".aliyun.com,.flagos.net,.baai.ac.cn" \
             -v "${WORK}/src:/work/src" \


### PR DESCRIPTION
## Summary

The NO_PROXY fix landed in #433 put its explanatory comment between backslash-continued lines of the `docker run` invocation. Bash joins those lines into one logical line, so the `#` starts a comment mid-command and discards every argument after it — including the image — failing with `docker: 'docker run' requires at least 1 argument` before the container starts.

Two fixes on this PR:

1. Move the comment to standalone lines before `docker run`.
2. The upload step's container runs the same pattern (`pip install twine pkginfo` from aliyun + twine upload to resource.flagos.net) — it also needs the NO_PROXY bypass, which it lacked.

This PR was written in part with the assistance of generative AI.