### PR TITLE
docs(megatron): refresh merged-PR statuses and drop unresolvable run refs

### DIFF
--- a/packaging/megatron/docs/megatron-verification-matrix.md
+++ b/packaging/megatron/docs/megatron-verification-matrix.md
@@ -72,12 +72,12 @@
   镜像，同 hygon §1.3.3）；inference = legacy `StaticInferenceEngine` 3 请求 ×
   8 tokens。inference driver 无需外部词表（注入 prompt_tokens + 重写
   detokenize，NullTokenizer 配方自洽），metax 容器无 gpt2 夹具也不阻塞。
-- **metax RL（双编译器全 ✅；实证链终止 2026-08-19）**：F 列 = run #17 走默认编译器
+- **metax RL（双编译器全 ✅；实证链终止 2026-08-19）**：F 列 = 默认编译器
   flagtree 线（/flagos env，`triton 3.6.0` 即 flagtree 0.6.1+metax3.6 的模块版本）；
-  **T 列 = run #18 走 vendor triton 线（`compiler triton` → `triton 3.6.0`
+  **T 列 = vendor triton 线（`compiler triton` → `triton 3.6.0`
   /opt/triton/triton/__init__.py），07:10:11 → 07:11:37 UTC exit 0**，同配方全链
   通过（rollout 8 组，GRPO 迭代 1/20，elapsed 30727 ms，0 错误）。真实障碍链
-  （17 个，runs #3–#17，全 E2E 实证）全为本地代码/参数/harness 缺陷——
+  （17 个，全 E2E 实证）全为本地代码/参数/harness 缺陷——
   NullTokenizer pad/bos/eos 缺口、`--return-log-probs` 未注册、dynamic 批参协调
   （`max_tokens<max_requests` 断言）、`[rl]` extra 运行时依赖缺失
   （pyzmq/msgpack/quart/hypercorn/datasets）、flash_attn 2.6.3 的

--- a/packaging/megatron/docs/memory/megatron-verification-state.md
+++ b/packaging/megatron/docs/memory/megatron-verification-state.md
@@ -5,7 +5,7 @@ metadata:
   node_type: memory
   type: project
   originSessionId: d7f830af-2108-4f39-aba9-825e3ddd911e
-  modified: 2026-08-17T09:00:00.000Z
+  modified: 2026-08-19T00:00:00.000Z
 ---
 
 # Megatron 应用镜像验证阶段 — 状态快照（2026-08-17 结构决策收口）
@@ -37,15 +37,15 @@ runtime
 
 ## 阶段二固化待办（2026-08-17 结构决策后刷新）
 
