### PR TITLE
docs(megatron): record metax flagtree training E2E and merged-wheel usage changes

### DIFF
--- a/packaging/megatron/docs/megatron-hygon25-e2e.md
+++ b/packaging/megatron/docs/megatron-hygon25-e2e.md
@@ -247,6 +247,8 @@ checkout；`megatron.training` 已在 wheel 中，§1.1）。**3.5.1 复验通�
 | `--no-persist-layer-norm` / `--no-gradient-accumulation-fusion` | 相应 fused kernel 在 DCU 上不可用的显式关闭 |
 | `--attention-backend unfused` | 仅 local 训练线需要；RL（TE）线不传（§5.4） |
 | `--transformer-impl` | 训练用 `local`；RL 必须 `transformer_engine`（§5.4） |
+| `--lr 1e-6` | 训练必传：merged wheel（config dataclass 重构）默认 `None`，不传即 `float(None)` 崩（§2.1 之外的上游使用方式变更，2026-08-18 定） |
+| `--eval-interval 1000` | 必传：merged wheel 默认 `None` + training.py 无条件 `train_iters // eval_interval` 崩（上游已知缺口，用法侧规避，2026-08-18 定） |
 | `--shm-size=8g`（docker run） | torch multiprocessing 需大于容器默认 64MB 共享内存 |
 
 ### 2.1 venv 缺 python3-config（2026-08-16 实测）

--- a/packaging/megatron/docs/megatron-verification-matrix.md
+++ b/packaging/megatron/docs/megatron-verification-matrix.md
@@ -43,7 +43,7 @@
 | 天数智芯 | COREX 4.4.0   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 昆仑芯   | XRE 5.37.1    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 沐曦     | MACA 3.7.2.1  | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
-| 沐曦     | MACA 3.8.1.3  | ⬜      | ✅      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
+| 沐曦     | MACA 3.8.1.3  | ✅      | ✅      | ⛔          | ⛔          | ✅        | ✅        | ✅      | ✅      |
 | 摩尔线程 | MUSA 4.3.6    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 摩尔线程 | MUSA 5.2.0    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 进迭时空 | SPACEMIT      | ⬜      | —       | ⬜          | —           | ？        | —         | ⛔      | —       |
@@ -59,12 +59,23 @@
 ## 已验证/已知事实
 
 - **metax training（2026-08-18）**：merged wheel
-  `0.17.1+fl.20260818.g48b97a13f1bb`（合并 #105/#106/#107/#114），flagtree
-  0.6.1，**5 iter E2E exit 0**（loss 1.084350E+01 → 1.084006E+01，lr 1e-6
-  constant，与 hygon 量级吻合）。环境要点：huggingface.co 不通 → NullTokenizer
-  离线路径；GPU 0 被占用 → `CUDA_VISIBLE_DEVICES=1`。启动命令参数集与 hygon
+  `0.17.1+fl.20260818.g48b97a13f1bb`（合并 #105/#106/#107/#114），**双编译器
+  均 5 iter E2E exit 0**——flagtree 0.6.1（loss 1.084350E+01 → 1.084006E+01）
+  与 vendor triton 3.6.0+metax3.8.1.0（loss 1.084290E+01，12:58 run，量级与
+  flagtree 线吻合）。环境要点：huggingface.co 不通 → NullTokenizer 离线路径；
+  GPU 0 被占用 → `CUDA_VISIBLE_DEVICES=1`。启动命令参数集与 hygon
   相同，**无 jit_fuser noop 补丁前置**（metax flagtree 0.6.1 实测 `--disable-jit-fuser`
   直接够用；hygon 3.6.0 需容器侧 jit.py 补丁，§1.4——编译器机制跨版本不移植）。
+- **metax post_training × inference（2026-08-18，双编译器全 ✅）**：两场景均
+  编译器无关路径，triton/flagtree 各跑一遍全 exit 0——post_training = DummyModel
+  + `simple_generate`（output shape (1,8)，modelopt 0.45.0 ad-hoc 装入，未入
+  镜像，同 hygon §1.3.3）；inference = legacy `StaticInferenceEngine` 3 请求 ×
+  8 tokens。inference driver 无需外部词表（注入 prompt_tokens + 重写
+  detokenize，NullTokenizer 配方自洽），metax 容器无 gpt2 夹具也不阻塞。
+- **metax RL（双编译器均 ⛔，阻塞项确认）**：前置 = **MLF local-THD 修复
+  （rl_utils.py:666 无条件 thd → 条件构造）** + 无 vendor TE（官网
+  maca-transformerengine-3.7.1.0 与 3.8.1.3 形态不匹配，用户定不装，见状态
+  #6）——均非 build-infra 可解，待上游/MLF。
 - **merged wheel 参数接口重构 = 使用方法变更（2026-08-18 定）**：hygon 验证用
   的全范围 wheel 无此问题，merged wheel 引入 config dataclass +
   `ArgumentGroupFactory` 自动生成参数，`--lr`（`SchedulerConfig`）与

