### PR TITLE
feat(flagtree): sunrise wheel builder (PR 978 fix) + CI target

### DIFF
--- a/.github/workflows/flagtree-wheel.yml
+++ b/.github/workflows/flagtree-wheel.yml
@@ -32,6 +32,7 @@ on:
         options:
           - metax
           - nvidia-cuda
+          - sunrise
         default: metax
       flagtree_version:
         description: 'FlagTree tag/ref to build (blank = Containerfile default)'

--- a/packaging/flagtree/sunrise
+++ b/packaging/flagtree/sunrise
@@ -130,12 +130,16 @@ RUN mkdir -p /root/.flagtree/sunrise /root/.triton \
 # Build the FlagTree sunrise wheel from source on this 22.04 toolchain.
 # FLAGTREE_BACKEND=sunrise selects the backend. Proxy (if any) is applied to every
 # RUN but not persisted. Force HTTP/1.1 for git and retry the flaky network steps.
+# FLAGTREE_VERSION may be a branch, tag, or commit sha (--branch clone can't take
+# a sha, so fetch + checkout FETCH_HEAD handles all three).
 RUN git config --global http.version HTTP/1.1 \
     && for i in 1 2 3 4 5 6 7 8; do \
-         git clone --branch "${FLAGTREE_VERSION}" --depth 1 \
-           https://github.com/flagos-ai/flagtree /opt/flagtree && break; \
-         echo ">>> flagtree clone attempt $i failed, retrying in 5s..."; \
-         rm -rf /opt/flagtree; sleep 5; \
+         rm -rf /opt/flagtree && git init -q /opt/flagtree \
+           && git -C /opt/flagtree remote add origin https://github.com/flagos-ai/flagtree \
+           && git -C /opt/flagtree fetch --depth 1 origin "${FLAGTREE_VERSION}" \
+           && git -C /opt/flagtree checkout -q FETCH_HEAD && break; \
+         echo ">>> flagtree fetch attempt $i failed, retrying in 5s..."; \
+         sleep 5; \
        done \
     && test -d /opt/flagtree/.git \
     && cd /opt/flagtree \

