### PR TITLE
fix(vllm-plugin-wheel): unblock upload step + tolerant cleanup

### DIFF
--- a/.github/workflows/vllm-plugin-wheel.yml
+++ b/.github/workflows/vllm-plugin-wheel.yml
@@ -224,7 +224,13 @@ jobs:
             echo "ERROR: NEXUS_TOKEN secret is empty or unset" >&2
             exit 1
           fi
-          vendor="${matrix.name%%-*}"
+          # `${{ matrix.name }}` cannot be substituted inside a bash
+          # parameter-expansion expression — ${matrix.name%%-*} reaches bash
+          # unexpanded and dies with "bad substitution". Expand into a local
+          # var first (2026-08-18, run 32138523697: build+audit passed, upload
+          # died on this line).
+          matrix_name="${{ matrix.name }}"
+          vendor="${matrix_name%%-*}"
           pypi_repo="${{ inputs.pypi_repo }}"
           pypi_repo="${pypi_repo:-flagos-pypi-${vendor}}"
           echo ">>> uploading $(ls "${WORK}"/out/*.whl | xargs -n1 basename) to ${pypi_repo}"
@@ -254,4 +260,12 @@ jobs:
 
       - name: Clean up the work dir
         if: ${{ always() }}
-        run: rm -rf "${WORK}"
+        run: |
+          # The container (root) writes git-clone and wheel-build files into
+          # the host bind mounts; under /tmp's sticky bit the runner user
+          # cannot delete them, so a plain `rm -rf` fails on every run that
+          # reaches file creation. Delete from inside the same runtime image
+          # (root) first, then remove the empty host dir. `|| true` keeps a
+          # failed cleanup from failing the job — the work is already done.
+          docker run --rm -v "${WORK}:/work" "${BASE_IMAGE}" rm -rf /work 2>/dev/null || true
+          rm -rf "${WORK}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Run 32138523697 (first pilot upload attempt) built the ascend plugin wheel and passed the dependency audit, then failed at the upload step: `vendor="${matrix.name%%-*}"` reaches bash unexpanded — GitHub Actions does not substitute contexts inside bash parameter-expansion syntax — so bash dies with `bad substitution` before twine ever runs.

The cleanup step failed on the same run for a structural reason that recurs on every run that reaches file creation: the container (root) writes git-clone and wheel-build files into the host bind mounts, and under `/tmp`'s sticky bit the runner user cannot remove root-owned files.

## Change

- `.github/workflows/vllm-plugin-wheel.yml`
  - Upload step: expand `${{ matrix.name }}` into a local variable first, then derive the vendor repo name from it.
  - Cleanup step: delete the work dir from inside the same runtime image (root) before removing the empty host dir, and tolerate either failure so a failed cleanup cannot fail a job whose real work already succeeded.

This PR was written in part with the assistance of generative AI.
