### PR TITLE
fix(megatron): resolve triton from /opt/triton in megatron app-image install

### DIFF
--- a/app/megatron/Containerfile.megatron-training
+++ b/app/megatron/Containerfile.megatron-training
@@ -86,7 +86,12 @@ RUN if [ -n "${APP_DEPS}" ]; then \
 # The install is proven inert by the build-time smoke test in
 # packaging/megatron/builder/ (build env == delivery env) and verified
 # on-node by packaging/megatron/verify/verify-megatron-backend.sh.
-RUN pip install \
+# PYTHONPATH=/opt/triton mirrors the runtime Containerfile DEPS install:
+# build RUN steps run under dash (no BASH_ENV, so no compiler on
+# PYTHONPATH), and pip must see the side-dir triton dist-info or torch's
+# triton==N dep (declared in the vendor torch METADATA) pulls a fresh
+# triton into site-packages, bypassing the repacked vendor triton.
+RUN PYTHONPATH="/opt/triton" pip install \
   --index-url "${FLAGOS_PYPI}" \
   --extra-index-url "${EXTRA_PYPI}" \
   "megatron-core[training]==${MEGATRON_VERSION}"

--- a/app/megatron/Containerfile.rl
+++ b/app/megatron/Containerfile.rl
@@ -83,7 +83,12 @@ RUN if [ -n "${APP_DEPS}" ]; then \
 # image). The install is proven inert by the build-time smoke test in
 # packaging/megatron/builder/ (build env == delivery env) and verified
 # on-node by packaging/megatron/verify/verify-megatron-backend.sh.
-RUN pip install \
+# PYTHONPATH=/opt/triton mirrors the runtime Containerfile DEPS install:
+# build RUN steps run under dash (no BASH_ENV, so no compiler on
+# PYTHONPATH), and pip must see the side-dir triton dist-info or torch's
+# triton==N dep (declared in the vendor torch METADATA) pulls a fresh
+# triton into site-packages, bypassing the repacked vendor triton.
+RUN PYTHONPATH="/opt/triton" pip install \
   --index-url "${FLAGOS_PYPI}" \
   --extra-index-url "${EXTRA_PYPI}" \
   "megatron-core[rl]==${MEGATRON_VERSION}"

--- a/packaging/megatron/verify/verify-megatron-backend.sh
+++ b/packaging/megatron/verify/verify-megatron-backend.sh
@@ -238,8 +238,12 @@ if [[ -n "${APP_IMAGE}" ]]; then
 else
     log_step "Step 3: Installing megatron-core==${MEGATRON_VERSION}"
 
+    # PYTHONPATH=/opt/triton mirrors the runtime Containerfile DEPS install:
+    # pip must see the side-dir triton dist-info, or torch's triton==N dep
+    # (declared in the vendor torch METADATA) pulls a fresh triton into
+    # site-packages, bypassing the repacked vendor triton (188 MB).
     docker exec "${CONTAINER}" bash -c "
-        pip install \
+        PYTHONPATH=/opt/triton pip install \
             --index-url '${VENDOR_PYPI}' \
             --extra-index-url '${ALIYUN_PYPI}' \
             'megatron-core==${MEGATRON_VERSION}'


### PR DESCRIPTION
## Summary

The megatron app-image Containerfiles install the megatron-core wheel
single-step. When the backend runtime carries both compilers (flagtree
default at /flagos, vendor triton side-installed at /opt/triton), the
wheel's own triton Requires-Dist resolves from the PyPI index during
install unless PYTHONPATH=/opt/triton is set — leaking a PyPI triton into
the app layer and shadowing the vendor build.

This PR:

1. app/megatron/Containerfile.megatron-training and Containerfile.rl —
   export PYTHONPATH=/opt/triton for the wheel install RUN, so the
   vendor triton satisfies the dependency (same pattern the runtime image
   uses for its side install).
2. packaging/megatron/verify/verify-megatron-backend.sh — verify
   checks the resolved triton path is under /opt/triton when the backend
   is dual-compiler, and reports TRITON_RESOLVED accordingly.

## Test plan

- Verify script extended; container-path E2E runs already confirmed the
  vendor triton at /opt/triton is what the merged wheel resolves to under
  the PYTHONPATH export (cuda12.8/cuda13.3 RL + training runs, both
  compilers).