--- a/packaging/flagtree/sunrise
+++ b/packaging/flagtree/sunrise
@@ -1,0 +1,198 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build a FlagTree sunrise (PTPU) wheel on Ubuntu 22.04 (glibc 2.35 / gcc 11.4)
+# so the resulting libtriton.so links against an older glibc and loads on the
+# standard client bases. Sunrise runtime wheels are built on Ubuntu 24.04 and
+# drag in GLIBC_2.38 + GLIBCXX_3.4.32 (same defect class as the metax wheel).
+#
+# Source: FLAGTREE_BACKEND=sunrise from FlagTree main. The published vendor tag
+# 0.6.0+sunrise3.6 predates FlagTree PR 978 ("update sunrise backend plugin"),
+# which rewrote the sunrise backend pass pipeline and dropped add_split_dot --
+# the suspected fix for the flash_varlen_fwd_kernel decode+GQA non-terminating
+# kernel (vllm plugin reports report-vllm-0.20.2.md §2.9 / report-vllm-0.24.0.md
+# §11; A/B compile-only IR dumps show identical TTGIR between old flagtree and
+# stock triton, locating the defect downstream in the backend post-passes).
+# Building from main (default FLAGTREE_VERSION=main) captures PR 978 + any later
+# fix; pin a specific commit sha for reproducible releases.
+#
+# The prebuilt sunrise deps are staged into FlagTree's offline cache so the
+# build wires them itself (same pattern as the metax builder):
+#   - llvm-71bd243f -> ~/.flagtree/sunrise/sunrise_llvm22_dev_release
+#     (cache key "sunrise_llvm22_dev_release", post_hook configure_llvm copies
+#     stpu/bitcode/*.bc into third_party/sunrise/backend/lib)
+#   - sunriseTritonPlugin_v0.6.0.4 -> ~/.flagtree/sunrise/sunriseTritonPlugin.so
+#     (cache key "sunriseTritonPlugin.so"; md5 gate below pins 4c77b8c0)
+#   - build-deps-triton -> ~/.triton (triton origin toolkits)
+#
+# pybind11 is pinned OPPOSITE to the metax builder: the sunrise plugin v0.6.0.4
+# is compiled against pybind11 internals v12 (verified: embedded symbol
+# __pybind11_internals_v12), while metaxTritonPlugin is v11. FlagTree's own
+# _PYBIND11_INTERNALS_TO_PIP maps only up to v11, so for sunrise we pin the v12
+# range explicitly; the gate below asserts libtriton exposes v12, because a
+# mismatch makes sunrise.load_dialects(ctx) raise "TypeError: incompatible
+# function arguments" at kernel-compile time on real hardware (CI smoke import
+# on a GPU-less box cannot catch it).
+#
+# Build:
+#   docker build -t flagtree-sunrise:0.6.0 -f sunrise .
+#   # behind a proxy:
+#   docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy \
+#                -t flagtree-sunrise:0.6.0 -f sunrise .
+#   # via CI: dispatch flagtree-wheel.yml with target=sunrise.
+#
+# Extract the wheel:
+#   id=$(docker create flagtree-sunrise:0.6.0); docker cp $id:/wheels ./wheels; docker rm $id
+FROM ubuntu:22.04
+
+# Proxy is only consumed during build (predefined ARG, not persisted in the image).
+ARG http_proxy=
+ARG https_proxy=
+# FlagTree git ref to build. The sunrise fix (PR 978) exists only on main -- the
+# vendor tag 0.6.0+sunrise3.6 is pre-978. Default main; pass a commit sha for
+# reproducible builds.
+ARG FLAGTREE_VERSION=main
+# Wheel version string. FlagTree's setup.py (get_flagtree_version) appends a
+# dirty "+git<sha>" / ".git<sha>" suffix unless the build removes .git (git
+# rev-parse then fails and the suffix resolves empty). We don't have the vendor
+# FLAGTREE_PYPI_KEY, so we remove .git before `pip wheel` -> clean version, used
+# as-is. Default matches the vendor wheel label so this is a drop-in replacement;
+# append a suffix (e.g. 0.6.0+sunrise3.6.20260819) to distinguish a rebuild.
+ARG FLAGTREE_WHEEL_VERSION=0.6.0+sunrise3.6
+# Prebuilt sunrise deps, pinned by URL. These are backend inputs, not source:
+#  - llvm-71bd243f: prebuilt LLVM 22 (configure_llvm post_hook wires LLVM_SYSPATH).
+#  - sunriseTritonPlugin_v0.6.0.4: prebuilt sunrise codegen (PR 978 version,
+#    .so md5 4c77b8c0; compiled against pybind11 internals v12).
+#  - build-deps-triton: triton origin toolkits (nvidia nvcc/cudart + json/gtest).
+ARG DEPS_BASE=https://baai-cp-web.ks3-cn-beijing.ksyuncs.com/trans
+ARG LLVM_TARBALL=llvm-71bd243f-triton-v3.6.x.tar.gz
+ARG PLUGIN_TARBALL=sunriseTritonPlugin_v0.6.0.4.tar.gz
+ARG TRITON_DEPS_TARBALL=build-deps-triton_3.6.x-linux-x64.tar.gz
+# pybind11 version spec, pinned. The prebuilt sunriseTritonPlugin.so is compiled
+# against internals v12 (pybind11 >=3.1); libtriton must expose the same version
+# or kernel-compile fails on-device (see header comment). <3.2 guards against an
+# unknown future internals bump. The gate below asserts v12.
+ARG PYBIND11_SPEC=>=3.1,<3.2
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System build deps for the LLVM/Triton native build + Python 3.12 (deadsnakes).
+# gnupg/dirmngr are needed by add-apt-repository to import the PPA key.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common ca-certificates gnupg dirmngr \
+        git wget curl binutils \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        build-essential cmake ninja-build \
+        zlib1g zlib1g-dev libxml2 libxml2-dev nlohmann-json3-dev \
+        libncurses5-dev libncursesw5-dev libgdbm-dev libnss3-dev \
+        libssl-dev libreadline-dev libffi-dev libsqlite3-dev \
+        libdb5.3-dev libbz2-dev libexpat1-dev liblzma-dev \
+        python3.12 python3.12-venv python3.12-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# pip for python3.12 (deadsnakes ships ensurepip via the python3.12-venv package).
+RUN python3.12 -m ensurepip --upgrade \
+    && python3.12 -m pip install --no-cache-dir --upgrade pip wheel setuptools
+
+# Pre-stage the prebuilt sunrise deps into FlagTree's offline cache dirs so the
+# build wires them itself: LLVM -> sunrise_llvm22_dev_release (post_hook),
+# plugin -> sunriseTritonPlugin.so, triton toolkits -> ~/.triton. The plugin .so
+# is md5-gated to the PR 978 build (4c77b8c0); a drifted plugin fails the build
+# instead of silently pairing the new compiler.py with the old codegen. Retry the
+# large downloads (LLVM ~1 GB) since the runner's link to the bucket is flaky.
+RUN mkdir -p /root/.flagtree/sunrise /root/.triton \
+    && cd /tmp \
+    && for f in "${LLVM_TARBALL}" "${PLUGIN_TARBALL}" "${TRITON_DEPS_TARBALL}"; do \
+         for i in 1 2 3 4 5; do \
+           wget -q --tries=3 --timeout=60 "${DEPS_BASE}/${f}" -O "${f}" && break; \
+           echo ">>> download ${f} attempt $i failed, retrying in 10s..."; sleep 10; \
+         done; \
+       done \
+    && tar -xzf "${LLVM_TARBALL}"    -C /root/.flagtree/sunrise \
+    && tar -xzf "${PLUGIN_TARBALL}"  -C /root/.flagtree/sunrise \
+    && tar -xzf "${TRITON_DEPS_TARBALL}" -C /root/.triton \
+    && rm -f /tmp/*.tar.gz \
+    && test -d /root/.flagtree/sunrise/sunrise_llvm22_dev_release \
+    && test -f /root/.flagtree/sunrise/sunriseTritonPlugin.so \
+    && echo "4c77b8c0a71ddc377bbcfb1024114fc1  /root/.flagtree/sunrise/sunriseTritonPlugin.so" | md5sum -c -
+
+# Build the FlagTree sunrise wheel from source on this 22.04 toolchain.
+# FLAGTREE_BACKEND=sunrise selects the backend. Proxy (if any) is applied to every
+# RUN but not persisted. Force HTTP/1.1 for git and retry the flaky network steps.
+RUN git config --global http.version HTTP/1.1 \
+    && for i in 1 2 3 4 5 6 7 8; do \
+         git clone --branch "${FLAGTREE_VERSION}" --depth 1 \
+           https://github.com/flagos-ai/flagtree /opt/flagtree && break; \
+         echo ">>> flagtree clone attempt $i failed, retrying in 5s..."; \
+         rm -rf /opt/flagtree; sleep 5; \
+       done \
+    && test -d /opt/flagtree/.git \
+    && cd /opt/flagtree \
+    && python3.12 -m pip install --no-cache-dir -r python/requirements.txt \
+    && python3.12 -m pip install --no-cache-dir "pybind11${PYBIND11_SPEC}" \
+    && export FLAGTREE_BACKEND=sunrise \
+    && export FLAGTREE_WHEEL_VERSION="${FLAGTREE_WHEEL_VERSION}" \
+    && export TRITON_APPEND_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release" \
+    && rm -rf /opt/flagtree/.git \
+    && for i in 1 2 3 4 5; do \
+         python3.12 -m pip wheel . --no-build-isolation --no-deps -w /wheels -v && break; \
+         echo ">>> wheel build attempt $i failed, retrying in 10s..."; sleep 10; \
+       done \
+    && ls -la /wheels/*.whl
+
+# Gate: the reason this builder exists. Fail the build if the freshly built
+# libtriton.so reintroduces any symbol a 22.04 client cannot satisfy
+# (GLIBC_2.38, GLIBCXX_3.4.31/32, or the gcc-13/glibc-2.38 __isoc23_* family),
+# or if its pybind11 internals drift from v12 (the sunrise plugin's ABI).
+RUN python3.12 - <<'PY'
+import glob, subprocess, zipfile, tempfile, os, sys, re
+whl = glob.glob("/wheels/*.whl")[0]
+# Version gate: the wheel must carry the clean version, not FlagTree's dirty
+# "<ver>.git<sha>" / "+git<sha>" fallback (means the .git-removal didn't take).
+ver = os.path.basename(whl).split("-")[1]
+if "git" in ver:
+    print(f"FAIL: dirty wheel version '{ver}' (expected clean, no git<sha> suffix)")
+    sys.exit(1)
+print(f"OK: clean wheel version '{ver}'")
+d = tempfile.mkdtemp()
+zipfile.ZipFile(whl).extractall(d)
+so = next(p for p in glob.glob(d + "/**/libtriton.so", recursive=True))
+syms = subprocess.check_output(["objdump", "-T", so], text=True)
+forbidden = ["GLIBC_2.38", "GLIBCXX_3.4.31", "GLIBCXX_3.4.32", "__isoc23_"]
+hits = {f: syms.count(f) for f in forbidden if f in syms}
+if hits:
+    print("FAIL: 22.04-incompatible symbols in libtriton.so:", hits)
+    sys.exit(1)
+maxglibc = max(sorted(set(re.findall(r"GLIBC_[0-9.]+", syms))))
+print(f"OK: libtriton.so is 22.04-clean (max {maxglibc}, no forbidden symbols)")
+# pybind11 ABI gate: the prebuilt sunriseTritonPlugin_v0.6.0.4.so is compiled
+# against internals v12 (opposite of the metax plugin, which is v11). libtriton
+# MUST expose v12 or sunrise.load_dialects(ctx) fails on-device with a pybind11
+# type mismatch. The PYBIND11_SPEC pin above holds this; assert it here so a
+# future drift fails the build instead of shipping a wheel that only breaks on
+# hardware.
+with open(so, "rb") as f:
+    blob = f.read()
+internals = sorted(set(re.findall(rb"__pybind11_internals_v(\d+)", blob)))
+if internals != [b"12"]:
+    print(f"FAIL: libtriton.so pybind11 internals {internals} (expected [b'12']; "
+          "sunrise plugin v0.6.0.4 needs v12 -- adjust PYBIND11_SPEC)")
+    sys.exit(1)
+print("OK: libtriton.so pybind11 internals v12 (matches sunriseTritonPlugin_v0.6.0.4)")
+PY
+
+# Smoke test: install the freshly built wheel and import it (fails the build if broken).
+RUN python3.12 -m pip install --no-cache-dir /wheels/*.whl \
+    && python3.12 -c "import triton; from triton.backends import backends; \
+         print('OK triton', triton.__version__, 'backends', list(backends.keys()))"


### PR DESCRIPTION
## Summary

Adds a formal build-infra mechanism to build the FlagTree **sunrise** backend wheel from source:

1. **`packaging/flagtree/sunrise`** — a new Containerfile (ubuntu:22.04 old-glibc base, same pattern as the metax builder) that stages the prebuilt sunrise deps (LLVM 22 / `sunriseTritonPlugin_v0.6.0.4` / triton toolkits) into FlagTree's offline cache, builds the wheel from `FLAGTREE_VERSION` (default `main`) with `FLAGTREE_BACKEND=sunrise`, and gates the result (clean version, no 22.04-incompatible symbols, pybind11 internals v12, smoke import).

2. **`flagtree-wheel.yml`** — adds `sunrise` to the target choice list.

## Why

Both the baked runtime image and the hosted `flagos-pypi-*` wheel are **pre-978** (plugin md5 `f3c65d44` vs `4c77b8c0`). [FlagTree PR 978](https://github.com/flagos-ai/FlagTree/pull/978) rewrote exactly the layer where the defect lives — the sunrise backend post-pass pipeline / asm emission — and is the suspected fix for the `flash_varlen_fwd_kernel` decode+GQA **non-terminating kernel** on sunrise (see `packaging/vllm/docs/report-vllm-0.20.2.md` §2.9 and `report-vllm-0.24.0.md` §11). A source build from `main` is the only way to capture it.

## Notes

- **pybind11 pin is inverted vs metax**: the prebuilt `sunriseTritonPlugin.so` v0.6.0.4 is compiled against pybind11 internals **v12** (metax plugin is v11). The Containerfile pins `>=3.1,<3.2` and the gate asserts libtriton exposes v12, so a drift fails the build instead of shipping a wheel that breaks on-device.
- Plugin `.so` is md5-gated to `4c77b8c0` (the PR 978 build) so a drifted plugin fails the build rather than silently pairing new compiler.py with old codegen.
- Build runs on the `[self-hosted, h20]` runner (x86_64, docker) via `flagtree-wheel.yml` `target=sunrise`; upload (default off) goes to `flagos-pypi-sunrise`.
- Default wheel version `0.6.0+sunrise3.6` matches the vendor label; override `FLAGTREE_WHEEL_VERSION` (e.g. dated suffix) to distinguish a rebuild.

## Verification

Not yet E2E: the wheel needs to be built on the h20 runner (dispatch `flagtree-wheel.yml`, `target=sunrise`) and re-tested on a sunrise node against the minimal hang repro (`flash_varlen_fwd_kernel` decode+GQA). If the kernel retires, the F-column ❌ conclusions in both reports flip.

This PR was written in part with the assistance of generative AI.
