### PR TITLE
feat(vllm-app): add vllm-serve launcher so a plain docker run works

### DIFF
--- a/app/vllm/Containerfile
+++ b/app/vllm/Containerfile
@@ -25,6 +25,10 @@
 #                wheel (vllm-plugin-fl==<version>) built + dependency-audited
 #                by the vllm-plugin-wheel workflow — no git clone, no source
 #                build inside the app image.
+#   2026-08-18   vllm-serve launcher (COPY + CMD default): sources the baked
+#                vendor env before exec'ing vllm's API server, so a plain
+#                `docker run <image>` works — non-bash starts miss the
+#                profile.d-only LD_LIBRARY_PATH (libascend_hal.so).
 # TODO
 #   - Publish-time verification (torch version, vllm import).
 # ============================================================
@@ -98,7 +102,20 @@ RUN if [ -n "${APP_DEPS}" ]; then \
       ${APP_DEPS} ; \
   fi
 
-# --- Runtime --------------------------------------------------
+# --- Serve launcher -------------------------------------------
+
+# vllm-serve: the single serve command for this image. The full vendor env
+# (CANN / NNAL-ATB LD_LIBRARY_PATH) lives in /etc/profile.d, not in the image
+# ENV — a plain `docker run <image> /flagos/bin/python ...` bypasses bash and
+# misses it (torch_npu fails: libascend_hal.so not found). vllm-serve sources
+# it (idempotent) then execs vllm's API server, passing user args verbatim.
+# Default CMD = the reference serve (Qwen3-4B, port 8031); users override
+# with e.g. `docker run <image> vllm-serve --model <path> --port 9000`.
+COPY vllm-serve /usr/local/bin/vllm-serve
+RUN chmod +x /usr/local/bin/vllm-serve
 
 ENV VLLM_PLUGINS=fl
 WORKDIR /workspace
+CMD ["vllm-serve", "--model", "/data/models/Qwen/Qwen3-4B", "--port", "8031", \
+  "--gpu-memory-utilization", "0.6", "--enforce-eager", "--trust-remote-code", \
+  "--max-model-len", "2048", "--dtype", "bfloat16"]

--- a/app/vllm/vllm-serve
+++ b/app/vllm/vllm-serve
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ============================================================================
+# vllm-serve — the single serve command for the vllm app image.
+#
+# Sources the baked vendor env (full CANN / NNAL-ATB LD_LIBRARY_PATH lives in
+# /etc/profile.d/vendor.sh, NOT in the image ENV — a plain
+# `docker run <image> /flagos/bin/python ...` bypasses bash and misses it),
+# then execs vllm's OpenAI API server with the caller's arguments passed
+# through verbatim.
+#
+#   docker run <image> vllm-serve --model /data/models/Qwen/Qwen3-4B --port 8031
+#   docker run <image> vllm-serve --help
+#
+# The env source is idempotent (export lines + the zz-compiler function), so
+# it is safe whether or not the caller already ran through bash.
+# ============================================================================
+
+set -euo pipefail
+[ -r /etc/bash_env.sh ] && . /etc/bash_env.sh
+exec /flagos/bin/python -m vllm.entrypoints.openai.api_server "$@"


### PR DESCRIPTION
## Summary

A plain `docker run <image> /flagos/bin/python -m vllm...` fails on ascend: the full vendor env (CANN / NNAL-ATB `LD_LIBRARY_PATH`) lives in `/etc/profile.d/vendor.sh`, **not** in the image ENV — a non-bash process start bypasses profile.d and misses it, so torch_npu dies at import with `libascend_hal.so: cannot open shared object file` (reproduced on the hw25 serve smoke).

## Change

- `app/vllm/vllm-serve` — new launcher (`/usr/local/bin`): sources the baked vendor env (idempotent) then `exec`s vllm's OpenAI API server with user args passed through verbatim.
- `app/vllm/Containerfile` — `COPY` the launcher and set it as the default `CMD` (reference serve: Qwen3-4B, port 8031).

Usage stays minimal and flexible:

| `docker run <image> ...` | behavior |
|---|---|
| *(no args)* | default CMD — reference serve (Qwen3-4B, port 8031) |
| `vllm-serve --model X --port 9000` | serve with user args |
| `vllm-serve --help` | vllm help |
| `bash` | non-interactive bash (no tty → exits immediately) |
| `--entrypoint bash <image> ...` | platform-style entrypoint (env still ready via `BASH_ENV`) |

This PR was written in part with the assistance of generative AI.
