### PR TITLE
fix(ci): flip app image prefix to flagos-app + adopt vllm app image tag naming

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -33,9 +33,7 @@ registry:
     # App images live under flagos-app (e.g. flagos-app/megatron-nvidia-cuda12.8,
     # flagos-app/vllm-nvidia-cuda12.8). Consumed by the app-image workflows
     # (megatron-app-image.yml, vllm-app-image.yml) to compose the image tag.
-    # TEMPORARY: the flagos-app Harbor project does not exist yet — images land
-    # in flagos-dev until it is created (flip back to flagos-app then).
-    app: flagos-dev
+    app: flagos-app
 
 # Which runner builds each image (base containerfile name -> runs-on).
 # Backends not listed under `overrides` use `default`.

--- a/.github/workflows/vllm-app-image.yml
+++ b/.github/workflows/vllm-app-image.yml
@@ -14,8 +14,9 @@
 
 name: vllm app image
 
-# Builds flagos-app/vllm-{vendor}-{backend}:{version} from the runtime image
-# by installing the repacked vllm wheel (+flagos) and the vllm-plugin-FL wheel
+# Builds flagos-app/vllm{vllm_version}-{vendor}-{backend}:{version}[-{plugin}]
+# from the runtime image by installing the repacked vllm wheel (+flagos) and
+# the vllm-plugin-FL wheel
 # single-step — two clean pip installs, no source builds (the plugin wheel is
 # built and audited by the vllm-plugin-wheel workflow; the vllm wheel by the
 # vllm-wheel workflow). The +flagos pin and the plugin's audited-empty
@@ -144,7 +145,17 @@ jobs:
           set -euo pipefail
           host="${{ needs.set-matrix.outputs.harbor_host }}"
           app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
-          app_tag="${host}/${app_prefix}/vllm-${{ matrix.name }}:${{ matrix.version }}"
+          # Tag naming (same as the images already in flagos-app):
+          #   vllm{vllm_version}-{backend}:{stack_version}[-{plugin_fl_version}]
+          # The plugin wheel's PEP 440 local version (0.2.0+g687217a.d20260819)
+          # carries a '+', which is not allowed in an image tag — use '_'.
+          plugin="${{ inputs.plugin_fl_version }}"
+          if [[ -n "${plugin}" ]]; then
+              app_tag="${host}/${app_prefix}/vllm${{ inputs.vllm_version }}-${{ matrix.name }}:${{ matrix.version }}-$(printf '%s' "${plugin}" | tr '+' '_')"
+          else
+              app_tag="${host}/${app_prefix}/vllm${{ inputs.vllm_version }}-${{ matrix.name }}:${{ matrix.version }}"
+          fi
+          echo "APP_TAG=${app_tag}" >> "$GITHUB_ENV"
           docker build \
             --build-arg "RUNTIME_IMAGE=${{ matrix.image_tag }}" \
             --build-arg "VLLM_VERSION=${{ inputs.vllm_version }}" \
@@ -168,18 +179,12 @@ jobs:
         if: ${{ inputs.verify }}
         run: |
           set -euo pipefail
-          host="${{ needs.set-matrix.outputs.harbor_host }}"
-          app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
-          app_tag="${host}/${app_prefix}/vllm-${{ matrix.name }}:${{ matrix.version }}"
           bash packaging/vllm/verify-vllm-backend.sh \
             "${{ matrix.name }}" \
             --vllm-version "${{ inputs.vllm_version }}" \
-            --app-image "${app_tag}"
+            --app-image "${APP_TAG}"
 
       - name: Push vllm app image
         if: ${{ inputs.push }}
         run: |
-          host="${{ needs.set-matrix.outputs.harbor_host }}"
-          app_prefix=$(python3 -c "import yaml;print(yaml.safe_load(open('.github/build-config.yml'))['registry']['prefixes']['app'])")
-          app_tag="${host}/${app_prefix}/vllm-${{ matrix.name }}:${{ matrix.version }}"
-          docker push "${app_tag}"
+          docker push "${APP_TAG}"

