### PR TITLE
fix(flagtree-sunrise): build cp310 wheel on system python3.10

### DIFF
--- a/packaging/flagtree/sunrise
+++ b/packaging/flagtree/sunrise
@@ -86,26 +86,24 @@ ARG TRITON_DEPS_TARBALL=build-deps-triton_3.6.x-linux-x64.tar.gz
 ARG PYBIND11_SPEC=>=3.1,<3.2
 ENV DEBIAN_FRONTEND=noninteractive
 
-# System build deps for the LLVM/Triton native build + Python 3.12 (deadsnakes).
+# System build deps for the LLVM/Triton native build + Python 3.10 (22.04 system).
 # Sunrise builds with clang/lld (not gcc) -- see the build-RUN comment below.
 # Symlinks expose the unversioned names setup.py and clang's -fuse-ld=lld expect:
 # clang/clang++ for CMAKE_C/CXX_COMPILER, lld for CMAKE_LINKER, ld.lld for the
 # -fuse-ld=lld linker lookup. The bare `lld` driver only prints a usage message
 # and exits 1 on --version (multi-flavor dispatch by argv[0]); ld.lld is the ELF
 # flavor and is the one that actually links, so the version check uses it.
-# gnupg/dirmngr are needed by add-apt-repository to import the PPA key.
+# python3.10-venv is what provides `python3.10 -m ensurepip` on Ubuntu.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        software-properties-common ca-certificates gnupg dirmngr \
+        ca-certificates \
         git wget curl binutils \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt-get update && apt-get install -y --no-install-recommends \
         build-essential cmake ninja-build \
         clang-14 lld-14 \
         zlib1g zlib1g-dev libxml2 libxml2-dev nlohmann-json3-dev \
         libncurses5-dev libncursesw5-dev libgdbm-dev libnss3-dev \
         libssl-dev libreadline-dev libffi-dev libsqlite3-dev \
         libdb5.3-dev libbz2-dev libexpat1-dev liblzma-dev \
-        python3.12 python3.12-venv python3.12-dev \
+        python3.10 python3.10-dev python3.10-venv \
     && ln -sf /usr/bin/clang-14 /usr/bin/clang \
     && ln -sf /usr/bin/clang++-14 /usr/bin/clang++ \
     && ln -sf /usr/bin/lld-14 /usr/bin/lld \
@@ -113,9 +111,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && clang++ --version && ld.lld --version \
     && rm -rf /var/lib/apt/lists/*
 
-# pip for python3.12 (deadsnakes ships ensurepip via the python3.12-venv package).
-RUN python3.12 -m ensurepip --upgrade \
-    && python3.12 -m pip install --no-cache-dir --upgrade pip wheel setuptools
+# pip for python3.10.
+RUN python3.10 -m ensurepip --upgrade \
+    && python3.10 -m pip install --no-cache-dir --upgrade pip wheel setuptools
 
 # Pre-stage the prebuilt sunrise deps into FlagTree's offline cache dirs so the
 # build wires them itself: LLVM -> sunrise_llvm22_dev_release (post_hook),
@@ -170,8 +168,8 @@ RUN git config --global http.version HTTP/1.1 \
        done \
     && test -d /opt/flagtree/.git \
     && cd /opt/flagtree \
-    && python3.12 -m pip install --no-cache-dir -r python/requirements.txt \
-    && python3.12 -m pip install --no-cache-dir "pybind11${PYBIND11_SPEC}" \
+    && python3.10 -m pip install --no-cache-dir -r python/requirements.txt \
+    && python3.10 -m pip install --no-cache-dir "pybind11${PYBIND11_SPEC}" \
     && export FLAGTREE_BACKEND=sunrise \
     && export FLAGTREE_WHEEL_VERSION="${FLAGTREE_WHEEL_VERSION}" \
     && export TRITON_BUILD_WITH_CLANG_LLD=1 \
@@ -179,7 +177,7 @@ RUN git config --global http.version HTTP/1.1 \
     && export TRITON_BUILD_PROTON=OFF \
     && rm -rf /opt/flagtree/.git \
     && for i in 1 2 3 4 5; do \
-         python3.12 -m pip wheel . --no-build-isolation --no-deps -w /wheels -v && break; \
+         python3.10 -m pip wheel . --no-build-isolation --no-deps -w /wheels -v && break; \
          echo ">>> wheel build attempt $i failed, retrying in 10s..."; sleep 10; \
        done \
     && ls -la /wheels/*.whl
@@ -188,7 +186,7 @@ RUN git config --global http.version HTTP/1.1 \
 # libtriton.so reintroduces any symbol a 22.04 client cannot satisfy
 # (GLIBC_2.38, GLIBCXX_3.4.31/32, or the gcc-13/glibc-2.38 __isoc23_* family),
 # or if its pybind11 internals drift from v12 (the sunrise plugin's ABI).
-RUN python3.12 - <<'PY'
+RUN python3.10 - <<'PY'
 import glob, subprocess, zipfile, tempfile, os, sys, re
 whl = glob.glob("/wheels/*.whl")[0]
 # Version gate: the wheel must carry the clean version, not FlagTree's dirty
@@ -198,6 +196,11 @@ if "git" in ver:
     print(f"FAIL: dirty wheel version '{ver}' (expected clean, no git<sha> suffix)")
     sys.exit(1)
 print(f"OK: clean wheel version '{ver}'")
+# cp310 gate: fail if the toolchain drifted to a different interpreter.
+if "-cp310-" not in os.path.basename(whl):
+    print(f"FAIL: wheel '{os.path.basename(whl)}' not tagged cp310 (wrong interpreter)")
+    sys.exit(1)
+print("OK: wheel tagged cp310")
 d = tempfile.mkdtemp()
 zipfile.ZipFile(whl).extractall(d)
 so = next(p for p in glob.glob(d + "/**/libtriton.so", recursive=True))