--- a/packaging/megatron/docs/megatron-verification-matrix.md
+++ b/packaging/megatron/docs/megatron-verification-matrix.md
@@ -43,7 +43,7 @@
 | 天数智芯 | COREX 4.4.0   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 昆仑芯   | XRE 5.37.1    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 沐曦     | MACA 3.7.2.1  | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
-| 沐曦     | MACA 3.8.1.3  | ✅      | ✅      | ⛔          | ⛔          | ✅        | ✅        | ✅      | ✅      |
+| 沐曦     | MACA 3.8.1.3  | ✅      | ✅      | ⬜          | ✅          | ✅        | ✅        | ✅      | ✅      |
 | 摩尔线程 | MUSA 4.3.6    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 摩尔线程 | MUSA 5.2.0    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 进迭时空 | SPACEMIT      | ⬜      | —       | ⬜          | —           | ？        | —         | ⛔      | —       |
@@ -72,10 +72,21 @@
   镜像，同 hygon §1.3.3）；inference = legacy `StaticInferenceEngine` 3 请求 ×
   8 tokens。inference driver 无需外部词表（注入 prompt_tokens + 重写
   detokenize，NullTokenizer 配方自洽），metax 容器无 gpt2 夹具也不阻塞。
-- **metax RL（双编译器均 ⛔，阻塞项确认）**：前置 = **MLF local-THD 修复
-  （rl_utils.py:666 无条件 thd → 条件构造）** + 无 vendor TE（官网
-  maca-transformerengine-3.7.1.0 与 3.8.1.3 形态不匹配，用户定不装，见状态
-  #6）——均非 build-infra 可解，待上游/MLF。
+- **metax RL（F 列 ✅，T 列待验；实证链终止 2026-08-19）**：run #17 走默认编译器
+  flagtree 线（/flagos env，`triton 3.6.0` 即 flagtree 0.6.1+metax3.6 的模块版本）。
+  真实障碍链（17 个，runs #3–#17，全 E2E 实证）全为本地代码/参数/harness 缺陷——
+  NullTokenizer pad/bos/eos 缺口、`--return-log-probs` 未注册、dynamic 批参协调
+  （`max_tokens<max_requests` 断言）、`[rl]` extra 运行时依赖缺失
+  （pyzmq/msgpack/quart/hypercorn/datasets）、flash_attn 2.6.3 的
+  `flash_decode_and_prefill` 仅 fp16/bf16（`--bf16` 规避）、torch inductor
+  异步编译 × flagtree metax driver `current_device()` fork 崩溃
+  （`TORCHINDUCTOR_COMPILE_THREADS=1`）、非 streaming drain 断言
+  （`--rl-partial-rollouts`）、harness eod 去重。**无 vendor TE 非阻塞项**——
+  驱动论点（"RL 双问题不应是阻塞项"）经 17 障碍全落地 + run #17 exit 0 坐实。
+  完整 GRPO 迭代 1/20 执行（consumed 8 samples，dynamic 引擎 8 组）。**T 列待验**
+  = `FLAGTREE_VERSION=none`（或 `compiler triton`）走 vendor triton 3.6.0+metax3.8.1.0
+  线重跑（运行事实：GPU 0 忙 → `CUDA_VISIBLE_DEVICES=1`；每次 relaunch 前 kill -9
+  遗留 pretrain 进程；watcher 只信 log "python exit=" 信号 + 25min 停滞双条件）。
 - **merged wheel 参数接口重构 = 使用方法变更（2026-08-18 定）**：hygon 验证用
   的全范围 wheel 无此问题，merged wheel 引入 config dataclass +
   `ArgumentGroupFactory` 自动生成参数，`--lr`（`SchedulerConfig`）与

--- a/packaging/megatron/docs/megatron-verification-matrix.md
+++ b/packaging/megatron/docs/megatron-verification-matrix.md
@@ -43,7 +43,7 @@
 | 天数智芯 | COREX 4.4.0   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 昆仑芯   | XRE 5.37.1    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 沐曦     | MACA 3.7.2.1  | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
