### PR TITLE
docs(vllm-repack): record sunrise 0.24.0 E2E — flagtree rebuild + app image

### DIFF
--- a/packaging/vllm/docs/report-vllm-0.24.0.md
+++ b/packaging/vllm/docs/report-vllm-0.24.0.md
@@ -941,6 +941,33 @@ clang-14/lld-14（sunrise 后端 flags 是 clang-only
 系统 python3.10（apt）+ pip 走 aliyun 镜像（runner 到 pypi.org 不通）；
 sunrise deps（LLVM/plugin/triton toolkits）从预置 URL 下载并 md5 门禁。
 
+### 11.6 app 镜像 serve E2E（2026-08-19~20）
+
+- 镜像：`harbor.baai.ac.cn/flagos-app/vllm0.24.0-sunrise-tangrt1.2.0:2.1.2-0.2.0_g687217a.d20260819`
+  （2026-08-19 push 至 flagos-app，与原
+  `flagos-dev/vllm-sunrise-tangrt1.2.0:2.1.2` tag 同一镜像，docker image
+  id `sha256:22a8f7f1...`，与节点本地镜像逐字节一致）
+- 版本指纹：vllm `0.24.0+flagos`（cp310 empty wheel，单步安装）；
+  vllm-plugin-fl `0.2.0+g687217a.d20260819`（vendor PyPI wheel，非
+  editable —— 同一 PR #391 代码，同 §11.2/11.3）；torch 2.11.0+cpu /
+  torch_ptpu 0.2.3+torch2.11 / flag_gems 5.3.4 / xgrammar 0.2.3+flagos /
+  compressed-tensors 0.17.0+flagos；编译器 = vendor triton
+  3.6.0.1+git0a5cfb35（`compiler triton`，`VLLM_PLUGINS=fl` 烘焙）
+- 启动：`/flagos/bin/vllm serve`（`compiler triton` 烘焙，`--privileged
+  -v /dev:/dev`）：`--model /models/Qwen3-8B --gpu-memory-utilization 0.6
+  --enforce-eager --trust-remote-code --max-model-len 2048 --dtype bfloat16`
+- 启动：`Application startup complete`；算子路由同 §11.3 ——
+  `attention_backend` `default.flagos` 因 CUDA unavailable 失败 →
+  **fallback `vendor.sunrise`**（CUSTOM 注册生效）；容器稳定运行 9h+，
+  期间 0 崩溃标记
+- 推理（2026-08-20 00:21 复测，system_fingerprint `vllm-0.24.0-6c831be5`，
+  与 §11.3 同一 wheel/plugin）：
+  - knowledge：`The capital of France is` → " Paris. The capital of
+    Italy is Rome. The capital of Spain is Madrid. ..." ✅
+  - math：`What is 7 times 8? Answer:` → " 56. What is 9 times 6? ..." ✅
+- 崩溃标记：0（serve 日志无 Traceback / ERROR / EngineDeadError；容器
+  存活；Avg generation throughput 6.4 tok/s）
+
 ---
 
 ## 12. 遗留事项

--- a/packaging/vllm/docs/vllm-verification-matrix.md
+++ b/packaging/vllm/docs/vllm-verification-matrix.md
@@ -38,7 +38,7 @@
 | 摩尔线程 | MUSA 4.3.6 | ⬜ | ⬜ | ✅ | ✅ |
 | 摩尔线程 | MUSA 5.2.0 | — | ✅ | ✅ | ✅ |
 | 进迭时空 | SPACEMIT | ⬜ | — | ⬜ | — |
-| 曦望 | TANGRT 1.2.0 | ✅ | ❌ | ✅ | ❌ |
+| 曦望 | TANGRT 1.2.0 | ✅ | ❌ | ✅ | ✅ |
 | 平头哥 | PPU 2.0.0 | ⬜ | — | ⬜ | — |
 | 清微智能 | TSM 260610 | ⬜ | ⬜ | ⬜ | ⬜ |
 