-**B 已定稿（2026-08-17）：两镜像依赖定案。** `megatron-training` = wheel + modelopt + tqdm + datasets(+pyarrow)（post_training 双引用，扫描实证）+ apex(hygon, runtime 继承)；不含 wandb/web 栈/TE（post_training 零引用）。`megatron-rl` = wheel + TE(vendor 条件) + 13 公共包全组 + flash_attn(runtime 继承) + apex(runtime 继承)。**安装两条 RUN**（vendor 装 TE → aliyun 装公共组，index 隔离便于检测）。**flash_attn 结论（2026-08-17 定）**：有则最好、无则有 workaround（MLF 内置一份 / 复用 flag_gems varlen paged——fork vllm-plugin-FL `AttentionFLBackend` 生产模板，vllm_fl/dispatch/backends/flaggems/impl/attention.py:589）。**TE 定性修正**：障碍是代码强制 thd（rl_utils.py:666-682 无条件构造 packed，含 sequence_packing=False 单序列）非 vendor 门；local-THD 修掉后 TE 降为可选加速包。**MLF 两缺口修掉后 RL = 纯公共依赖场景**（假设，待第二后端实证）。**enflame modelopt 例外不担心**（用户：见到了就装，可要可不要）。**verify 定性（用户 2026-08-17）**：断言是测试阶段手段（pip check / torch 落位 / §3 driver / TE+FA 版本断言 / run 13 同款 RL driver），**最终镜像锁定版本后行为即确定**——断言不进最终镜像，锁版才是交付契约。**Containerfile 拆分（#4）已落地：PR #427 OPEN（2026-08-18）**；点 2 lock 版本清单已随 #114 落地（`[rl]` extra 15 包全 pin，含 pyarrow 版本对，§5.2）。
+**B 已定稿（2026-08-17）：两镜像依赖定案。** `megatron-training` = wheel + modelopt + tqdm + datasets(+pyarrow)（post_training 双引用，扫描实证）+ apex(hygon, runtime 继承)；不含 wandb/web 栈/TE（post_training 零引用）。`megatron-rl` = wheel + TE(vendor 条件) + 13 公共包全组 + flash_attn(runtime 继承) + apex(runtime 继承)。**安装两条 RUN**（vendor 装 TE → aliyun 装公共组，index 隔离便于检测）。**flash_attn 结论（2026-08-17 定）**：有则最好、无则有 workaround（MLF 内置一份 / 复用 flag_gems varlen paged——fork vllm-plugin-FL `AttentionFLBackend` 生产模板，vllm_fl/dispatch/backends/flaggems/impl/attention.py:589）。**TE 定性修正**：障碍是代码强制 thd（rl_utils.py:666-682 无条件构造 packed，含 sequence_packing=False 单序列）非 vendor 门；local-THD 修掉后 TE 降为可选加速包。**MLF 两缺口修掉后 RL = 纯公共依赖场景**（假设，待第二后端实证）。**enflame modelopt 例外不担心**（用户：见到了就装，可要可不要）。**verify 定性（用户 2026-08-17）**：断言是测试阶段手段（pip check / torch 落位 / §3 driver / TE+FA 版本断言 / run 13 同款 RL driver），**最终镜像锁定版本后行为即确定**——断言不进最终镜像，锁版才是交付契约。**Containerfile 拆分（#4）已落地：PR #427 MERGED（2026-08-18T07:31Z）**；点 2 lock 版本清单已随 #114 落地（`[rl]` extra 15 包全 pin，含 pyarrow 版本对，§5.2）。
 
 **C 定稿（2026-08-17）："让 wheel 自己说话"。** 公共包依赖真相全部回 MLF extras（`[training]` + `[rl]` 一起提，各带版本 pin，pyarrow 版本对进 datasets 声明）；build-infra 只握顶层 wheel 名 + extra 选择器；configs.yaml `deps_app` 只背 vendor 条件包（TE），**不重复 13 包清单**；两条 RUN（vendor / mirror）保留。**边界规则**：extra 只许公共包；vendor 条件包（TE）不许进 extra，留 deps_app；flash_attn 是 runtime 层继承、不属 app 声明。**MLF pyproject 修 extra 的 PR 升格为 C 前置阻塞项**。C 机制"结构定了、等 MLF PR + hygon RL 验证后落地"。**#1 已提（2026-08-17）：PR #114**（feat/declare-runtime-extras，`[training]` +4 包 pin、新 `[rl]` extra 15 包全 pin）——待合并；C 机制落地解锁条件 = #114 合并。
 
 **C/D 形状（2026-08-17 定稿）：deps_app 每后端显式列全 app（vllm/megatron-training/megatron-rl 一键），vendor 包按需填——`[]` 表示"该 app 在此后端存在、需验证、但无 vendor 包"，不是不建。两职责解耦：app 存在性 = 键本身（验证矩阵全展开依据，期望状态）；vendor 包 = 列表内容（构建时实际装什么）。hygon megatron-rl 有 TE，其余后端全空。交付矩阵（现实状态）是验证结论的产物，不在 configs 硬编码。app 级平级（vllm/training/rl），"rl 是否可建"是每后端待验证项（默认可建）——未来纯公共 RL 后所有后端 rl 皆 `[]` 而恒建。**
 