-| 沐曦     | MACA 3.8.1.3  | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
+| 沐曦     | MACA 3.8.1.3  | ⬜      | ✅      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 摩尔线程 | MUSA 4.3.6    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 摩尔线程 | MUSA 5.2.0    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 进迭时空 | SPACEMIT      | ⬜      | —       | ⬜          | —           | ？        | —         | ⛔      | —       |
@@ -57,6 +57,26 @@
 - **仅 triton**（4 backend）：cambricon×2, spacemit, thead
 
 ## 已验证/已知事实
+
+- **metax training（2026-08-18）**：merged wheel
+  `0.17.1+fl.20260818.g48b97a13f1bb`（合并 #105/#106/#107/#114），flagtree
+  0.6.1，**5 iter E2E exit 0**（loss 1.084350E+01 → 1.084006E+01，lr 1e-6
+  constant，与 hygon 量级吻合）。环境要点：huggingface.co 不通 → NullTokenizer
+  离线路径；GPU 0 被占用 → `CUDA_VISIBLE_DEVICES=1`。启动命令参数集与 hygon
+  相同，**无 jit_fuser noop 补丁前置**（metax flagtree 0.6.1 实测 `--disable-jit-fuser`
+  直接够用；hygon 3.6.0 需容器侧 jit.py 补丁，§1.4——编译器机制跨版本不移植）。
+- **merged wheel 参数接口重构 = 使用方法变更（2026-08-18 定）**：hygon 验证用
+  的全范围 wheel 无此问题，merged wheel 引入 config dataclass +
+  `ArgumentGroupFactory` 自动生成参数，`--lr`（`SchedulerConfig`）与
+  `--eval-interval`（`TrainingConfig`）默认 `None`——不传即崩：`--lr` → 
+  `optimizer_param_scheduler.py:148` `float(None)` TypeError；`--eval-interval`
+  → `training.py:3672` `train_iters // None` TypeError。**非功能变更，是使用
+  方法变更**：训练功能仍在，但喂参接口重构。影响所有用 merged wheel 的后端，
+  **hygon 留下的 E2E 参数基线需逐参数重核**（可能有更多参数同样 None 默认）。
+  处置（2026-08-18 定，用法侧规避，不回馈上游）：两参数均随 sync #34
+  来自上游 Core 0.17.0（非 fork 偏离，上游 0.17.0 分支已过时，提修复意义
+  不大）；`--eval-interval` 默认 None + 无条件除法 = 上游已知缺口，
+  `--lr` 属训练必传参数——两者均由复现基线强制传参规避。
 
 - **hygon training**：vendor triton **3.5.1** ✅（2026-08-17 复验：mock data
   5 iter E2E exit 0，loss 1.084036E+01 → 1.083188E+01；3.3.0 时代已验证，但

--- a/packaging/megatron/docs/megatron-verification-matrix.md
+++ b/packaging/megatron/docs/megatron-verification-matrix.md
@@ -43,7 +43,7 @@
 | 天数智芯 | COREX 4.4.0   | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 昆仑芯   | XRE 5.37.1    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 沐曦     | MACA 3.7.2.1  | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
-| 沐曦     | MACA 3.8.1.3  | ✅      | ✅      | ⬜          | ✅          | ✅        | ✅        | ✅      | ✅      |
+| 沐曦     | MACA 3.8.1.3  | ✅      | ✅      | ✅          | ✅          | ✅        | ✅        | ✅      | ✅      |
 | 摩尔线程 | MUSA 4.3.6    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 摩尔线程 | MUSA 5.2.0    | ⬜      | ⬜      | ⬜          | ⬜          | ？        | ？        | ⛔      | ⛔      |
 | 进迭时空 | SPACEMIT      | ⬜      | —       | ⬜          | —           | ？        | —         | ⛔      | —       |
@@ -72,21 +72,24 @@
   镜像，同 hygon §1.3.3）；inference = legacy `StaticInferenceEngine` 3 请求 ×
   8 tokens。inference driver 无需外部词表（注入 prompt_tokens + 重写
   detokenize，NullTokenizer 配方自洽），metax 容器无 gpt2 夹具也不阻塞。