@@ -79,7 +79,9 @@
 - **ascend-cann9.0.0**（910B4，aarch64 cp311）：flagtree 路径 ✅
   （修复 flag_gems 5.3.4 `j0`/`log2` 后全链路跑通）；triton 路径未单独验证。
 - **sunrise-tangrt1.2.0**：官方 Triton ✅；flagtree flash-attn **decode 挂死** ❌，
-  交付路径固定 `compiler triton`。
+  交付路径固定 `compiler triton`。（该缺陷 2026-08-19 起已由 rebuilt
+  flagtree wheel 修复 —— 0.24.0 中 F 路径 ✅，见下方 0.24.0 格与
+  `report-vllm-0.24.0.md` §11.5；0.20.2 未复测，本格维持当时结论。）
 - **kunlunxin-xre5.37.1**（P800 XPU）：⛔ 三处 attention 内核编译失败——
   flagtree 0.6.1+xpu3.6（`TritonSDNNLegalize` / `TritonSDNNCombineBefore`）、
   triton 3.0.0（XTDK LLVM19 空 SetVector 断言）。应用层无法绕过，已交编译器团队，
@@ -171,9 +173,14 @@
   （合成 `torch.ptpu.memory_stats()` 供 FL worker KV-cache 定容，
   首次 serve 曾崩 `AttributeError: no attribute 'memory_stats'`）。
   详见 `report-vllm-0.24.0.md` §11。
-  **F 路径 ❌** —— 沿用 0.20.2 §2.9 结论（FlagTree flash-attn
-  **decode 挂死**，编译器缺陷，未在 0.24.0 复测以免挂卡）；
-  交付路径固定 `compiler triton`。
+  **F 路径 ✅（2026-08-19，rebuilt flagtree wheel）** —— 旧 §2.9
+  decode 挂死由 FlagTree PR 978 修复（`packaging/flagtree/sunrise`
+  从 main 重建 wheel，A/B 0.4 → 2.4 tok/s 终止），`compiler flagtree`
+  serve + 推理 E2E 通过（§11.5）。
+  **app 镜像路径 ✅（§11.6）**：`flagos-app/vllm0.24.0-sunrise-
+  tangrt1.2.0:2.1.2-0.2.0_g687217a.d20260819`（wheel 单步安装 + plugin
+  wheel）serve 到 `Application startup complete`、推理连贯、崩溃标记
+  0，指纹 `vllm-0.24.0-6c831be5`（同一 wheel）。
 
 **跨版本事实**
 


### PR DESCRIPTION
## Summary

Records the sunrise-tangrt1.2.0 vllm 0.24.0 verification wrap-up.

1. **Matrix — `sunrise 0.24.0(F)` flips ❌ → ✅**: the FlagTree flash-attn
   decode hang (0.20.2 report §2.9) is fixed by FlagTree PR 978; the rebuilt
   `packaging/flagtree/sunrise` wheel passes serve + inference on 0.24.0
   (report §11.5, A/B 0.4 → 2.4 tok/s).
2. **Matrix — 0.20.2 sunrise note annotated**: the defect is fixed since the
   rebuilt wheel; 0.20.2 was not re-tested, so the cell keeps the original ❌.
3. **Report — new §11.6 app-image serve E2E** for
   `flagos-app/vllm0.24.0-sunrise-tangrt1.2.0:2.1.2-0.2.0_g687217a.d20260819`
   (same image previously under `flagos-dev/vllm-sunrise-tangrt1.2.0:2.1.2`):
   `Application startup complete`, coherent inference (knowledge "Paris" /
   math "56"), 0 crash markers over a 9h+ soak, fingerprint
   `vllm-0.24.0-6c831be5`, attention fallback `vendor.sunrise` (CUSTOM
   registration proven end-to-end).

This PR was written in part with the assistance of generative AI.
