### PR TITLE
fix(flagtree-sunrise): install pip via python3-pip, not ensurepip

### DIFF
--- a/packaging/flagtree/sunrise
+++ b/packaging/flagtree/sunrise
@@ -103,7 +103,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libncurses5-dev libncursesw5-dev libgdbm-dev libnss3-dev \
         libssl-dev libreadline-dev libffi-dev libsqlite3-dev \
         libdb5.3-dev libbz2-dev libexpat1-dev liblzma-dev \
-        python3.10 python3.10-dev python3.10-venv \
+        python3.10 python3.10-dev python3.10-venv python3-pip \
     && ln -sf /usr/bin/clang-14 /usr/bin/clang \
     && ln -sf /usr/bin/clang++-14 /usr/bin/clang++ \
     && ln -sf /usr/bin/lld-14 /usr/bin/lld \
@@ -111,9 +111,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && clang++ --version && ld.lld --version \
     && rm -rf /var/lib/apt/lists/*
 
-# pip for python3.10.
-RUN python3.10 -m ensurepip --upgrade \
-    && python3.10 -m pip install --no-cache-dir --upgrade pip wheel setuptools
+# pip for python3.10 (ensurepip is disabled for Ubuntu system python).
+RUN python3.10 -m pip install --no-cache-dir --upgrade pip wheel setuptools
 
 # Pre-stage the prebuilt sunrise deps into FlagTree's offline cache dirs so the
 # build wires them itself: LLVM -> sunrise_llvm22_dev_release (post_hook),


### PR DESCRIPTION
## Problem

Run 32241730615 (PR #447, cp310 conversion) failed immediately at the pip
step:

```
#6 0.271 ensurepip is disabled in Debian/Ubuntu for the system python.
#6 ERROR: process ... did not complete successfully: exit code: 1
```

Ubuntu 22.04 patches the system `python3.x` to disable ensurepip (the
`python3.10-venv` package ships a stub that tells you to use apt). So
`python3.10 -m ensurepip` exits 1 on the 22.04 system python — unlike
deadsnakes 3.12, whose `python3.12-venv` provides a real ensurepip.

## Fix

- `apt` install `python3-pip` (bootstraps pip for python3.10)
- replace the ensurepip RUN with `python3.10 -m pip install --upgrade pip wheel setuptools`

This is the same get-pip mechanism the deadsnakes path used, just via apt.

This PR was written in part with the assistance of generative AI.
