### PR TITLE
fix(megatron): resolve triton from /opt/triton in app-image APP_DEPS install

### DIFF
--- a/app/megatron/Containerfile.megatron-training
+++ b/app/megatron/Containerfile.megatron-training
@@ -69,8 +69,13 @@ ARG APP_DEPS=""
 
 # --- Install vendor-conditional deps ---------------------------
 
+# PYTHONPATH=/opt/triton for the same reason as the megatron-core step
+# below: pip resolving any APP_DEPS that pulls torch re-reads the installed
+# torch's METADATA triton==N Requires-Dist. Without the side-dir triton
+# dist-info visible, pip installs a fresh triton into site-packages,
+# bypassing the repacked vendor triton. No-op on single-compiler backends.
 RUN if [ -n "${APP_DEPS}" ]; then \
-      pip install \
+      PYTHONPATH="/opt/triton" pip install \
         --index-url "${FLAGOS_PYPI}" \
         --extra-index-url "${EXTRA_PYPI}" \
         ${APP_DEPS}; \

--- a/app/megatron/Containerfile.rl
+++ b/app/megatron/Containerfile.rl
@@ -65,8 +65,13 @@ ARG APP_DEPS=""
 
 # --- Install vendor-conditional deps ---------------------------
 
+# PYTHONPATH=/opt/triton for the same reason as the megatron-core step
+# below: pip resolving any of APP_DEPS that pulls torch (e.g. flash_attn)
+# re-reads the installed torch's METADATA triton==N Requires-Dist. Without
+# the side-dir triton dist-info visible, pip installs a fresh triton into
+# site-packages, bypassing the repacked vendor triton (188 MB).
 RUN if [ -n "${APP_DEPS}" ]; then \
-      pip install \
+      PYTHONPATH="/opt/triton" pip install \
         --index-url "${FLAGOS_PYPI}" \
         --extra-index-url "${EXTRA_PYPI}" \
         ${APP_DEPS}; \


### PR DESCRIPTION
## Summary

The megatron app-image Containerfiles install vendor-conditional deps
(configs.yaml `deps_app`, e.g. `flash_attn`) before the megatron-core
wheel. Unlike the wheel install step (fixed in #456 with
`PYTHONPATH=/opt/triton`), the APP_DEPS install ran without that guard:
resolving `flash_attn` makes pip re-read the installed torch's
`triton==N` Requires-Dist, and with no triton visible in site-packages it
pulled a fresh triton from the PyPI index into site-packages — shadowing
the vendor build. The app-image verify step caught the leak (matrix
change: triton missing before, triton 3.6.0 in site-packages after).

This PR applies the same `PYTHONPATH=/opt/triton` guard to the APP_DEPS
install in both app Containerfiles, with a comment explaining why.
No-op on single-compiler backends.

## Test plan

Dry-run of the exact APP_DEPS install on the cuda12.8 runtime with the
guard: triton resolves to /opt/triton (already satisfied), and only
einops + flash_attn would be installed — the torch/triton/flag_gems/numpy
matrix is untouched. Re-dispatch of the app-image build (megatron-rl,
nvidia-cuda12.8 + nvidia-cuda13.3, verify + push) after merge.

This PR was written in part with the assistance of generative AI.