-- **metax RL（F 列 ✅，T 列待验；实证链终止 2026-08-19）**：run #17 走默认编译器
-  flagtree 线（/flagos env，`triton 3.6.0` 即 flagtree 0.6.1+metax3.6 的模块版本）。
-  真实障碍链（17 个，runs #3–#17，全 E2E 实证）全为本地代码/参数/harness 缺陷——
+- **metax RL（双编译器全 ✅；实证链终止 2026-08-19）**：F 列 = run #17 走默认编译器
+  flagtree 线（/flagos env，`triton 3.6.0` 即 flagtree 0.6.1+metax3.6 的模块版本）；
+  **T 列 = run #18 走 vendor triton 线（`compiler triton` → `triton 3.6.0`
+  /opt/triton/triton/__init__.py），07:10:11 → 07:11:37 UTC exit 0**，同配方全链
+  通过（rollout 8 组，GRPO 迭代 1/20，elapsed 30727 ms，0 错误）。真实障碍链
+  （17 个，runs #3–#17，全 E2E 实证）全为本地代码/参数/harness 缺陷——
   NullTokenizer pad/bos/eos 缺口、`--return-log-probs` 未注册、dynamic 批参协调
   （`max_tokens<max_requests` 断言）、`[rl]` extra 运行时依赖缺失
   （pyzmq/msgpack/quart/hypercorn/datasets）、flash_attn 2.6.3 的
   `flash_decode_and_prefill` 仅 fp16/bf16（`--bf16` 规避）、torch inductor
-  异步编译 × flagtree metax driver `current_device()` fork 崩溃
+  异步编译 × metax driver `current_device()` fork 崩溃
   （`TORCHINDUCTOR_COMPILE_THREADS=1`）、非 streaming drain 断言
-  （`--rl-partial-rollouts`）、harness eod 去重。**无 vendor TE 非阻塞项**——
-  驱动论点（"RL 双问题不应是阻塞项"）经 17 障碍全落地 + run #17 exit 0 坐实。
-  完整 GRPO 迭代 1/20 执行（consumed 8 samples，dynamic 引擎 8 组）。**T 列待验**
-  = `FLAGTREE_VERSION=none`（或 `compiler triton`）走 vendor triton 3.6.0+metax3.8.1.0
-  线重跑（运行事实：GPU 0 忙 → `CUDA_VISIBLE_DEVICES=1`；每次 relaunch 前 kill -9
-  遗留 pretrain 进程；watcher 只信 log "python exit=" 信号 + 25min 停滞双条件）。
+  （`--rl-partial-rollouts`）、harness eod 去重。**两处环境不合规均实证非阻塞**：
+  无 vendor TE（`--transformer-impl local` 全程无 TE）+ flash_attn 2.6.3 版本断言
+  不达标但功能支持 block_table 路径（断言是版本号检查非功能检查，对 vendor 变体
+  不适用）。**固化清单见状态文档 #6（5 补丁 + 4 配方参数）**。运行事实：GPU 0 忙
+  → `CUDA_VISIBLE_DEVICES=1`；每次 relaunch 前 kill -9 遗留 pretrain 进程；
+  watcher 只信 log "python exit=" 信号 + 25min 停滞双条件。
 - **merged wheel 参数接口重构 = 使用方法变更（2026-08-18 定）**：hygon 验证用
   的全范围 wheel 无此问题，merged wheel 引入 config dataclass +
   `ArgumentGroupFactory` 自动生成参数，`--lr`（`SchedulerConfig`）与

--- a/packaging/megatron/docs/memory/megatron-verification-state.md
+++ b/packaging/megatron/docs/memory/megatron-verification-state.md
@@ -48,9 +48,21 @@ runtime
 3. **CI 支撑（已落地，两 PR）**：generate_matrix 支持 app 级 deps + `--app {app}` 输出 `app_env`/`app_deps` 随 **PR #424 OPEN**；megatron-app-image.yml 参数化 app 名（`megatron-training`|`megatron-rl` input → 镜像 tag / matrix / APP_DEPS build-arg，Containerfile 前置 vendor RUN）随 **PR #425 OPEN**
 4. **apex 纳入 hygon runtime**（A1，2026-08-17 确认，**已落地：PR #422 merged + wheel 已传 flagos-pypi-hygon**）：上传 `apex==1.7.0+das.opt1.dtk2604.torch290` + configs.yaml hygon deps 加 `apex==1.7.0+das.opt1.dtk2604.torch290`。**定性：apex 是 vendor 可选加速包（熔断可选，MLF 里 4 处使用全 try/except fallback——multi_tensor_applier / FusedLayerNorm / FusedAdam），非 RL 硬依赖**；kunlunxin/metax 已有先例（apex==0.1 / apex==0.1+metax3.8.1.0）
 5. **TE 每后端条件性登记（已落地，随 #424）**：hygon `megatron-rl` deps_app 登记 `transformer_engine==2.10.0+das.opt1.dtk2604.torch290`；其余后端 `[]`（无 vendor TE，构建时无 vendor 包，RL 纯公共场景假设待第二后端实证）
