### PR TITLE
fix(flagtree-sunrise): pip via aliyun mirror (pypi.org unreachable from runners)

### DIFF
--- a/packaging/flagtree/sunrise
+++ b/packaging/flagtree/sunrise
@@ -112,7 +112,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # pip for python3.10 (ensurepip is disabled for Ubuntu system python).
-RUN python3.10 -m pip install --no-cache-dir --upgrade pip wheel setuptools
+# Index = aliyun mirror: pypi.org is unreachable from the build runners.
+RUN printf '[global]\nindex-url = https://mirrors.aliyun.com/pypi/simple/\n' > /etc/pip.conf \
+    && python3.10 -m pip install --no-cache-dir --upgrade pip wheel setuptools
 
 # Pre-stage the prebuilt sunrise deps into FlagTree's offline cache dirs so the
 # build wires them itself: LLVM -> sunrise_llvm22_dev_release (post_hook),


### PR DESCRIPTION
## Problem

Run 32242504765 failed at `RUN python3.10 -m pip install ... pip wheel setuptools` with `ReadTimeoutError: HTTPSConnectionPool(host='files.pythonhosted.org')`. The h20 runner cannot reliably reach pypi.org — the same connectivity class the wget/git retry loops and the DEPS_BASE bucket already work around.

## Fix

Point every pip invocation in the sunrise builder at the aliyun mirror via `/etc/pip.conf` (repo convention for public packages). One line covers all five pip calls — bootstrap, `requirements.txt`, pybind11, `pip wheel`, smoke install — instead of sprinkling `-i` flags through each RUN.

No behavior change beyond the index: all packages installed here are public (pip/wheel/setuptools, triton build deps, pybind11).

## Verification

Containerfile-only change; the flagtree-wheel.yml CI build (target=sunrise) is the real-container gate — will dispatch after merge.

This PR was written in part with the assistance of generative AI.