-1. **`app/megatron/Containerfile` 拆分**（**已落地：PR #427 OPEN，2026-08-18**）：`Containerfile.megatron-training`（wheel + modelopt + tqdm + datasets）/ `Containerfile.rl`（wheel + TE 条件 + 13 包全组）；原 `Containerfile` 改名并留注释说明目录名≠镜像名的对应。**megatron-rl 可建性门槛 = MLF PR #114 合并 + 新 wheel（带 `[rl]` extra）；megatron-training 现 wheel 即可建（`[training]` 已存在）**
-2. **configs.yaml `deps_app` 机制**（新建，对称 `env.app`，**已落地：PR #424 OPEN**）：19 后端全展开 `deps_app: {vllm, megatron-training, megatron-rl}`，`[]` = app 存在待验证无 vendor 包（非"不建"）；仅 hygon `megatron-rl` 有 `transformer_engine==2.10.0+das.opt1.dtk2604.torch290`。**wheel 边界（用户 2026-08-17 定案）：wheel 不是 deps_app 条目——是 app 身份，走 Containerfile `MEGATRON_VERSION` arg，判定准则 = 每后端条件性而非装自哪个 index**，已写进 configs.yaml header 注释。公共包（modelopt/tqdm/datasets/13 组）**不在此处**——走 wheel extras（C 定稿，等 #114）
-3. **CI 支撑（已落地，两 PR）**：generate_matrix 支持 app 级 deps + `--app {app}` 输出 `app_env`/`app_deps` 随 **PR #424 OPEN**；megatron-app-image.yml 参数化 app 名（`megatron-training`|`megatron-rl` input → 镜像 tag / matrix / APP_DEPS build-arg，Containerfile 前置 vendor RUN）随 **PR #425 OPEN**
+1. **`app/megatron/Containerfile` 拆分**（**已落地：PR #427 MERGED，2026-08-18**）：`Containerfile.megatron-training`（wheel + modelopt + tqdm + datasets）/ `Containerfile.rl`（wheel + TE 条件 + 13 包全组）；原 `Containerfile` 改名并留注释说明目录名≠镜像名的对应。**megatron-rl 可建性门槛 = MLF PR #114 合并 + 新 wheel（带 `[rl]` extra）；megatron-training 现 wheel 即可建（`[training]` 已存在）**
+2. **configs.yaml `deps_app` 机制**（新建，对称 `env.app`，**已落地：PR #424 MERGED，2026-08-17**）：19 后端全展开 `deps_app: {vllm, megatron-training, megatron-rl}`，`[]` = app 存在待验证无 vendor 包（非"不建"）；仅 hygon `megatron-rl` 有 `transformer_engine==2.10.0+das.opt1.dtk2604.torch290`。**wheel 边界（用户 2026-08-17 定案）：wheel 不是 deps_app 条目——是 app 身份，走 Containerfile `MEGATRON_VERSION` arg，判定准则 = 每后端条件性而非装自哪个 index**，已写进 configs.yaml header 注释。公共包（modelopt/tqdm/datasets/13 组）**不在此处**——走 wheel extras（C 定稿，等 #114）
+3. **CI 支撑（已落地，两 PR）**：generate_matrix 支持 app 级 deps + `--app {app}` 输出 `app_env`/`app_deps` 随 **PR #424 MERGED，2026-08-17**；megatron-app-image.yml 参数化 app 名（`megatron-training`|`megatron-rl` input → 镜像 tag / matrix / APP_DEPS build-arg，Containerfile 前置 vendor RUN）随 **PR #425 MERGED，2026-08-17**
 4. **apex 纳入 hygon runtime**（A1，2026-08-17 确认，**已落地：PR #422 merged + wheel 已传 flagos-pypi-hygon**）：上传 `apex==1.7.0+das.opt1.dtk2604.torch290` + configs.yaml hygon deps 加 `apex==1.7.0+das.opt1.dtk2604.torch290`。**定性：apex 是 vendor 可选加速包（熔断可选，MLF 里 4 处使用全 try/except fallback——multi_tensor_applier / FusedLayerNorm / FusedAdam），非 RL 硬依赖**；kunlunxin/metax 已有先例（apex==0.1 / apex==0.1+metax3.8.1.0）
 5. **TE 每后端条件性登记（已落地，随 #424）**：hygon `megatron-rl` deps_app 登记 `transformer_engine==2.10.0+das.opt1.dtk2604.torch290`；其余后端 `[]`（无 vendor TE，构建时无 vendor 包，RL 纯公共场景假设待第二后端实证）
 6. **metax 无 vendor TE（2026-08-18 用户定，2026-08-19 双编译器实证坐实非阻塞）**：