-6. **metax 无 vendor TE（2026-08-18 用户定）**：官网仅有 `maca-transformerengine-3.7.1.0` 包（TE 2.13.0 + flash_fusion + grouped_gemm 三件套，wheel 只带 torch2.6/2.8，`.layerspec/` conda 形态，install.sh 按 torch X.Y glob 匹配）——SDK/torch/环境形态三样均不匹配 metax 3.8.1.3（torch 2.10.0），**官网无 3.8.1.3 版本**。该 3.7.1.0 包或可用于另一后端（maca3.7.2.1 线 torch2.8），但非关键包，**用户定：不装**。metax `deps_app.megatron-rl` 保持 `[]`；metax RL 前置 = **MLF local-THD 修复（rl_utils.py:666 无条件 thd → 条件构造）**——从此前"建议项"升格为 metax RL 阻塞项
+6. **metax 无 vendor TE（2026-08-18 用户定，2026-08-19 实证坐实非阻塞）**：官网仅有
+   `maca-transformerengine-3.7.1.0` 包（TE 2.13.0 + flash_fusion + grouped_gemm
+   三件套，wheel 只带 torch2.6/2.8，`.layerspec/` conda 形态，install.sh 按 torch
+   X.Y glob 匹配）——SDK/torch/环境形态三样均不匹配 metax 3.8.1.3（torch 2.10.0），
+   **官网无 3.8.1.3 版本**。该 3.7.1.0 包或可用于另一后端（maca3.7.2.1 线
+   torch2.8），但非关键包，**用户定：不装**。metax `deps_app.megatron-rl` 保持 `[]`。
+   **实证（2026-08-19 终止）**：run #17（flagtree 线）完整 GRPO E2E exit 0——
+   `--transformer-impl local` 全程无 TE 跑通，**无 vendor TE 确证非阻塞项**。
+   **local-THD（rl_utils.py:666 无条件 thd）**：实证链以容器侧条件化补丁
+   （transformer_impl=="local" 时 thd=None）落地、非阻塞；归类为 MLF 反馈项
+   （见待反馈项），**不再是 metax RL 阻塞项**。真实障碍链 17 个（runs #3–#17）
+   全为本地代码/参数/harness 缺陷，详见
+   `megatron-verification-matrix.md` metax RL 条目。
 
-**待 MLF 反馈项**（建议权，不阻塞 build-infra）：jit_fuser 惰性装饰、RL extra 声明偏差（**已提 PR #114，见 C 定稿**）、local-THD（rl_utils.py:666 无条件 thd → 条件构造）、eos_id None 兜底、dynamic 引擎 flash_attn 依赖软化（megatron.py:87 可配置 fallback）。
+**待 MLF 反馈项**（建议权，不阻塞 build-infra）：jit_fuser 惰性装饰、RL extra 声明偏差（**已提 PR #114，见 C 定稿**）、local-THD（rl_utils.py:666 无条件 thd → 条件构造；**2026-08-19 实证：容器侧条件化补丁即通，非阻塞，但 metax RL 走 local impl 必需**）、eos_id None 兜底、dynamic 引擎 flash_attn 依赖软化（megatron.py:87 可配置 fallback）。
 
 ## 既有定案（早前，仍有效）
 

--- a/packaging/megatron/docs/memory/megatron-verification-state.md
+++ b/packaging/megatron/docs/memory/megatron-verification-state.md
@@ -48,6 +48,7 @@ runtime
 3. **CI 支撑（已落地，两 PR）**：generate_matrix 支持 app 级 deps + `--app {app}` 输出 `app_env`/`app_deps` 随 **PR #424 OPEN**；megatron-app-image.yml 参数化 app 名（`megatron-training`|`megatron-rl` input → 镜像 tag / matrix / APP_DEPS build-arg，Containerfile 前置 vendor RUN）随 **PR #425 OPEN**
 4. **apex 纳入 hygon runtime**（A1，2026-08-17 确认，**已落地：PR #422 merged + wheel 已传 flagos-pypi-hygon**）：上传 `apex==1.7.0+das.opt1.dtk2604.torch290` + configs.yaml hygon deps 加 `apex==1.7.0+das.opt1.dtk2604.torch290`。**定性：apex 是 vendor 可选加速包（熔断可选，MLF 里 4 处使用全 try/except fallback——multi_tensor_applier / FusedLayerNorm / FusedAdam），非 RL 硬依赖**；kunlunxin/metax 已有先例（apex==0.1 / apex==0.1+metax3.8.1.0）
 5. **TE 每后端条件性登记（已落地，随 #424）**：hygon `megatron-rl` deps_app 登记 `transformer_engine==2.10.0+das.opt1.dtk2604.torch290`；其余后端 `[]`（无 vendor TE，构建时无 vendor 包，RL 纯公共场景假设待第二后端实证）
