### PR TITLE
docs(vllm-repack): record sunrise 0.20.2(F) recheck — rebuilt flagtree wheel

### DIFF
--- a/packaging/vllm/docs/report-vllm-0.20.2.md
+++ b/packaging/vllm/docs/report-vllm-0.20.2.md
@@ -1323,6 +1323,14 @@ PR 978 重写 sunrise backend pass pipeline 并删除 `add_split_dot`（疑似
 `report-vllm-0.24.0.md` §11.5）。wheel 沿用原版标签上传
 `flagos-pypi-sunrise`，可 drop-in 替换；本单元格 F 路径由"挂死"升级为 ✅。
 
+**复测（2026-08-20）：0.20.2(F) 路径在 rebuilt wheel 下全绿。** 直接在
+0.20.2 环境复测 FlagTree 路径（`compiler flagtree`，runtime 2.1.2 已烘焙
+rebuilt wheel，`/opt/flagtree/triton/_C/libtriton.so` md5 924b1c0d 匹配
+§11.5 门禁值），serve `/data/nmodels/Qwen3-8B` 达 `Application startup
+complete`；推理连贯（knowledge "Paris..." / math "56"）、decode 正常终止
+（2 请求均 `finish_reason=length`，无挂死）、崩溃标记 0。A/B 结论在
+0.20.2 自身版本下成立，矩阵 `0.20.2(F)` 格 ❌→✅。
+
 ### 环境
 
 | 组件 | 版本 |

--- a/packaging/vllm/docs/vllm-verification-matrix.md
+++ b/packaging/vllm/docs/vllm-verification-matrix.md
@@ -38,7 +38,7 @@
 | 摩尔线程 | MUSA 4.3.6 | ⬜ | ⬜ | ✅ | ✅ |
 | 摩尔线程 | MUSA 5.2.0 | — | ✅ | ✅ | ✅ |
 | 进迭时空 | SPACEMIT | ⬜ | — | ⬜ | — |
-| 曦望 | TANGRT 1.2.0 | ✅ | ❌ | ✅ | ✅ |
+| 曦望 | TANGRT 1.2.0 | ✅ | ✅ | ✅ | ✅ |
 | 平头哥 | PPU 2.0.0 | ⬜ | — | ⬜ | — |
 | 清微智能 | TSM 260610 | ⬜ | ⬜ | ⬜ | ⬜ |
 
@@ -81,7 +81,9 @@
 - **sunrise-tangrt1.2.0**：官方 Triton ✅；flagtree flash-attn **decode 挂死** ❌，
   交付路径固定 `compiler triton`。（该缺陷 2026-08-19 起已由 rebuilt
   flagtree wheel 修复 —— 0.24.0 中 F 路径 ✅，见下方 0.24.0 格与
-  `report-vllm-0.24.0.md` §11.5；0.20.2 未复测，本格维持当时结论。）
+  `report-vllm-0.24.0.md` §11.5；**2026-08-20 在 rebuilt wheel 下复测
+  0.20.2(F) 路径 ✅**——serve 达 `Application startup complete`、推理连贯
+  （knowledge "Paris" / math "56"）、decode 正常终止，本格翻 ✅。）
 - **kunlunxin-xre5.37.1**（P800 XPU）：⛔ 三处 attention 内核编译失败——
   flagtree 0.6.1+xpu3.6（`TritonSDNNLegalize` / `TritonSDNNCombineBefore`）、
   triton 3.0.0（XTDK LLVM19 空 SetVector 断言）。应用层无法绕过，已交编译器团队，


### PR DESCRIPTION
## Summary

Records the 0.20.2(F) sunrise recheck: the FlagTree flash-attn decode hang
(0.20.2 report §2.9, fixed by FlagTree PR 978) is now verified fixed **in the
0.20.2 environment itself**, not just 0.24.0.

1. **Matrix — `sunrise 0.20.2(F)` flips ❌ → ✅**: rechecked 2026-08-20 on the
   sunrise node with `compiler flagtree` (runtime 2.1.2, rebuilt flagtree
   wheel baked in, `/opt/flagtree/triton/_C/libtriton.so` md5 `924b1c0d`
   matching the §11.5 gate). Serve reaches `Application startup complete`,
   inference coherent (knowledge "Paris..." / math "56"), decode terminates
   normally (both requests `finish_reason=length`, no hang), 0 crash markers.
2. **Report 0.20.2 — new recheck paragraph in §2.9**: the 2026-08-19 rebuild
   chain now carries its own in-version A/B evidence; the matrix note
   "0.20.2 未复测" is superseded.

This PR was written in part with the assistance of generative AI.
