### PR TITLE
feat(flash-attn): source-build nvidia flash-attn wheels (workflow + deps_app) for megatron-rl

### DIFF
--- a/.github/workflows/flash-attn-wheel.yml
+++ b/.github/workflows/flash-attn-wheel.yml
@@ -1,0 +1,187 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: flash-attn wheel
+
+# Build source-compiled flash_attn wheels (nvidia backends only) and
+# (optionally) upload them to the internal PyPI.
+#
+# GitHub prebuilt wheels are ABI-locked to torch 2.8 (newest cu12 =
+# 2.8.3.post1+cu12torch2.8) and die on import against torch 2.10/2.11
+# (`undefined symbol: c10_cuda_check_implementation`), and FA3/FA4 have
+# no usable wheels — so the nvidia megatron-rl app images need a
+# self-built wheel (packaging/flash-attn/Containerfile).
+#
+# The wheel's runtime ABI is bound to the BUILD-TIME torch, so the
+# backend map below must match configs.yaml's torch for that backend:
+#
+#   nvidia-cuda12.8  BASE_IMAGE=cuda:12.8.0-devel  torch 2.10.0+cu128  fl.cu128.torch210
+#   nvidia-cuda13.3  BASE_IMAGE=cuda:13.3.0-devel  torch 2.11.0+cu130  fl.cu130.torch211
+#
+# WHEEL_TAG becomes the PEP 440 local segment (FLASH_ATTN_LOCAL_VERSION),
+# so both wheels coexist on flagos-pypi-nvidia without clobbering.
+# TORCH_INDEX defaults inside the Containerfile to the vendor PyPI
+# (flagos-pypi-nvidia) — the same index the runtime installs torch from.
+#
+# Build machine = the h20 runner (devel images cached on node); no GPU
+# needed — pure compilation. The Containerfile's own gates (wheel shape,
+# METADATA version, ABI-load smoke) fail `docker build` on a broken
+# wheel, so a bad wheel never reaches the extract/upload steps. Uploads
+# are manual, no schedule.
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: 'Backend to build for: nvidia-cuda12.8 / nvidia-cuda13.3'
+        type: string
+        default: nvidia-cuda12.8
+      flash_attn_version:
+        description: 'flash-attn version to compile (megatron gate requires >= 2.7.3)'
+        type: string
+        default: 2.8.3.post1
+      upload:
+        description: 'upload the wheel to the internal PyPI'
+        type: boolean
+        default: false
+      pypi_repo:
+        description: 'Nexus PyPI repo (default flagos-pypi-nvidia)'
+        type: string
+        default: flagos-pypi-nvidia
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  authorize:
+    # Only accounts listed in .github/builders.txt may trigger this workflow
+    # manually; see .github/actions/check-trigger-author for the check.
+    # actions/checkout is required: local composite actions are resolved from
+    # the workspace, so the repo must exist before the action step runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/check-trigger-author
+
+  build:
+    needs: authorize
+    # h20 hosts both nvcr devel images; the build needs nvcc + cuDNN only.
+    runs-on: [self-hosted, h20]
+    env:
+      IMAGE: flash-attn-wheel:${{ github.run_id }}
+    steps:
+      - name: Checkout build-infra
+        uses: actions/checkout@v7
+
+      - name: Resolve backend build args
+        id: args
+        run: |
+          set -euo pipefail
+          case "${{ inputs.backend }}" in
+            nvidia-cuda12.8)
+              echo "base_image=nvcr.io/nvidia/cuda:12.8.0-devel-ubuntu24.04" >> "$GITHUB_OUTPUT"
+              echo "torch_version=2.10.0+cu128" >> "$GITHUB_OUTPUT"
+              echo "wheel_tag=fl.cu128.torch210" >> "$GITHUB_OUTPUT"
+              ;;
+            nvidia-cuda13.3)
+              echo "base_image=nvcr.io/nvidia/cuda:13.3.0-devel-ubuntu24.04" >> "$GITHUB_OUTPUT"
+              echo "torch_version=2.11.0+cu130" >> "$GITHUB_OUTPUT"
+              echo "wheel_tag=fl.cu130.torch211" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "ERROR: unknown backend '${{ inputs.backend }}'" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Build the wheel image
+        working-directory: packaging/flash-attn
+        env:
+          BASE_IMAGE: ${{ steps.args.outputs.base_image }}
+          TORCH_VERSION: ${{ steps.args.outputs.torch_version }}
+          WHEEL_TAG: ${{ steps.args.outputs.wheel_tag }}
+          FLASH_ATTN_VERSION: ${{ inputs.flash_attn_version }}
+        run: |
+          set -euo pipefail
+          # Wheel-shape gate, METADATA version gate and ABI-load smoke run
+          # inside this build; a failure here means the wheel is broken and
+          # must not be published. TORCH_INDEX is not passed — the
+          # Containerfile defaults it to the vendor PyPI (flagos-pypi-nvidia).
+          docker build \
+            --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+            --build-arg TORCH_VERSION="${TORCH_VERSION}" \
+            --build-arg WHEEL_TAG="${WHEEL_TAG}" \
+            --build-arg FLASH_ATTN_VERSION="${FLASH_ATTN_VERSION}" \
+            -t "$IMAGE" \
+            -f Containerfile .
+
+      # Host-side copy for inspection/debugging; the upload step reads
+      # /wheels from the image directly and does not use this directory.
+      - name: Extract the wheel
+        working-directory: packaging/flash-attn
+        run: |
+          set -euo pipefail
+          rm -rf wheels && mkdir -p wheels
+          cid=$(docker create "$IMAGE")
+          docker cp "$cid:/wheels/." wheels/
+          docker rm "$cid" >/dev/null
+          ls -la wheels/*.whl
+
+      # Upload only when explicitly requested (default false so a manual build
+      # from a branch is safe). The wheel is published as-is — the build gates
+      # already vetted it.
+      - name: Upload to internal PyPI
+        if: ${{ inputs.upload }}
+        env:
+          NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEXUS_TOKEN:-}" ]; then
+            echo "ERROR: NEXUS_TOKEN secret is empty or unset" >&2
+            exit 1
+          fi
+          pypi_repo="${{ inputs.pypi_repo }}"
+          pypi_repo="${pypi_repo:-flagos-pypi-nvidia}"
+          # Upload FROM INSIDE the build image: the wheel and the
+          # python3/pip/twine toolchain both live in $IMAGE, so no host python
+          # is needed. The secret travels via `-e NEXUS_TOKEN` (inherits the
+          # step env) so it never appears in a process list or image layer.
+          # resource.flagos.net is inside the Containerfile's baked NO_PROXY.
+          # --break-system-packages: the nvcr devel image's python3 is PEP 668
+          # externally-managed (the Containerfile already overrides it).
+          echo ">>> uploading $(docker run --rm "$IMAGE" sh -c 'ls /wheels/*.whl' | tr '\n' ' ') to ${pypi_repo}"
+          docker run --rm \
+            -e NEXUS_TOKEN \
+            -e pypi_repo="${pypi_repo}" \
+            "$IMAGE" \
+            bash -euo pipefail -c '
+              # Upgrade pkginfo too: setuptools >=77 (PEP 639) stamps
+              # Metadata-Version 2.4 into the wheel, which older pkginfo cannot
+              # parse ("Metadata is missing required fields: Name, Version") ->
+              # twine aborts before upload. pkginfo >=1.11 reads 2.4.
+              python3 -m pip install --quiet --break-system-packages \
+                --index-url "https://mirrors.aliyun.com/pypi/simple" \
+                --upgrade twine pkginfo
+              export TWINE_USERNAME="${NEXUS_TOKEN%%:*}"
+              export TWINE_PASSWORD="${NEXUS_TOKEN#*:}"
+              python3 -m twine upload \
+                --repository-url "https://resource.flagos.net/repository/${pypi_repo}/" \
+                --non-interactive \
+                /wheels/*.whl
+            '
+
+      - name: Clean up the build image
+        if: ${{ always() }}
+        run: docker rmi "$IMAGE" 2>/dev/null || true

--- a/configs.yaml
+++ b/configs.yaml
@@ -136,7 +136,13 @@ vendors:
       deps_app:
         vllm: []
         megatron-training: []
-        megatron-rl: []
+        # flash-attn is a hard dependency of the RL dynamic engine
+        # (attention.py flash_attn_with_kvcache assertion, ≥2.7.3 gate). The
+        # wheel is source-built (packaging/flash-attn/Containerfile) with the
+        # ABI locked to this backend's torch: build-time torch must equal the
+        # runtime torch, hence the per-backend +fl.cu128.torch210 tag.
+        megatron-rl:
+          - flash_attn==2.8.3.post1+fl.cu128.torch210
       sdk:
         - CUDA 12.8 (x86_64)
 
@@ -166,7 +172,10 @@ vendors:
       deps_app:
         vllm: []
         megatron-training: []
-        megatron-rl: []
+        # flash-attn wheel source-built with ABI locked to torch 2.11.0+cu130
+        # (build-time torch == runtime torch; see cuda12.8 comment).
+        megatron-rl:
+          - flash_attn==2.8.3.post1+fl.cu130.torch211
       sdk:
         - CUDA 13.3 (x86_64)
 

--- a/packaging/flash-attn/Containerfile
+++ b/packaging/flash-attn/Containerfile
@@ -1,0 +1,235 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ============================================================
+# Flash-Attention wheel builder (nvidia backends only)
+#
+# Builds a source-compiled flash_attn wheel ABI-locked to the
+# target runtime's torch. GitHub prebuilt wheels are ABI-locked
+# to torch 2.8 (newest cu12 = 2.8.3.post1+cu12torch2.8) and die
+# on import against torch 2.10/2.11:
+#   undefined symbol: c10_cuda_check_implementation
+# Megatron's RL dynamic-batching engine hard-depends on
+# flash-attn >= 2.7.3 (attention.py:943 gate) and FA3/FA4 have
+# no usable wheels — so nvidia needs a self-built wheel. This is
+# the ONLY self-built nvidia deps_app package (TE is skipped:
+# `--transformer-impl local` needs no TE, metax precedent).
+#
+# Build environment = nvcr devel image (nvcc + cuDNN present).
+# The build machine needs no GPU — this is pure compilation; the
+# resulting .so's runtime ABI is bound to the BUILD-TIME torch,
+# so the torch pip-installed here MUST equal the runtime image's
+# torch version. Two nvidia backends -> two wheels:
+#
+#   nvidia-cuda12.8   torch 2.10.0+cu128  WHEEL_TAG=fl.cu128.torch210
+#   nvidia-cuda13.3   torch 2.11.0+cu130  WHEEL_TAG=fl.cu130.torch211
+#
+# WHEEL_TAG becomes the PEP 440 local segment (upstream's
+# FLASH_ATTN_LOCAL_VERSION) so both wheels coexist on the vendor
+# PyPI without clobbering each other.
+#
+# Upstream build-system facts (verified against v2.8.3.post1
+# setup.py; these make the recipe non-obvious):
+#   - FLASH_ATTENTION_FORCE_BUILD=TRUE is REQUIRED. The custom
+#     bdist_wheel (CachedWheelsCommand) otherwise urlretrieves a
+#     prebuilt wheel from GitHub releases — the wrong-ABI
+#     cu12torch2.8 artifact on a firewalled network (hang, or a
+#     wheel that crashes on import). FORCE_BUILD bypasses to the
+#     real source build.
+#   - Arch control is FLASH_ATTN_CUDA_ARCHS (default "80;90;100;120"),
+#     NOT TORCH_CUDA_ARCH_LIST — the latter is ignored. H20 = sm_90.
+#   - Version injection is the FLASH_ATTN_LOCAL_VERSION env, read
+#     by get_package_version() -> "{public}+{local}". No sed needed.
+#   - Source = aliyun sdist (pip download --no-binary :all:), NOT a
+#     git clone: the clone path runs `git submodule update --init`
+#     for csrc/cutlass AND csrc/composable_kernel against GitHub
+#     (firewalled), while the sdist carries both vendored.
+#     Metadata prep runs setup.py, which imports torch — so the
+#     sdist download RUN must come AFTER torch is installed.
+#   - The CUDA build produces ONE extension module:
+#     flash_attn_2_cuda (imported at runtime as flash_attn_gpu).
+#     The second ext_modules.append in setup.py is the ROCm
+#     branch (IS_ROCM only) and never fires on CUDA.
+#
+# Typical invocation (upload side: .github/workflows/flash-attn-wheel.yml):
+#   docker build -t flash-attn-wheel:build \
+#     --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda:12.8.0-devel-ubuntu24.04 \
+#     --build-arg TORCH_VERSION=2.10.0+cu128 \
+#     --build-arg WHEEL_TAG=fl.cu128.torch210 \
+#     packaging/flash-attn/
+# TORCH_INDEX defaults to the vendor PyPI (flagos-pypi-nvidia) — the
+# same index the runtime image installs torch from — so it is not
+# passed here. Both nvidia backends share it; only BASE_IMAGE /
+# TORCH_VERSION / WHEEL_TAG differ.
+#   cid=$(docker create flash-attn-wheel:build)
+#   docker cp "$cid:/wheels/." /tmp/fa-wheels/ && docker rm "$cid"
+#
+# Revision history:
+#   2026-08-19   Initial: source-build engineering for nvidia
+#                deps_app.megatron-rl (flash-attn >= 2.7.3 gate).
+# ============================================================
+
+# Build environment: nvcr CUDA devel image (nvcc + cuDNN baked in).
+# One base image per nvidia backend; the only ARGs that differ are
+# BASE_IMAGE / TORCH_VERSION / TORCH_INDEX / WHEEL_TAG.
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda:12.8.0-devel-ubuntu24.04
+FROM ${BASE_IMAGE}
+
+# --- Build arguments ------------------------------------------
+
+# Upstream flash-attn version to compile (must be >= 2.7.3 for the
+# megatron dynamic-batching gate). 2.8.3.post1 is the newest sdist
+# on the mirror; downgrade ladder if a compile fails:
+# 2.8.3.post1 -> 2.8.3 -> 2.8.2 -> 2.7.4.post1.
+ARG FLASH_ATTN_VERSION=2.8.3.post1
+
+# Runtime torch version this wheel must ABI-match. Building against
+# the wrong torch produces a wheel that dies on import with
+# `undefined symbol` (the exact defect this image exists to fix).
+ARG TORCH_VERSION=2.10.0+cu128
+
+# Torch comes from the SAME vendor PyPI the runtime image installs
+# from (configs.yaml deps -> PIP_INDEX_URL=${FLAGOS_PYPI}), so the
+# build-time torch is byte-identical to the runtime torch — the
+# strongest possible ABI lock. Public non-CUDA deps (sympy, filelock,
+# ...) resolve from the aliyun extra-index, exactly like the runtime.
+ARG TORCH_INDEX=https://resource.flagos.net/repository/flagos-pypi-nvidia/simple
+
+# PEP 440 local version segment, e.g. fl.cu128.torch210. Carries
+# (cuda, torch) ABI identity so the vendor PyPI can host one wheel
+# per nvidia backend without clobbering.
+ARG WHEEL_TAG=fl.cu128.torch210
+
+# Target GPU architecture: H20 = sm_90. Explicitly pinned so a
+# build on other hardware does not silently pick the default
+# "80;90;100;120" (huge build + wrong wheel for the target node).
+ARG FLASH_ATTN_CUDA_ARCHS=90
+
+# Public packages come from the aliyun mirror (never pypi.org).
+ARG EXTRA_PYPI="https://mirrors.aliyun.com/pypi/simple"
+
+ENV NO_PROXY=".aliyun.com,.flagos.net,.baai.ac.cn"
+
+# --- System deps -----------------------------------------------
+
+# The nvcr devel image is minimal: no pip, no host compiler.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      --no-install-recommends \
+      python3-pip \
+      python3-dev \
+      ninja-build \
+      build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Build-time torch (ABI-critical) ---------------------------
+
+# Must be the EXACT runtime torch version. The cu128/cu130 wheels
+# bundle their CUDA libs; torch and its nvidia-* companions install
+# from the vendor PyPI (flagos-pypi-nvidia), their non-CUDA deps
+# (sympy, filelock, ...) from the aliyun extra-index — the same
+# index pair the runtime image's torch install uses.
+# --break-system-packages: the nvcr ubuntu24.04 devel image's python3
+# is PEP 668 externally-managed; this is a throwaway build container,
+# so the override is safe and standard.
+RUN python3 -m pip install --no-cache-dir --break-system-packages \
+      --index-url "${TORCH_INDEX}" \
+      --extra-index-url "${EXTRA_PYPI}" \
+      "torch==${TORCH_VERSION}"
+
+# --- flash-attn build deps -------------------------------------
+
+# setup.py's NinjaBuildExtension imports psutil at class-definition
+# time; setup_requires lists packaging/psutil/ninja. einops is the
+# runtime install_requires (needed by the smoke import below).
+RUN python3 -m pip install --no-cache-dir --break-system-packages \
+      --index-url "${EXTRA_PYPI}" \
+      "setuptools" "wheel" "ninja" "packaging" "psutil" "einops"
+
+# --- Source: aliyun sdist --------------------------------------
+
+# pip download resolves the mirror's per-version hash path for us
+# (no hardcoded URL) and verifies sha256. Metadata prep runs
+# setup.py -> imports torch -> must come after the torch RUN.
+# --no-build-isolation is required: with isolation pip would run
+# setup.py egg_info in a fresh env lacking torch (flash-attn has no
+# pyproject.toml, so isolation installs only setuptools+wheel).
+# The sdist carries vendored cutlass (asserted below) so no GitHub
+# submodule fetch happens — this is what makes the build work on a
+# firewalled runner.
+RUN mkdir -p /src /wheels \
+    && cd /src \
+    && python3 -m pip download --no-deps --no-binary :all: \
+         --no-build-isolation \
+         --index-url "${EXTRA_PYPI}" -d /src \
+         "flash_attn==${FLASH_ATTN_VERSION}" \
+    && tar xzf "flash_attn-${FLASH_ATTN_VERSION}.tar.gz" \
+    && test -f "flash_attn-${FLASH_ATTN_VERSION}/csrc/cutlass/include/cutlass/cutlass.h" \
+    && test -f "flash_attn-${FLASH_ATTN_VERSION}/flash_attn/__init__.py"
+
+# --- Compile ---------------------------------------------------
+
+# FLASH_ATTENTION_FORCE_BUILD=TRUE: bypass CachedWheelsCommand's
+# GitHub-release wheel download (wrong-ABI artifact / hang on
+# firewalled network) and go straight to the source build.
+# FLASH_ATTN_CUDA_ARCHS=90: sm_90 only (H20).
+# FLASH_ATTN_LOCAL_VERSION: PEP 440 local segment (wheel filename
+# becomes flash_attn-{public}+{WHEEL_TAG}-cp312-cp312-linux_x86_64.whl).
+# MAX_JOBS is left to setup.py's own logic (cpu/2, ram/9).
+RUN cd "/src/flash_attn-${FLASH_ATTN_VERSION}" \
+    && FLASH_ATTENTION_FORCE_BUILD=TRUE \
+       FLASH_ATTN_CUDA_ARCHS="${FLASH_ATTN_CUDA_ARCHS}" \
+       FLASH_ATTN_LOCAL_VERSION="${WHEEL_TAG}" \
+       python3 setup.py bdist_wheel -d /wheels
+
+# --- Gate: wheel shape + version + .so -------------------------
+
+# ARG values are not container env vars — pass them through the
+# RUN shell so the heredoc's os.environ can read them.
+RUN FLASH_ATTN_VERSION="${FLASH_ATTN_VERSION}" \
+    WHEEL_TAG="${WHEEL_TAG}" python3 - <<'PY'
+import glob, os, zipfile
+
+wheels = sorted(glob.glob("/wheels/flash_attn-*.whl"))
+assert wheels, "no wheel produced in /wheels"
+wheel = wheels[-1]
+print("wheel:", os.path.basename(wheel))
+
+z = zipfile.ZipFile(wheel)
+names = z.namelist()
+
+so = [n for n in names if n.endswith(".so")]
+assert any("flash_attn_2_cuda" in n for n in so), \
+    "flash_attn_2_cuda .so missing from wheel: %s" % [n for n in so]
+print("extensions:", [n.rsplit("/", 1)[-1] for n in so])
+
+md_name = [n for n in names if n.endswith("dist-info/METADATA")][0]
+meta = z.read(md_name).decode()
+expected = "Version: %s+%s" % (os.environ["FLASH_ATTN_VERSION"],
+                               os.environ["WHEEL_TAG"])
+assert expected in meta, "version mismatch: want %r, got %r" % (
+    expected, [l for l in meta.splitlines() if l.startswith("Version:")])
+print("METADATA:", expected, "OK")
+PY
+
+# --- Smoke: install + ABI load ---------------------------------
+
+# Installs the wheel into the build image's python and loads the
+# compiled extension — proves the .so links against the pip'd torch
+# (the failure mode the prebuilt wheels hit). Kernel execution is
+# verified later on-node (megatron RL E2E). Index pinned to aliyun
+# so dependency resolution never falls through to pypi.org; the
+# install itself is no-op for already-satisfied torch/einops.
+RUN python3 -m pip install --no-cache-dir --break-system-packages \
+      --index-url "${EXTRA_PYPI}" /wheels/flash_attn-*.whl \
+    && python3 -c "import flash_attn, flash_attn.flash_attn_interface; print('flash_attn', flash_attn.__version__, 'import OK')"

--- a/packaging/flash-attn/README.md
+++ b/packaging/flash-attn/README.md
@@ -1,0 +1,94 @@
+# packaging/flash-attn — flash-attn source-built wheels (nvidia)
+
+Builds a source-compiled `flash_attn` wheel, ABI-locked to a specific
+nvidia runtime image's torch. This is the **only self-built nvidia
+deps_app package**: Megatron's RL dynamic-batching engine
+hard-depends on flash-attn ≥ 2.7.3, and no usable binary wheel exists
+for torch 2.10/2.11.
+
+## Why self-built
+
+- GitHub's newest cu12 wheel is `2.8.3.post1+cu12torch2.8` — built
+  against torch 2.8's libtorch. On torch 2.10.0+cu128 it dies at
+  import with
+  `undefined symbol: c10_cuda_check_implementation` (ABI mismatch).
+- FA3 / FA4 have no wheels at all (`flash_attn_3` absent from both
+  GitHub releases and the aliyun mirror).
+- TE is NOT needed — `--transformer-impl local` runs the full chain
+  without it (metax precedent), so flash-attn is the only package to
+  build.
+
+## ABI contract
+
+The compiled `.so`'s runtime ABI is bound to the **build-time torch**.
+The Containerfile pip-installs `TORCH_VERSION` from `TORCH_INDEX` —
+that version must equal the target runtime image's torch exactly.
+One wheel per backend, distinguished by the PEP 440 local segment:
+
+| Backend | Runtime torch | WHEEL_TAG | Wheel |
+|---|---|---|---|
+| nvidia-cuda12.8 | `2.10.0+cu128` | `fl.cu128.torch210` | `flash_attn-2.8.3.post1+fl.cu128.torch210-cp312-cp312-linux_x86_64.whl` |
+| nvidia-cuda13.3 | `2.11.0+cu130` | `fl.cu130.torch211` | `flash_attn-2.8.3.post1+fl.cu130.torch211-cp312-cp312-linux_x86_64.whl` |
+
+## Build
+
+Build environment = the nvcr devel image (`nvcc` + cuDNN baked in).
+No GPU needed — pure compilation. The two nvidia backends reuse the
+same Containerfile; only three ARGs differ. Torch installs from the
+**vendor PyPI** (`flagos-pypi-nvidia` — the same index the runtime
+image installs torch from, so the build-time torch is byte-identical
+to the runtime torch); `TORCH_INDEX` is overridable but defaults to it.
+
+```bash
+docker build -t flash-attn-wheel:build \
+  --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda:12.8.0-devel-ubuntu24.04 \
+  --build-arg TORCH_VERSION=2.10.0+cu128 \
+  --build-arg WHEEL_TAG=fl.cu128.torch210 \
+  packaging/flash-attn/
+
+cid=$(docker create flash-attn-wheel:build)
+docker cp "$cid:/wheels/." /tmp/fa-wheels/ && docker rm "$cid"
+```
+
+The build image runs its own gates (gate + smoke steps): wheel shape
+(`flash_attn_2_cuda*.so` present), METADATA version
+(`2.8.3.post1+<WHEEL_TAG>`), and an import of the installed wheel
+proving the `.so` links against the pip'd torch. Kernel execution is
+verified on-node by the megatron RL E2E.
+
+## Upstream build-system facts (non-obvious, verified against
+v2.8.3.post1 setup.py)
+
+- `FLASH_ATTENTION_FORCE_BUILD=TRUE` is **required** — otherwise the
+  custom `bdist_wheel` (`CachedWheelsCommand`) tries to
+  `urlretrieve` a prebuilt wheel from GitHub releases (the
+  wrong-ABI `cu12torch2.8` artifact; hangs on the firewalled
+  network).
+- Arch control is `FLASH_ATTN_CUDA_ARCHS` (default `80;90;100;120`),
+  **not** `TORCH_CUDA_ARCH_LIST` (ignored). H20 → `90` (sm_90).
+- Version injection is the `FLASH_ATTN_LOCAL_VERSION` env, read by
+  `get_package_version()` → `{public}+{local}`. No sed patch.
+- Source = aliyun sdist (`pip download --no-binary :all: --no-build-isolation`),
+  **not** a git clone: the clone path runs `git submodule update --init`
+  for `csrc/cutlass` + `csrc/composable_kernel` against GitHub, while
+  the sdist carries both vendored. `--no-build-isolation` matters
+  because flash-attn has no `pyproject.toml` (isolation would run
+  setup.py without torch). Metadata prep imports torch, so the
+  download RUN must come after the torch install.
+- The CUDA build produces exactly one extension, `flash_attn_2_cuda`
+  (imported at runtime as `flash_attn_gpu`). The second
+  `ext_modules.append` in setup.py is the ROCm branch (`IS_ROCM`
+  only) and never fires on CUDA.
+- Downgrade ladder if a compile fails: 2.8.3.post1 → 2.8.3 → 2.8.2 →
+  2.7.4.post1 (all satisfy the megatron ≥ 2.7.3 gate).
+
+## Consumption chain (already wired — no code changes)
+
+`configs.yaml deps_app.megatron-rl` → `scripts/generate_matrix.py`
+(`matrix.app_deps`) → `megatron-app-image.yml` `--build-arg
+APP_DEPS` → `app/megatron/Containerfile.rl` vendor-PyPI install.
+
+The upload step lives in `.github/workflows/flash-attn-wheel.yml`
+(twine → `flagos-pypi-nvidia`); `configs.yaml` pins the exact wheel
+with `==`, so the build, the PyPI upload, and the app-image install
+all agree on one artifact.


### PR DESCRIPTION
## Summary

The RL dynamic engine in Megatron-LM-FL hard-depends on flash-attn
(`flash_attn_with_kvcache` assertion, `>=2.7.3` gate). GitHub's prebuilt
cu12 wheels stop at `cu12torch2.8` (2.8.3.post1), which is ABI-incompatible
with our runtimes (torch 2.10.0+cu128 / 2.11.0+cu130) — `import flash_attn`
crashes with `undefined symbol: c10_cuda_check_implementation`. TE is not an
alternative: metax/nvidia E2E already run with `--transformer-impl local`.

This PR makes the source build reproducible in-repo and wires it into the
app image install path:

1. **`packaging/flash-attn/Containerfile`** — source build from the flash-attn
   tag, with `TORCH_VERSION` pinned to the target runtime's torch (ABI lock),
   `TORCH_CUDA_ARCH_LIST=9.0` for H20 (sm_90), PEP 440 `WHEEL_TAG` local
   segment to keep per-ABI wheels distinct on the vendor PyPI, and build-time
   gates (wheel shape + METADATA version + ABI import smoke run) so a broken
   wheel is never published.
2. **`.github/workflows/flash-attn-wheel.yml`** — manual `workflow_dispatch`
   build/upload workflow on the h20 runner (`backend` input: nvidia-cuda12.8
   or nvidia-cuda13.3 → devel base image + torch + wheel tag). Upload only
   when `upload=true`, default `flagos-pypi-nvidia`. Verified on-node: the
   cu128 wheel passes `import flash_attn` + the `is_fa_min_version` gate in
   the megatron-nv128 container, and the cuda13.3 RL E2E (GRPO, both
   compilers) exits 0 with the cu130 wheel installed.
3. **`configs.yaml`** — `deps_app.megatron-rl` for both nvidia backends pins
   the source-built wheel (`flash_attn==2.8.3.post1+fl.cu128.torch210` /
   `...+fl.cu130.torch211`), consumed by `megatron-app-image.yml` via
   `--build-arg APP_DEPS`.

## Note on the E2E evidence

The cuda12.8/cuda13.3 RL E2E runs described in the matrix docs used the wheel
built from this Containerfile (adhoc) and installed into the verify
containers. The wheel upload to `flagos-pypi-nvidia` happens from this
workflow with `upload=true` once this PR merges (NEXUS_TOKEN is a repo
secret); until then the wheels exist only as adhoc builds.

## Test plan

- [x] `python scripts/generate_matrix.py nvidia-cuda12.8 nvidia-cuda13.3 --app megatron-rl` emits `app_deps: flash_attn==2.8.3.post1+fl.cu128.torch210` / `...+fl.cu130.torch211`
- [x] cu128 wheel: `import flash_attn` + `is_fa_min_version` gate pass in megatron-nv128 (torch 2.10.0+cu128)
- [x] cu130 wheel: RL E2E (GRPO, flagtree + triton) exit 0 in megatron-nv133 (torch 2.11.0+cu130)
- [ ] upload=true run after merge publishes both wheels to flagos-pypi-nvidia

Co-authored with Claude (AI-assisted).