### PR TITLE
fix(vllm-plugin-wheel): move upload-step proxy comment off continuation lines

### DIFF
--- a/.github/workflows/vllm-plugin-wheel.yml
+++ b/.github/workflows/vllm-plugin-wheel.yml
@@ -228,13 +228,13 @@ jobs:
           pypi_repo="${{ inputs.pypi_repo }}"
           pypi_repo="${pypi_repo:-flagos-pypi-${vendor}}"
           echo ">>> uploading $(ls "${WORK}"/out/*.whl | xargs -n1 basename) to ${pypi_repo}"
+          # Same proxy bypass as the build step: no baked NO_PROXY in the
+          # runtime image, so aliyun (twine/pkginfo install) and
+          # resource.flagos.net (upload) must bypass the tunnel.
           docker run --rm \
             -e NEXUS_TOKEN \
             -e pypi_repo="${pypi_repo}" \
             -e EXTRA_PYPI="${EXTRA_PYPI}" \
-            # Same proxy bypass as the build step: no baked NO_PROXY in the
-            # runtime image, so aliyun (twine/pkginfo install) and
-            # resource.flagos.net (upload) must bypass the tunnel.
             -e NO_PROXY=".aliyun.com,.flagos.net,.baai.ac.cn" \
             -e no_proxy=".aliyun.com,.flagos.net,.baai.ac.cn" \
             -v "${WORK}/out:/wheels" \


### PR DESCRIPTION
## Summary

#434 fixed the build step's mid-command comment, but the upload step's `docker run` has the identical bug: the NO_PROXY comment sits between backslash-continued lines, so the `#` discards the image argument and the upload fails with `docker: 'docker run' requires at least 1 argument`.

Move the comment to standalone lines before `docker run`. A scan now finds no comment on any backslash-continuation line in the workflow.

This PR was written in part with the assistance of generative AI.