@@ -55,11 +55,11 @@ runtime
    3.8.1.3（torch 2.10.0），**官网无 3.8.1.3 版本**。该 3.7.1.0 包或可用于另一
    后端（maca3.7.2.1 线 torch2.8），但非关键包，**用户定：不装**。metax
    `deps_app.megatron-rl` 保持 `[]`。**实证（2026-08-19 终止，双编译器全 ✅）**：
-   F 列 run #17（flagtree 线）与 T 列 run #18（vendor triton 线）均完整 GRPO E2E
+   F 列（flagtree 线）与 T 列（vendor triton 线）均完整 GRPO E2E
    exit 0——`--transformer-impl local` 全程无 TE 跑通，**无 vendor TE 确证非阻塞项**。
    **local-THD（rl_utils.py:666 无条件 thd）**：实证链以容器侧条件化补丁
    （transformer_impl=="local" 时 thd=None）落地、非阻塞；归类为 MLF 反馈项
-   （见待反馈项），**不再是 metax RL 阻塞项**。真实障碍链 17 个（runs #3–#17）
+   （见待反馈项），**不再是 metax RL 阻塞项**。真实障碍链 17 个（全 E2E 实证）
    全为本地代码/参数/harness 缺陷，详见 `megatron-verification-matrix.md` metax RL 条目。
 
    **metax RL 固化清单（2026-08-19 两编译器并齐后，阶段二输入；2026-08-19 落地）**：
@@ -69,9 +69,10 @@ runtime
    （local 时 None，双线必需）、**rl_utils.py unwrap_model 替换 `.module.module`
    链（inference 模式取 lang_module，清单初版遗漏的第二 hunk，随 #116 一并入**）、
    arguments.py 注册 `--return-log-probs`、flash_attn 断言门控（attention.py:943
-   按 DotProductAttention 跳过，版本号检查对 vendor 变体不适用）；镜像 ENV 候选 =
+   按 DotProductAttention 跳过，版本号检查对 vendor 变体不适用）；镜像 ENV =
    `TORCHINDUCTOR_COMPILE_THREADS=1`（进程内编译避 fork×driver current_device
-   崩溃）；配方参数 = `--transformer-impl local`、`--bf16`（flash_decode_and_prefill
+   崩溃，**已落地：build-infra PR #443 MERGED，2026-08-19**）；配方参数 =
+   `--transformer-impl local`、`--bf16`（flash_decode_and_prefill
    仅 fp16/bf16）、`--rl-partial-rollouts`（streaming 跳 drain 断言）。harness
    自研（dummy_agent isinstance/env_id/eod 去重）不入固化。
 


### PR DESCRIPTION
## Summary

Refresh the megatron verification docs to match post-merge reality.

- Mark build-infra PRs **#424 / #425 / #427** as MERGED (they read OPEN).
- Record the `TORCHINDUCTOR_COMPILE_THREADS=1` env as **landed via PR #443** (was "candidate").
- Replace metax run #17/#18 and "runs #3–#17" refs with self-contained evidence (compiler line, timestamps, exit code): the hygon worklog documents runs only through run 13, so the metax run numbers are not resolvable in-repo and would confuse future maintainers.

Remaining "PR #N OPEN" mentions are MLF PRs #107/#114/#116, which are still open.

This PR was written in part with the assistance of generative AI.