+6. **metax 无 vendor TE（2026-08-18 用户定）**：官网仅有 `maca-transformerengine-3.7.1.0` 包（TE 2.13.0 + flash_fusion + grouped_gemm 三件套，wheel 只带 torch2.6/2.8，`.layerspec/` conda 形态，install.sh 按 torch X.Y glob 匹配）——SDK/torch/环境形态三样均不匹配 metax 3.8.1.3（torch 2.10.0），**官网无 3.8.1.3 版本**。该 3.7.1.0 包或可用于另一后端（maca3.7.2.1 线 torch2.8），但非关键包，**用户定：不装**。metax `deps_app.megatron-rl` 保持 `[]`；metax RL 前置 = **MLF local-THD 修复（rl_utils.py:666 无条件 thd → 条件构造）**——从此前"建议项"升格为 metax RL 阻塞项
 
 **待 MLF 反馈项**（建议权，不阻塞 build-infra）：jit_fuser 惰性装饰、RL extra 声明偏差（**已提 PR #114，见 C 定稿**）、local-THD（rl_utils.py:666 无条件 thd → 条件构造）、eos_id None 兜底、dynamic 引擎 flash_attn 依赖软化（megatron.py:87 可配置 fallback）。
 

--- a/packaging/megatron/docs/memory/megatron-verification-state.md
+++ b/packaging/megatron/docs/memory/megatron-verification-state.md
@@ -48,19 +48,30 @@ runtime
 3. **CI 支撑（已落地，两 PR）**：generate_matrix 支持 app 级 deps + `--app {app}` 输出 `app_env`/`app_deps` 随 **PR #424 OPEN**；megatron-app-image.yml 参数化 app 名（`megatron-training`|`megatron-rl` input → 镜像 tag / matrix / APP_DEPS build-arg，Containerfile 前置 vendor RUN）随 **PR #425 OPEN**
 4. **apex 纳入 hygon runtime**（A1，2026-08-17 确认，**已落地：PR #422 merged + wheel 已传 flagos-pypi-hygon**）：上传 `apex==1.7.0+das.opt1.dtk2604.torch290` + configs.yaml hygon deps 加 `apex==1.7.0+das.opt1.dtk2604.torch290`。**定性：apex 是 vendor 可选加速包（熔断可选，MLF 里 4 处使用全 try/except fallback——multi_tensor_applier / FusedLayerNorm / FusedAdam），非 RL 硬依赖**；kunlunxin/metax 已有先例（apex==0.1 / apex==0.1+metax3.8.1.0）
 5. **TE 每后端条件性登记（已落地，随 #424）**：hygon `megatron-rl` deps_app 登记 `transformer_engine==2.10.0+das.opt1.dtk2604.torch290`；其余后端 `[]`（无 vendor TE，构建时无 vendor 包，RL 纯公共场景假设待第二后端实证）
