### PR TITLE
fix(flagtree-sunrise): restore $ORIGIN RUNPATH + ship tang alias

### DIFF
--- a/packaging/flagtree/sunrise
+++ b/packaging/flagtree/sunrise
@@ -176,7 +176,7 @@ RUN git config --global http.version HTTP/1.1 \
     && export TRITON_BUILD_WITH_CLANG_LLD=1 \
     && export TRITON_OFFLINE_BUILD=1 \
     && export TRITON_BUILD_PROTON=OFF \
-    && export TRITON_APPEND_CMAKE_ARGS='-DCMAKE_INSTALL_RPATH=$ORIGIN' \
+    && export TRITON_APPEND_CMAKE_ARGS='-DCMAKE_INSTALL_RPATH=$ORIGIN -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON' \
     && ln -sfn ptpu third_party/sunrise/language/tang \
     && rm -rf /opt/flagtree/.git \
     && for i in 1 2 3 4 5; do \
@@ -239,7 +239,9 @@ if missing:
 print("OK: wheel ships triton.language.extra ptpu + tang")
 # RUNPATH gate: upstream main dropped INSTALL_RPATH, so the default is an absolute
 # /usr/local/... path that breaks when the wheel installs to /opt/flagtree.
-# TRITON_APPEND_CMAKE_ARGS injects -DCMAKE_INSTALL_RPATH=$ORIGIN; assert it landed.
+# TRITON_APPEND_CMAKE_ARGS injects -DCMAKE_INSTALL_RPATH=$ORIGIN plus
+# -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON (the wheel ships the build-tree .so, so
+# INSTALL_RPATH alone never applies); assert the token landed.
 rp = subprocess.check_output(["readelf", "-d", so], text=True)
 m = re.search(r"Library runpath: \[([^\]]*)\]", rp)
 if not m or "$ORIGIN" not in m.group(1) or "/usr/local" in m.group(1):

--- a/packaging/flagtree/sunrise
+++ b/packaging/flagtree/sunrise
@@ -176,7 +176,7 @@ RUN git config --global http.version HTTP/1.1 \
     && export TRITON_BUILD_WITH_CLANG_LLD=1 \
     && export TRITON_OFFLINE_BUILD=1 \
     && export TRITON_BUILD_PROTON=OFF \
-    && export TRITON_APPEND_CMAKE_ARGS="-DCMAKE_INSTALL_RPATH=\$ORIGIN" \
+    && export TRITON_APPEND_CMAKE_ARGS='-DCMAKE_INSTALL_RPATH=$ORIGIN' \
     && ln -sfn ptpu third_party/sunrise/language/tang \
     && rm -rf /opt/flagtree/.git \
     && for i in 1 2 3 4 5; do \

--- a/packaging/flagtree/sunrise
+++ b/packaging/flagtree/sunrise
@@ -176,6 +176,8 @@ RUN git config --global http.version HTTP/1.1 \
     && export TRITON_BUILD_WITH_CLANG_LLD=1 \
     && export TRITON_OFFLINE_BUILD=1 \
     && export TRITON_BUILD_PROTON=OFF \
+    && export TRITON_APPEND_CMAKE_ARGS="-DCMAKE_INSTALL_RPATH=\$ORIGIN" \
+    && ln -sfn ptpu third_party/sunrise/language/tang \
     && rm -rf /opt/flagtree/.git \
     && for i in 1 2 3 4 5; do \
          python3.10 -m pip wheel . --no-build-isolation --no-deps -w /wheels -v && break; \
@@ -227,6 +229,23 @@ if internals != [b"12"]:
           "sunrise plugin v0.6.0.4 needs v12 -- adjust PYBIND11_SPEC)")
     sys.exit(1)
 print("OK: libtriton.so pybind11 internals v12 (matches sunriseTritonPlugin_v0.6.0.4)")
+# extra-alias gate: flag_gems <=5.3.4 imports triton.language.extra.tang; upstream
+# main renamed it to ptpu, so the build symlinks ptpu -> tang. Assert both shipped.
+extra_dir = os.path.join(d, "triton", "language", "extra")
+missing = [name for name in ("ptpu", "tang") if not os.path.isdir(os.path.join(extra_dir, name))]
+if missing:
+    print(f"FAIL: wheel missing triton.language.extra.{missing} (tang symlink not picked up)")
+    sys.exit(1)
+print("OK: wheel ships triton.language.extra ptpu + tang")
+# RUNPATH gate: upstream main dropped INSTALL_RPATH, so the default is an absolute
+# /usr/local/... path that breaks when the wheel installs to /opt/flagtree.
+# TRITON_APPEND_CMAKE_ARGS injects -DCMAKE_INSTALL_RPATH=$ORIGIN; assert it landed.
+rp = subprocess.check_output(["readelf", "-d", so], text=True)
+m = re.search(r"Library runpath: \[([^\]]*)\]", rp)
+if not m or "$ORIGIN" not in m.group(1) or "/usr/local" in m.group(1):
+    print(f"FAIL: libtriton.so RUNPATH '{m.group(1) if m else '<none>'}' (expected $ORIGIN)")
+    sys.exit(1)
+print("OK: libtriton.so RUNPATH contains $ORIGIN")
 PY
 
 # Smoke test: install the freshly built wheel and import it (fails the build


### PR DESCRIPTION
Two regressions in the rebuilt sunrise wheel vs the vendor bake (PR #446), found during node A/B against the decode-hang baseline:

**1. libtriton.so RUNPATH** — upstream main dropped `INSTALL_RPATH "$ORIGIN"` (still present at fec6c8a0c CMakeLists.txt:459-461), so the rebuilt wheel's libtriton.so carries an absolute `/usr/local/lib/python3.10/dist-packages/triton/_C` RUNPATH and fails to load when installed to `/opt/flagtree` (the runtime's compiler prefix). Fix: `TRITON_APPEND_CMAKE_ARGS="-DCMAKE_INSTALL_RPATH=\$ORIGIN"` (setup.py:574 appends it after `-DTRITON_BUILD_UT=OFF`; shlex.split passes `$ORIGIN` through literally — locally validated).

**2. tang alias** — upstream renamed `third_party/sunrise/language/tang` → `ptpu`, but the baked runtime's flag_gems 5.3.4 imports `triton.language.extra.tang` (newer flag_gems uses ptpu). The wheel previously shipped only `ptpu`, requiring a manual `ln -sfn ptpu tang` on the node. Fix: symlink `ptpu` → `tang` before `pip wheel` — `get_package_dirs()` iterates `os.listdir(backend.language_dir)`, so both names ship as real directories.

Both are gated in the Containerfile: the wheel must contain `triton/language/extra/{ptpu,tang}` and libtriton.so's RUNPATH must contain `$ORIGIN` (no `/usr/local`).

A/B context (PR-978 rebuild fixes the sunrise flash-attn decode hang, 0.4 → 2.4 tok/s, terminates) will be recorded in report-vllm-0.24.0.md after the rebuilt wheel re-passes node E2E.

This PR was written in part with the assistance of generative AI.