@@ -225,7 +228,8 @@ if internals != [b"12"]:
 print("OK: libtriton.so pybind11 internals v12 (matches sunriseTritonPlugin_v0.6.0.4)")
 PY
 
-# Smoke test: install the freshly built wheel and import it (fails the build if broken).
-RUN python3.12 -m pip install --no-cache-dir /wheels/*.whl \
-    && python3.12 -c "import triton; from triton.backends import backends; \
+# Smoke test: install the freshly built wheel and import it (fails the build
+# if the libpython3.10 linkage is wrong).
+RUN python3.10 -m pip install --no-cache-dir /wheels/*.whl \
+    && python3.10 -c "import triton; from triton.backends import backends; \
          print('OK triton', triton.__version__, 'backends', list(backends.keys()))"


### PR DESCRIPTION
## Problem

Run 32237410789 (head `64c6cd9`, PR #446) failed at the smoke test:

```
ImportError: libpython3.10.so.1.0: cannot open shared object file
    from triton._C.libtriton import ...
```

The wheel was tagged `flagtree-0.6.0+sunrise3.6-cp312-cp312-linux_x86_64.whl`
but `libtriton.so` links `libpython3.10.so.1.0` — the builder installed
deadsnakes python3.12 (the `pip wheel` interpreter, hence the cp312 tag) while
the base image's `libpython3.10` was present (dependency of
`software-properties-common` via the deadsnakes PPA path), and the toolchain
resolved the python linkage against the system 3.10. The cp312-tagged wheel is
importable under neither interpreter. The clang conversion itself works — all
other gates passed (clean `0.6.0+sunrise3.6`, max `GLIBC_2.6`, pybind11
internals v12).

## Fix

Build on the 22.04 **system python3.10** and ship a **cp310** wheel:

- The sunrise client runtime is Python 3.10 (`configs.yaml`
  `sunrise.tangrt1.2.0` `python: "3.10"`), so cp310 is consistent with the
  client **and** with the `libpython3.10` linkage.
- Drop the deadsnakes PPA entirely (no more `software-properties-common` /
  `add-apt-repository`); install `python3 python3-dev python3-venv`.
- Run pip/wheel/gate/smoke under `python3` instead of `python3.12`.
- The gate now asserts the wheel is tagged `cp310` (drift insurance: a future
  interpreter drift fails the build instead of shipping a broken wheel).
- Header documents why sunrise diverges from metax (first cp310 flagtree
  builder; metax stays cp312).

## Verification

CI `flagtree-wheel.yml` `target=sunrise` — the smoke gate now runs `import
triton` under python3.10, which succeeds only if the `libpython3.10` linkage is
satisfiable. Upload stays off ("先不上传"); the wheel still needs the on-node
A/B against the PR-978 hang repro before publishing.

This PR was written in part with the assistance of generative AI.