-6. **metax 无 vendor TE（2026-08-18 用户定，2026-08-19 实证坐实非阻塞）**：官网仅有
-   `maca-transformerengine-3.7.1.0` 包（TE 2.13.0 + flash_fusion + grouped_gemm
-   三件套，wheel 只带 torch2.6/2.8，`.layerspec/` conda 形态，install.sh 按 torch
-   X.Y glob 匹配）——SDK/torch/环境形态三样均不匹配 metax 3.8.1.3（torch 2.10.0），
-   **官网无 3.8.1.3 版本**。该 3.7.1.0 包或可用于另一后端（maca3.7.2.1 线
-   torch2.8），但非关键包，**用户定：不装**。metax `deps_app.megatron-rl` 保持 `[]`。
-   **实证（2026-08-19 终止）**：run #17（flagtree 线）完整 GRPO E2E exit 0——
-   `--transformer-impl local` 全程无 TE 跑通，**无 vendor TE 确证非阻塞项**。
+6. **metax 无 vendor TE（2026-08-18 用户定，2026-08-19 双编译器实证坐实非阻塞）**：
+   官网仅有 `maca-transformerengine-3.7.1.0` 包（TE 2.13.0 + flash_fusion +
+   grouped_gemm 三件套，wheel 只带 torch2.6/2.8，`.layerspec/` conda 形态，
+   install.sh 按 torch X.Y glob 匹配）——SDK/torch/环境形态三样均不匹配 metax
+   3.8.1.3（torch 2.10.0），**官网无 3.8.1.3 版本**。该 3.7.1.0 包或可用于另一
+   后端（maca3.7.2.1 线 torch2.8），但非关键包，**用户定：不装**。metax
+   `deps_app.megatron-rl` 保持 `[]`。**实证（2026-08-19 终止，双编译器全 ✅）**：
+   F 列 run #17（flagtree 线）与 T 列 run #18（vendor triton 线）均完整 GRPO E2E
+   exit 0——`--transformer-impl local` 全程无 TE 跑通，**无 vendor TE 确证非阻塞项**。
    **local-THD（rl_utils.py:666 无条件 thd）**：实证链以容器侧条件化补丁
    （transformer_impl=="local" 时 thd=None）落地、非阻塞；归类为 MLF 反馈项
    （见待反馈项），**不再是 metax RL 阻塞项**。真实障碍链 17 个（runs #3–#17）
-   全为本地代码/参数/harness 缺陷，详见
-   `megatron-verification-matrix.md` metax RL 条目。
+   全为本地代码/参数/harness 缺陷，详见 `megatron-verification-matrix.md` metax RL 条目。
+
+   **metax RL 固化清单（2026-08-19 两编译器并齐后，阶段二输入）**：容器内 5 补丁
+   + 4 配方参数（对应真实障碍，全实证）。归属：MLF 反馈项 = null_tokenizer
+   pad/bos/eos 属性组、inference/utils.py getattr 回退、rl_utils.py thd 条件化
+   （local 时 None，双线必需）、arguments.py 注册 `--return-log-probs`、flash_attn
+   断言门控（attention.py:943 按 DotProductAttention 跳过，版本号检查对 vendor
+   变体不适用）；镜像 ENV 候选 = `TORCHINDUCTOR_COMPILE_THREADS=1`（进程内编译避
+   fork×driver current_device 崩溃）；配方参数 = `--transformer-impl local`、
+   `--bf16`（flash_decode_and_prefill 仅 fp16/bf16）、`--rl-partial-rollouts`
+   （streaming 跳 drain 断言）。harness 自研（dummy_agent isinstance/env_id/eod
+   去重）不入固化。
 
 **待 MLF 反馈项**（建议权，不阻塞 build-infra）：jit_fuser 惰性装饰、RL extra 声明偏差（**已提 PR #114，见 C 定稿**）、local-THD（rl_utils.py:666 无条件 thd → 条件构造；**2026-08-19 实证：容器侧条件化补丁即通，非阻塞，但 metax RL 走 local impl 必需**）、eos_id None 兜底、dynamic 引擎 flash_attn 依赖软化（megatron.py:87 可配置 fallback）。
 

--- a/packaging/megatron/docs/memory/megatron-verification-state.md
+++ b/packaging/megatron/docs/memory/megatron-verification-state.md
@@ -62,18 +62,20 @@ runtime
    （见待反馈项），**不再是 metax RL 阻塞项**。真实障碍链 17 个（runs #3–#17）
    全为本地代码/参数/harness 缺陷，详见 `megatron-verification-matrix.md` metax RL 条目。
 
-   **metax RL 固化清单（2026-08-19 两编译器并齐后，阶段二输入）**：容器内 5 补丁
-   + 4 配方参数（对应真实障碍，全实证）。归属：MLF 反馈项 = null_tokenizer
+   **metax RL 固化清单（2026-08-19 两编译器并齐后，阶段二输入；2026-08-19 落地）**：
+   容器内 5 补丁（6 hunk，全 5 文件已提 **MLF PR #116 OPEN**，与实证容器补丁逐字节
+   一致）+ 4 配方参数（对应真实障碍，全实证）。归属：MLF 反馈项 = null_tokenizer
    pad/bos/eos 属性组、inference/utils.py getattr 回退、rl_utils.py thd 条件化
