### PR TITLE
docs(megatron): record megatron-training app image build + h20 dual-compiler verify

### DIFF
--- a/packaging/megatron/docs/megatron-verification-matrix.md
+++ b/packaging/megatron/docs/megatron-verification-matrix.md
@@ -154,6 +154,20 @@
   pip 解析 torch 的 triton==N Requires-Dist 拉新 triton 3.6.0 进
   site-packages，verify 判矩阵变化 abort；与 #456 的 megatron-core 步同款修复，
   dry-run 实证仅装 einops + flash_attn。
+- **nvidia megatron-training app image 构建+push（2026-08-20，双后端 ✅）+ h20 E2E
+  双编译器复验（cuda12.8）**：`flagos-app/megatron_training0.17.1-nvidia-cuda12.8:
+  2.1.2-0.2.1_9.g48b97a13f` 与 `-cuda13.3` 同款 tag 已构建并推送（tag 命名与 RL
+  一致：应用版本 0.17.1 + fork 版本 0.2.1_9.g48b97a13f）。app=megatron-training、
+  megatron_version=0.17.1、mlf_version=0.2.1_9.g48b97a13f，workflow 内 verify
+  （--app-image 模式：BEFORE(runtime) vs AFTER(app) 矩阵逐包 unchanged +
+  megatron.core import）双后端均过。training 无 vendor 条件包（configs.yaml
+  deps_app.megatron-training = `[]`，仅 RL 有 flash_attn）——镜像 = runtime +
+  wheel `[training]` extra 单步安装。**h20 E2E 复验（cuda12.8，`megatron-train-app`
+  容器）**：mock data 5 iter 直跑 pretrain_gpt.py，双编译器全 exit 0——flagtree
+  3.6.0 默认线与 vendor triton 3.6.0（`compiler triton`）逐 iter loss 完全一致：
+  8.371983/8.363531/8.348538/8.366852/8.357372，validation loss test set 两线均
+  8.360331E+00（validation set 8.359479E+00）——与矩阵 nvidia training 基线逐位
+  一致，app-image 装配路径相对 runtime+wheel 无行为回归（mock 数据确定性）。
 - **nvidia post_training × inference（2026-08-19，cuda12.8 双编译器全 ✅）**：
   两场景均编译器无关路径，同 metax 配方——post_training = DummyModel +
   `simple_generate`（output shape (1,8)，nvidia-modelopt 0.45.0 ad-hoc 装入

--- a/packaging/megatron/docs/memory/megatron-verification-state.md
+++ b/packaging/megatron/docs/memory/megatron-verification-state.md
@@ -1,11 +1,11 @@
 ---
 name: megatron-verification-state
-description: megatron 应用镜像验证阶段的状态：已定决策、待决事项、文件状态、任务状态（2026-08-14 结束点）
+description: megatron 应用镜像验证阶段的状态：已定决策、待决事项、文件状态、任务状态（2026-08-20 结束点）
 metadata: 
   node_type: memory
   type: project
   originSessionId: d7f830af-2108-4f39-aba9-825e3ddd911e
-  modified: 2026-08-19T00:00:00.000Z
+  modified: 2026-08-20T00:00:00.000Z
 ---
 
 # Megatron 应用镜像验证阶段 — 状态快照（2026-08-17 结构决策收口）
@@ -43,7 +43,7 @@ runtime
 
 **C/D 形状（2026-08-17 定稿）：deps_app 每后端显式列全 app（vllm/megatron-training/megatron-rl 一键），vendor 包按需填——`[]` 表示"该 app 在此后端存在、需验证、但无 vendor 包"，不是不建。两职责解耦：app 存在性 = 键本身（验证矩阵全展开依据，期望状态）；vendor 包 = 列表内容（构建时实际装什么）。hygon megatron-rl 有 TE，其余后端全空。交付矩阵（现实状态）是验证结论的产物，不在 configs 硬编码。app 级平级（vllm/training/rl），"rl 是否可建"是每后端待验证项（默认可建）——未来纯公共 RL 后所有后端 rl 皆 `[]` 而恒建。**
 