--- a/packaging/vllm/docs/report-vllm-0.24.0.md
+++ b/packaging/vllm/docs/report-vllm-0.24.0.md
@@ -769,8 +769,9 @@ reference]` 后再跑仍全绿 → 重排非必要，仓库未改（容器最终
 app 镜像（wheel 单步安装线 + `vllm-serve` launcher）在 NPU 上的
 serve + 推理，即 `app/vllm/` 全流程的端到端证明。
 
-- 镜像：`harbor.baai.ac.cn/flagos-dev/vllm-ascend-cann9.0.0:2.1.2`
-  （构建 run 32146899749，已 push）
+- 镜像：`harbor.baai.ac.cn/flagos-app/vllm0.24.0-ascend-cann9.0.0:2.1.2-0.2.0_gcf8998c.d20260818`
+  （构建 run 32146899749；2026-08-19 按新命名 re-tag 至 flagos-app，
+  flagos-dev 下旧 `vllm-ascend-cann9.0.0:2.1.2` tag 保留）
 - 版本指纹：vllm `0.24.0+flagos`（cp311 aarch64 empty wheel，
   单步安装）；vllm-plugin-fl `0.2.0+gcf8998c.d20260818`（vendor PyPI
   wheel，非 editable —— setuptools-scm 编码同 §10.4 的 `cf8998c`

--- a/packaging/vllm/verify-vllm-backend.sh
+++ b/packaging/vllm/verify-vllm-backend.sh
@@ -38,7 +38,8 @@
 #   6. Test vllm serve and inference
 #
 # --app-image <image>: instead of steps 3-6, verify a prebuilt
-#   flagos-dev/vllm-{vendor}-{backend}:{version} image (built by the
+#   flagos-app/vllm{vllm_version}-{vendor}-{backend}:{version}[-{plugin}] image
+#   (built by the
 #   vllm-app-image workflow): the critical-package matrix
 #   (torch/torch_npu/triton/flag_gems/numpy) must be identical to the runtime
 #   image's, and vllm + vllm_fl must import. No installs run; serve is skipped.
@@ -197,7 +198,8 @@ log_info "Container started: ${CONTAINER}"
 # ── App-image mode: verify a prebuilt vllm app image ─────────────────────
 #
 # Facility 2 (vllm-app-image.yml) verifies the built
-# flagos-dev/vllm-{vendor}-{backend}:{version} image instead of installing
+# flagos-app/vllm{vllm_version}-{vendor}-{backend}:{version}[-{plugin}] image
+# instead of installing
 # from scratch: BEFORE snapshot from the runtime image, AFTER from the app
 # image — the critical-package matrix (torch / torch_npu / triton /
 # flag_gems / numpy) must match item by item, proving the single-step wheel


### PR DESCRIPTION
Both app-image workflows (vllm-app-image.yml, megatron-app-image.yml) read `registry.prefixes.app` from .github/build-config.yml at job runtime, so flipping it back to flagos-app sends their pushes there again (the flagos-app Harbor project now exists — created 2026-08-19 — so the TEMPORARY flagos-dev fallback from #431 is no longer needed).

On top of the prefix flip, this PR aligns the vllm app image **tag naming** with the images already pushed to flagos-app. The workflow now produces

```
flagos-app/vllm{vllm_version}-{backend}:{stack_version}[-{plugin_fl_version}]
```

e.g. `vllm0.24.0-sunrise-tangrt1.2.0:2.1.2-0.2.0_g687217a.d20260819`, instead of `vllm-{backend}:{stack_version}`. The plugin wheel's PEP 440 local version carries a `+`, which image tags disallow — it is replaced with `_` (the suffix is omitted when `plugin_fl_version` is empty). The tag is now computed once in the build step and exported via `GITHUB_ENV`; the verify and push steps reuse it instead of recomputing it in three places.

Also updates the `verify-vllm-backend.sh` comments (app-image mode) and the §10.5 image ref in `packaging/vllm/docs/report-vllm-0.24.0.md` (the ascend app image was re-tagged to flagos-app under the new name on 2026-08-19).

Images already pushed to flagos-dev (vllm-sunrise-tangrt1.2.0, vllm-ascend-cann9.0.0) are kept as-is.

This PR was written in part with the assistance of generative AI.