-   （local 时 None，双线必需）、arguments.py 注册 `--return-log-probs`、flash_attn
-   断言门控（attention.py:943 按 DotProductAttention 跳过，版本号检查对 vendor
-   变体不适用）；镜像 ENV 候选 = `TORCHINDUCTOR_COMPILE_THREADS=1`（进程内编译避
-   fork×driver current_device 崩溃）；配方参数 = `--transformer-impl local`、
-   `--bf16`（flash_decode_and_prefill 仅 fp16/bf16）、`--rl-partial-rollouts`
-   （streaming 跳 drain 断言）。harness 自研（dummy_agent isinstance/env_id/eod
-   去重）不入固化。
+   （local 时 None，双线必需）、**rl_utils.py unwrap_model 替换 `.module.module`
+   链（inference 模式取 lang_module，清单初版遗漏的第二 hunk，随 #116 一并入**）、
+   arguments.py 注册 `--return-log-probs`、flash_attn 断言门控（attention.py:943
+   按 DotProductAttention 跳过，版本号检查对 vendor 变体不适用）；镜像 ENV 候选 =
+   `TORCHINDUCTOR_COMPILE_THREADS=1`（进程内编译避 fork×driver current_device
+   崩溃）；配方参数 = `--transformer-impl local`、`--bf16`（flash_decode_and_prefill
+   仅 fp16/bf16）、`--rl-partial-rollouts`（streaming 跳 drain 断言）。harness
+   自研（dummy_agent isinstance/env_id/eod 去重）不入固化。
 
-**待 MLF 反馈项**（建议权，不阻塞 build-infra）：jit_fuser 惰性装饰、RL extra 声明偏差（**已提 PR #114，见 C 定稿**）、local-THD（rl_utils.py:666 无条件 thd → 条件构造；**2026-08-19 实证：容器侧条件化补丁即通，非阻塞，但 metax RL 走 local impl 必需**）、eos_id None 兜底、dynamic 引擎 flash_attn 依赖软化（megatron.py:87 可配置 fallback）。
+**待 MLF 反馈项**（建议权，不阻塞 build-infra）：jit_fuser 惰性装饰、RL extra 声明偏差（**已提 PR #114，见 C 定稿**）、**RL local-impl 全套（2026-08-19 已提 PR #116 OPEN，见固化清单）**：local-THD 条件化（rl_utils.py:666 无条件 thd → 条件构造，实证必需）、null_tokenizer pad/bos/eos、inference/utils.py getattr 回退、`--return-log-probs` 注册、attention.py:943 flash_attn 断言门控、rl_utils.py unwrap_model。余：eos_id None 兜底、dynamic 引擎 flash_attn 依赖软化（megatron.py:87 可配置 fallback）。
 
 ## 既有定案（早前，仍有效）
 


### PR DESCRIPTION
## Summary

Record the metax (MACA 3.8.1.3) verify-track findings: the training E2E result on the merged wheel, the merged-wheel parameter interface changes, and the subsequent dual-compiler RL(GRPO) E2E passes.

## Changes

1. **Verification matrix**: metax MACA 3.8.1.3 training (flagtree) ⬜ → ✅ (2026-08-18, flagtree 0.6.1, merged wheel `0.17.1+fl.20260818.g48b97a13f1bb`, 5-iter E2E exit 0, loss 1.084350E+01 → 1.084006E+01).
2. **Verification matrix**: new entry "merged wheel parameter interface refactor = usage change" — `--lr` / `--eval-interval` default to `None` and crash if not passed (`float(None)` / `train_iters // None`). Disposition: work around on the usage side (both params came from upstream Core 0.17.0 via sync #34, not a fork deviation; 0.17.0 is outdated, no upstream feedback).
3. **Verification matrix**: metax needs no jit_fuser noop patch (flagtree 0.6.1 verified `--disable-jit-fuser` is enough; hygon 3.6.0 needs the container-side patch — compiler mechanism does not port across versions).
4. **RL cells reclassified**: metax MACA 3.8.1.3 RL ⛔/⛔ → ✅/✅ — run #17 (flagtree) + run #18 (vendor triton) full GRPO E2E both exit 0. The 17-obstacle empirical chain proved no-vendor-TE is **not** a blocker; local-THD downgraded from blocker to feedback item.
5. **memory state doc**: metax has no vendor TE (official index only ships 3.7.1.0 package, shape mismatch with 3.8.1.3, user decided not to install); metax RL prerequisite = MLF local-THD fix (rl_utils.py:666), now filed as MLF PR #116.

## Related

- Consolidation env: PR #443 (`TORCHINDUCTOR_COMPILE_THREADS=1` in metax megatron-rl app env)
- Patch side: MLF PR #116

This PR was written in part with the assistance of generative AI.