-1. **`app/megatron/Containerfile` 拆分**（**已落地：PR #427 MERGED，2026-08-18**）：`Containerfile.megatron-training`（wheel + modelopt + tqdm + datasets）/ `Containerfile.rl`（wheel + TE 条件 + 13 包全组）；原 `Containerfile` 改名并留注释说明目录名≠镜像名的对应。**megatron-rl 可建性门槛 = MLF PR #114 合并 + 新 wheel（带 `[rl]` extra）；megatron-training 现 wheel 即可建（`[training]` 已存在）**。**门槛已过（2026-08-20 端到端实证）：nvidia 两后端 megatron-rl app image 构建+验证+push 全 ✅（`flagos-app/megatron_rl0.17.1-nvidia-cuda12.8:2.1.2-0.2.1_9.g48b97a13f` / `-cuda13.3:2.1.2-0.2.1_9.g48b97a13f`，wheel `0.17.1+fl.20260818.g48b97a13f1bb` 带 `[rl]` extra），详见 megatron-verification-matrix.md 对应条目**
+1. **`app/megatron/Containerfile` 拆分**（**已落地：PR #427 MERGED，2026-08-18**）：`Containerfile.megatron-training`（wheel + modelopt + tqdm + datasets）/ `Containerfile.rl`（wheel + TE 条件 + 13 包全组）；原 `Containerfile` 改名并留注释说明目录名≠镜像名的对应。**megatron-rl 可建性门槛 = MLF PR #114 合并 + 新 wheel（带 `[rl]` extra）；megatron-training 现 wheel 即可建（`[training]` 已存在）**。**门槛已过（2026-08-20 端到端实证）：nvidia 两后端 megatron-rl app image 构建+验证+push 全 ✅（`flagos-app/megatron_rl0.17.1-nvidia-cuda12.8:2.1.2-0.2.1_9.g48b97a13f` / `-cuda13.3:2.1.2-0.2.1_9.g48b97a13f`，wheel `0.17.1+fl.20260818.g48b97a13f1bb` 带 `[rl]` extra），详见 megatron-verification-matrix.md 对应条目**。**megatron-training app image 同款落地（2026-08-20）：双后端构建+push 全 ✅（`flagos-app/megatron_training0.17.1-nvidia-cuda12.8:2.1.2-0.2.1_9.g48b97a13f` / `-cuda13.3` 同款 tag），training 无 vendor 条件包（deps_app.megatron-training = `[]`，仅 RL 有 flash_attn），镜像 = runtime + wheel `[training]` extra 单步安装；workflow 内 verify（--app-image 模式）双后端均过。h20 E2E 复验（cuda12.8）双编译器全 exit 0：flagtree 3.6.0 与 vendor triton 3.6.0 逐 iter loss 逐位一致（8.371983/8.363531/8.348538/8.366852/8.357372），validation loss test set 两线均 8.360331E+00 —— 与矩阵 nvidia training 基线逐位一致，app-image 装配路径无行为回归**
 2. **configs.yaml `deps_app` 机制**（新建，对称 `env.app`，**已落地：PR #424 MERGED，2026-08-17**）：19 后端全展开 `deps_app: {vllm, megatron-training, megatron-rl}`，`[]` = app 存在待验证无 vendor 包（非"不建"）；仅 hygon `megatron-rl` 有 `transformer_engine==2.10.0+das.opt1.dtk2604.torch290`。**wheel 边界（用户 2026-08-17 定案）：wheel 不是 deps_app 条目——是 app 身份，走 Containerfile `MEGATRON_VERSION` arg，判定准则 = 每后端条件性而非装自哪个 index**，已写进 configs.yaml header 注释。公共包（modelopt/tqdm/datasets/13 组）**不在此处**——走 wheel extras（C 定稿，等 #114）
 3. **CI 支撑（已落地，两 PR）**：generate_matrix 支持 app 级 deps + `--app {app}` 输出 `app_env`/`app_deps` 随 **PR #424 MERGED，2026-08-17**；megatron-app-image.yml 参数化 app 名（`megatron-training`|`megatron-rl` input → 镜像 tag / matrix / APP_DEPS build-arg，Containerfile 前置 vendor RUN）随 **PR #425 MERGED，2026-08-17**
 4. **apex 纳入 hygon runtime**（A1，2026-08-17 确认，**已落地：PR #422 merged + wheel 已传 flagos-pypi-hygon**）：上传 `apex==1.7.0+das.opt1.dtk2604.torch290` + configs.yaml hygon deps 加 `apex==1.7.0+das.opt1.dtk2604.torch290`。**定性：apex 是 vendor 可选加速包（熔断可选，MLF 里 4 处使用全 try/except fallback——multi_tensor_applier / FusedLayerNorm / FusedAdam），非 RL 硬依赖**；kunlunxin/metax 已有先例（apex==0.1 / apex==0.1+metax3.8.1.0）


### PR DESCRIPTION
## Problem

The megatron-training app image (sibling of the megatron-rl app image) was
built, verified and pushed for both nvidia backends with the new tag naming
(app version + MLF fork version), and E2E re-verified on h20 — but the
verification matrix and state docs don't record this yet.

## Changes

- `packaging/megatron/docs/megatron-verification-matrix.md`: new entry —
  nvidia megatron-training app image build+push (cuda12.8/cuda13.3, tag
  `megatron_training0.17.1-...:2.1.2-0.2.1_9.g48b97a13f`) + h20 E2E
  dual-compiler re-verification (cuda12.8): per-iter loss identical across
  flagtree/triton lines (8.371983/8.363531/8.348538/8.366852/8.357372),
  validation loss test set 8.360331E+00 on both — matches the nvidia
  training baseline bit-for-bit, no behavior regression from the app-image
  assembly path.
- `packaging/megatron/docs/memory/megatron-verification-state.md`: bump
  snapshot end-point to 2026-08-20; extend item 1 with the
  megatron-training app image milestone (no vendor-conditional deps —
  `deps_app.megatron-training = []`, only RL carries flash_attn).

This PR was written in part with the assistance of generative AI.
