### PR TITLE
feat(configs): bake TORCHINDUCTOR_COMPILE_THREADS=1 into metax megatron-rl app env

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -53,7 +53,7 @@
 #                          runtime:     vars baked into flagos-runtime-{vendor}-{backend}
 #                          app:         per-app vars baked into
 #                                       flagos-app/{app}-{vendor}-{backend}, keyed by
-#                                       app name (vllm / megatron)
+#                                       app name (vllm / megatron-training / megatron-rl)
 #                        base/runtime/app must mirror EXACTLY what the image sets —
 #                        the source of truth for per-image env documentation.
 #   "deps:"            — Python dependencies (torch stack, etc.).
@@ -495,6 +495,15 @@ vendors:
           PATH: /opt/maca/mxgpu_llvm/bin:/opt/maca/bin:${PATH}
           MACA_PATH: /opt/maca
           LD_LIBRARY_PATH: /opt/maca/lib:/opt/maca/mxgpu_llvm/lib
+        app:
+          megatron-rl:
+            # RL's first rollout forward triggers self_attn_bda torch.compile;
+            # inductor's default subproc pool forks compile workers and flagtree's
+            # torch.cuda.current_device() call crashes in the forked child
+            # ("Cannot re-initialize CUDA in forked subprocess").
+            # TORCHINDUCTOR_COMPILE_THREADS=1 compiles in-process instead.
+            # This is specific to metax → app layer, not runtime.
+            TORCHINDUCTOR_COMPILE_THREADS: "1"
       deps:
         - apex==0.1+metax3.8.1.0
         - torch==2.10.0+metax3.8.1.0


### PR DESCRIPTION
## Summary

Bake `TORCHINDUCTOR_COMPILE_THREADS=1` into the metax `maca3.8.1.3` app env for `megatron-rl`.

**Root cause:** RL's first rollout forward triggers `self_attn_bda` `torch.compile`. Inductor's default subproc pool forks compile workers, and flagtree's `torch.cuda.current_device()` call in the forked child crashes with "Cannot re-initialize CUDA in forked subprocess" (metax × flagtree × torch-inductor interaction). `TORCHINDUCTOR_COMPILE_THREADS=1` disables the subproc pool so compilation runs in-process.

**Placement:** `env.app.megatron-rl` (metax `maca3.8.1.3` only), not `env.runtime` — this is specific to metax, so a global runtime-layer setting would be overreach. The value flows via the `megatron-app-image.yml` `APP_ENV` build-arg into `/etc/profile.d/app_env.sh`.

## Change

- `configs.yaml`: add `env.app.megatron-rl.TORCHINDUCTOR_COMPILE_THREADS=1` under metax `maca3.8.1.3`; update the `env.app` header comment to list the new app name.

## Related

- Patch side: MLF PR #116 (rl local backend fixes)
- Verification records: PR #435 (metax RL dual-compiler E2E matrix + state doc)

This PR was written in part with the assistance of generative AI.
